### PR TITLE
feat: Add Docker-based build support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.github
+udev
+target
+systemd

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist/
 *.swo
 *~
 .DS_Store
+.idea
+.cache

--- a/README.md
+++ b/README.md
@@ -51,8 +51,17 @@ lianli-gui             Tauri 2 + Vue 3 desktop app - connects to daemon via Unix
 The daemon runs as a user systemd service. USB access is granted via udev rules (no root required).
 The GUI connects over `$XDG_RUNTIME_DIR/lianli-daemon.sock`.
 
-## Prerequisites
+## Building
 
+### Manually
+#### Prerequisites
+1) clone the repo and submodules
+```bash
+git clone --recurse-submodules https://github.com/sgtaziz/lian-li-linux.git && cd lian-li-linux
+```
+> if you cloned the project without the --recurse-submodules flag, run: git submodule update --init --recursive
+
+2) install dependencies
 - **Rust** (stable, 1.75+)
 - **Bun** (for the GUI frontend)
 - **ffmpeg** and **ffprobe** in `PATH` (for video/GIF decoding)
@@ -69,21 +78,34 @@ sudo apt install libhidapi-dev libusb-1.0-0-dev libwebkit2gtk-4.1-dev libgtk-3-d
 sudo dnf install hidapi-devel libusb1-devel webkit2gtk4.1-devel gtk3-devel librsvg2-devel ffmpeg
 ```
 
-## Building
-
+3) build the project
 ```bash
-git clone --recurse-submodules https://github.com/sgtaziz/LIAN-LI-LINUX.git
-cd LIAN-LI-LINUX
-
-# If you already cloned without --recurse-submodules:
-git submodule update --init --recursive
-
 # Install GUI frontend dependencies and build everything
-cd crates/lianli-gui && bun install && cd ../..
-cargo build --release
+cd crates/lianli-gui && bun install \
+&& cd ../.. cargo build --release
 ```
 
-Binaries: `target/release/lianli-daemon` and `target/release/lianli-gui`
+### With Docker
+
+1) build the docker image
+```bash
+docker build -f docker/build.Dockerfile -t lianli-linux-builder \
+  --build-arg USER_ID="$(id -u)" \
+  --build-arg GROUP_ID="$(id -g)" \
+  .
+```  
+2) build the project
+```bash
+docker run --rm -it \                                            
+  -v "$PWD:/work" \               
+  -v "$PWD/target:/work/target" \  
+  -v "$PWD/.cache/cargo-registry:/home/builder/.cargo/registry" \
+  -v "$PWD/.cache/cargo-git:/home/builder/.cargo/git" \
+  lianli-linux-builder
+
+```
+
+### Binaries: `target/release/lianli-daemon` and `target/release/lianli-gui`
 
 ## Installation
 

--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -1,0 +1,39 @@
+FROM rust:1.93-trixie
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl git \
+    build-essential pkg-config \
+    clang cmake ninja-build \
+    libssl-dev \
+    libhidapi-dev libusb-1.0-0-dev libudev-dev \
+    libwebkit2gtk-4.1-dev libgtk-3-dev librsvg2-dev \
+    ffmpeg \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV PATH=/usr/local/bun/bin:/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN curl -fsSL https://bun.sh/install | bash \
+  && mv /root/.bun/bin/bun /usr/local/bin/bun \
+  && chmod +x /usr/local/bin/bun \
+  && bun -v
+
+RUN groupadd -g ${GROUP_ID} builder \
+  && useradd -m -u ${USER_ID} -g ${GROUP_ID} -s /bin/bash builder
+
+USER builder
+WORKDIR /work
+
+ENV CARGO_TARGET_DIR=/work/target
+
+CMD ["bash", "-c", "\
+  set -euo pipefail; \
+  set -x; \
+  command -v cargo && cargo -V; \
+  command -v bun && bun -v; \
+  cd /work/crates/lianli-gui && bun install; \
+  cd /work && cargo build --release; \
+"]


### PR DESCRIPTION
This change adds a Docker workflow for building the project in a consistent, reproducible environment without requiring all native dependencies to be installed on the host.

- Introduces a dedicated Docker build image/setup for compiling the project.
- Documents the Docker build and run steps, including mounting the workspace/target and caching cargo artifacts for faster rebuilds.
- Ensures the container build runs with the host user/group IDs to avoid permission issues on generated files.