### PR TITLE
feat: add HydroShift II LCD Square (1cbe:a034) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 | Device | LCD | Tested | Notes |
 |--------|:---:|:------:|-------|
 | HydroShift II LCD Circle | 480x480 | Yes | LCD Supports Background image only |
+| HydroShift II LCD Square | 480x480 | Yes | LCD Supports Background image only |
 | Lancool 207 Digital | 1472x720 | Yes | LCD Supports Background image only |
 | Universal Screen 8.8" | 1920x480 | - | LCD Supports Background image only |
 

--- a/crates/lianli-shared/src/device_id.rs
+++ b/crates/lianli-shared/src/device_id.rs
@@ -202,6 +202,12 @@ pub static KNOWN_DEVICES: &[DeviceEntry] = &[
         hid_usage_page: None,
     },
     DeviceEntry {
+        id: UsbId::new(0x1CBE, 0xA034),
+        family: DeviceFamily::HydroShift2Lcd,
+        name: "HydroShift II LCD Square",
+        hid_usage_page: None,
+    },
+    DeviceEntry {
         id: UsbId::new(0x1CBE, 0xA065),
         family: DeviceFamily::Lancool207,
         name: "Lancool 207 Digital",

--- a/udev/99-lianli.rules
+++ b/udev/99-lianli.rules
@@ -40,6 +40,8 @@ SUBSYSTEM=="usb", ATTR{idVendor}=="1cbe", ATTR{idProduct}=="0005", MODE="0666"
 SUBSYSTEM=="usb", ATTR{idVendor}=="1cbe", ATTR{idProduct}=="0006", MODE="0666"
 # HydroShift II LCD Circle
 SUBSYSTEM=="usb", ATTR{idVendor}=="1cbe", ATTR{idProduct}=="a021", MODE="0666"
+# HydroShift II LCD Square (H2S)
+SUBSYSTEM=="usb", ATTR{idVendor}=="1cbe", ATTR{idProduct}=="a034", MODE="0666"
 # Lancool 207 Digital
 SUBSYSTEM=="usb", ATTR{idVendor}=="1cbe", ATTR{idProduct}=="a065", MODE="0666"
 # Universal Screen 8.8"


### PR DESCRIPTION
## Summary

Adds the HydroShift II LCD Square (H2S) AIO cooler as a supported device.

- Registers `0x1CBE:0xA034` in `KNOWN_DEVICES` as `HydroShift2Lcd` family — same WinUSB bulk protocol as the LCD Circle (`0xA021`)
- Adds udev rule for userspace access

Tested on CachyOS with an H2S-1.7 (firmware string `lianli-H2S-1.7`). The daemon detects the device, opens the bulk endpoints, and communicates successfully.

## Hardware

- **Device**: Lian Li HydroShift II LCD Square AIO
- **USB ID**: `1cbe:a034`
- **Firmware**: `lianli-H2S-1.7`
- **Protocol**: WinUSB bulk (same as HydroShift II LCD Circle)