### PR TITLE
Sensors reworked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target/
+/.vscode/
 node_modules/
 dist/
 *.swp

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,23 +72,21 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-activity"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef6978589202a00cd7e118380c448a08b6ed394c3a8df3a430d0898e3a42d046"
+checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
 dependencies = [
  "android-properties",
  "bitflags 2.11.0",
  "cc",
- "cesu8",
  "jni",
- "jni-sys",
  "libc",
  "log",
  "ndk",
  "ndk-context",
  "ndk-sys",
  "num_enum",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -108,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "annotate-snippets"
-version = "0.12.13"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fc7650eedcb2fee505aad48491529e408f0e854c2d9f63eb86c1361b9b3f93"
+checksum = "92570a3f9c98e7e84df84b71d0965ac99b1871fcd75a3773a3bd1bad13f64cf7"
 dependencies = [
  "anstyle",
  "memchr",
@@ -359,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "async-signal"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
 dependencies = [
  "async-io",
  "async-lock",
@@ -490,7 +488,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "shlex",
  "syn",
 ]
@@ -567,10 +565,11 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
+ "bytes",
  "cfg_aliases",
 ]
 
@@ -692,21 +691,15 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cexpr"
@@ -863,8 +856,8 @@ dependencies = [
 
 [[package]]
 name = "const-field-offset"
-version = "0.1.5"
-source = "git+https://github.com/slint-ui/slint#31a7f21a81b494072288e30fc14a92b787c96ad4"
+version = "0.2.0"
+source = "git+https://github.com/slint-ui/slint#e27d0d19e983baf71532de8b7a4a0ebce2026237"
 dependencies = [
  "const-field-offset-macro",
  "field-offset",
@@ -872,8 +865,8 @@ dependencies = [
 
 [[package]]
 name = "const-field-offset-macro"
-version = "0.1.5"
-source = "git+https://github.com/slint-ui/slint#31a7f21a81b494072288e30fc14a92b787c96ad4"
+version = "0.2.0"
+source = "git+https://github.com/slint-ui/slint#e27d0d19e983baf71532de8b7a4a0ebce2026237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -914,6 +907,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,7 +929,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -939,7 +942,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "libc",
 ]
 
@@ -1154,17 +1157,16 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
 name = "drm"
-version = "0.14.2"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b71449a23fe79542d6527ca572844b2016abf9573c49e43144d546b1735aec"
+checksum = "80bc8c5c6c2941f70a55c15f8d9f00f9710ebda3ffda98075f996a0e6c92756f"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
- "bytemuck_derive",
  "drm-ffi",
  "drm-fourcc",
  "libc",
- "rustix 1.1.4",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -1270,9 +1272,9 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "euclid"
-version = "0.22.13"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df61bf483e837f88d5c2291dcf55c67be7e676b3a51acc48db3a7b163b91ed63"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
 ]
@@ -1315,9 +1317,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fax"
@@ -1350,9 +1352,9 @@ dependencies = [
 
 [[package]]
 name = "femtovg"
-version = "0.20.4"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35695993a8264f5dfa8facc135c003965cea40d83705b49e0f8c3a3b632a2171"
+checksum = "7403dbff7267ff6bebebbf23951180c2c9b4cda27340945b28441f5f5dc70148"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
@@ -1364,7 +1366,6 @@ dependencies = [
  "rgb",
  "slotmap",
  "swash",
- "ttf-parser 0.25.1",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -1432,9 +1433,9 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "font-types"
-version = "0.10.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a654f404bbcbd48ea58c617c2993ee91d1cb63727a37bf2323a4edeed1b8c5"
+checksum = "2d9237c6d82152100c691fb77ea18037b402bcc7257d2c876a4ffac81bc22a1c"
 dependencies = [
  "bytemuck",
 ]
@@ -1453,24 +1454,23 @@ dependencies = [
 
 [[package]]
 name = "fontique"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bbc252c93499b6d3635d692f892a637db0dbb130ce9b32bf20b28e0dcc470b"
+checksum = "23358480a54a886d51b306718d5ca743fdfe238e5df38ef650f4e72f29c5d9e9"
 dependencies = [
- "bytemuck",
  "hashbrown 0.16.1",
- "icu_locale_core",
  "linebender_resource_handle",
  "memmap2",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-text",
  "objc2-foundation 0.3.2",
+ "parlance",
  "read-fonts",
  "roxmltree",
  "smallvec",
- "windows 0.58.0",
- "windows-core 0.58.0",
+ "windows",
+ "windows-core",
  "yeslogic-fontconfig-sys",
 ]
 
@@ -1726,9 +1726,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "glow"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -1804,9 +1804,9 @@ dependencies = [
 
 [[package]]
 name = "grid"
-version = "0.15.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36119f3a540b086b4e436bb2b588cf98a68863470e0e880f4d0842f112a3183a"
+checksum = "f9e2d4c0a8296178d8802098410ca05d86b17a10bb5ab559b3fb404c1f948220"
 
 [[package]]
 name = "half"
@@ -1821,9 +1821,9 @@ dependencies = [
 
 [[package]]
 name = "harfrust"
-version = "0.3.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c020db12c71d8a12a3fe7607873cade3a01a6287e29d540c8723276221b9d8"
+checksum = "9da2e5ae821f6e96664977bf974d6d6a2d6682f9ccee23e62ec1d134246845f9"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
@@ -1904,7 +1904,7 @@ checksum = "48ce8546b993eaf241d69ded33b1be6d205dd9857ec879d9d18bd05d3676e144"
 [[package]]
 name = "i-slint-backend-linuxkms"
 version = "1.16.0"
-source = "git+https://github.com/slint-ui/slint#31a7f21a81b494072288e30fc14a92b787c96ad4"
+source = "git+https://github.com/slint-ui/slint#e27d0d19e983baf71532de8b7a4a0ebce2026237"
 dependencies = [
  "calloop 0.14.4",
  "drm",
@@ -1922,7 +1922,7 @@ dependencies = [
 [[package]]
 name = "i-slint-backend-selector"
 version = "1.16.0"
-source = "git+https://github.com/slint-ui/slint#31a7f21a81b494072288e30fc14a92b787c96ad4"
+source = "git+https://github.com/slint-ui/slint#e27d0d19e983baf71532de8b7a4a0ebce2026237"
 dependencies = [
  "cfg-if",
  "i-slint-backend-linuxkms",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "i-slint-backend-winit"
 version = "1.16.0"
-source = "git+https://github.com/slint-ui/slint#31a7f21a81b494072288e30fc14a92b787c96ad4"
+source = "git+https://github.com/slint-ui/slint#e27d0d19e983baf71532de8b7a4a0ebce2026237"
 dependencies = [
  "block2 0.6.2",
  "cfg-if",
@@ -1967,7 +1967,8 @@ dependencies = [
  "vtable",
  "wasm-bindgen",
  "web-sys",
- "windows 0.62.2",
+ "webbrowser",
+ "windows",
  "winit",
  "zbus",
 ]
@@ -1975,24 +1976,26 @@ dependencies = [
 [[package]]
 name = "i-slint-common"
 version = "1.16.0"
-source = "git+https://github.com/slint-ui/slint#31a7f21a81b494072288e30fc14a92b787c96ad4"
+source = "git+https://github.com/slint-ui/slint#e27d0d19e983baf71532de8b7a4a0ebce2026237"
 dependencies = [
  "fontique",
  "htmlparser",
  "pulldown-cmark",
+ "skrifa",
  "thiserror 2.0.18",
- "ttf-parser 0.25.1",
 ]
 
 [[package]]
 name = "i-slint-compiler"
 version = "1.16.0"
-source = "git+https://github.com/slint-ui/slint#31a7f21a81b494072288e30fc14a92b787c96ad4"
+source = "git+https://github.com/slint-ui/slint#e27d0d19e983baf71532de8b7a4a0ebce2026237"
 dependencies = [
  "annotate-snippets",
  "by_address",
+ "data-url",
  "derive_more",
  "i-slint-common",
+ "icu_normalizer",
  "image 0.25.10",
  "itertools 0.14.0",
  "linked_hash_set",
@@ -2010,13 +2013,14 @@ dependencies = [
  "strum",
  "swash",
  "typed-index-collections",
+ "unicode-segmentation",
  "url",
 ]
 
 [[package]]
 name = "i-slint-core"
 version = "1.16.0"
-source = "git+https://github.com/slint-ui/slint#31a7f21a81b494072288e30fc14a92b787c96ad4"
+source = "git+https://github.com/slint-ui/slint#e27d0d19e983baf71532de8b7a4a0ebce2026237"
 dependencies = [
  "auto_enums",
  "bitflags 2.11.0",
@@ -2028,6 +2032,7 @@ dependencies = [
  "euclid",
  "i-slint-common",
  "i-slint-core-macros",
+ "icu_normalizer",
  "image 0.25.10",
  "lyon_algorithms",
  "lyon_extra",
@@ -2062,7 +2067,7 @@ dependencies = [
 [[package]]
 name = "i-slint-core-macros"
 version = "1.16.0"
-source = "git+https://github.com/slint-ui/slint#31a7f21a81b494072288e30fc14a92b787c96ad4"
+source = "git+https://github.com/slint-ui/slint#e27d0d19e983baf71532de8b7a4a0ebce2026237"
 dependencies = [
  "quote",
  "serde_json",
@@ -2072,7 +2077,7 @@ dependencies = [
 [[package]]
 name = "i-slint-renderer-femtovg"
 version = "1.16.0"
-source = "git+https://github.com/slint-ui/slint#31a7f21a81b494072288e30fc14a92b787c96ad4"
+source = "git+https://github.com/slint-ui/slint#e27d0d19e983baf71532de8b7a4a0ebce2026237"
 dependencies = [
  "cfg-if",
  "const-field-offset",
@@ -2093,7 +2098,7 @@ dependencies = [
 [[package]]
 name = "i-slint-renderer-skia"
 version = "1.16.0"
-source = "git+https://github.com/slint-ui/slint#31a7f21a81b494072288e30fc14a92b787c96ad4"
+source = "git+https://github.com/slint-ui/slint#e27d0d19e983baf71532de8b7a4a0ebce2026237"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -2122,14 +2127,14 @@ dependencies = [
  "softbuffer",
  "unicode-segmentation",
  "vtable",
- "windows 0.62.2",
+ "windows",
  "write-fonts",
 ]
 
 [[package]]
 name = "i-slint-renderer-software"
 version = "1.16.0"
-source = "git+https://github.com/slint-ui/slint#31a7f21a81b494072288e30fc14a92b787c96ad4"
+source = "git+https://github.com/slint-ui/slint#e27d0d19e983baf71532de8b7a4a0ebce2026237"
 dependencies = [
  "bytemuck",
  "clru",
@@ -2157,7 +2162,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -2171,22 +2176,38 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locale_core"
-version = "2.1.1"
+name = "icu_locale"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_locale_data",
+ "icu_provider",
+ "potential_utf",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2197,10 +2218,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_normalizer"
-version = "2.1.1"
+name = "icu_locale_data"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2212,15 +2239,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -2232,24 +2259,47 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
  "writeable",
  "yoke",
  "zerofrom",
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_segmenter"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0794db0b1a86193ac9c48768d0e6c52c54448e0870ad87907d456ee0dac964"
+dependencies = [
+ "icu_collections",
+ "icu_locale",
+ "icu_provider",
+ "icu_segmenter_data",
+ "potential_utf",
+ "utf8_iter",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_segmenter_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a2c462a4d927d512f5f882a033ddd62f33a05bb9f230d98f736ac3dc85938f"
 
 [[package]]
 name = "id-arena"
@@ -2344,9 +2394,9 @@ checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -2399,9 +2449,9 @@ dependencies = [
 
 [[package]]
 name = "input-sys"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd4f5b4d1c00331c5245163aacfe5f20be75b564c7112d45893d4ae038119eb0"
+checksum = "36eee07d8e02bd95bf52b2e642cf13d33701b94c6e4b04fbf1d1fb07e9cb19e7"
 
 [[package]]
 name = "instant"
@@ -2469,31 +2519,67 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-macros",
+ "jni-sys 0.4.1",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
 ]
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -2516,10 +2602,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2559,17 +2647,6 @@ checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
-]
-
-[[package]]
-name = "kurbo"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce9729cc38c18d86123ab736fd2e7151763ba226ac2490ec092d1dd148825e32"
-dependencies = [
- "arrayvec",
- "euclid",
- "smallvec",
 ]
 
 [[package]]
@@ -2692,9 +2769,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2724,9 +2801,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
@@ -2797,9 +2874,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -2927,9 +3004,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
@@ -2949,9 +3026,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c1738382f66ed56b3b9c8119e794a2e23148ac8ea214eda86622d4cb9d415a"
+checksum = "7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -2979,7 +3056,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
  "bitflags 2.11.0",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "ndk-sys",
  "num_enum",
@@ -2999,7 +3076,7 @@ version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
- "jni-sys",
+ "jni-sys 0.3.1",
 ]
 
 [[package]]
@@ -3619,17 +3696,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "parley"
-version = "0.7.0"
+name = "parlance"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ada5338c3a9794af7342e6f765b6e78740db37378aced034d7bf72c96b94ed94"
+checksum = "4b6937eda350acc1a5d05872c3cbf99fe78619c269096e2be3d4a350058639d5"
+
+[[package]]
+name = "parley"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6c00ec192e1a402861526eff91a4b4690a2e5a17a4ae2deb772d72b49daf868"
 dependencies = [
  "fontique",
  "harfrust",
  "hashbrown 0.16.1",
+ "icu_normalizer",
+ "icu_properties",
+ "icu_segmenter",
  "linebender_resource_handle",
+ "parlance",
+ "parley_data",
  "skrifa",
- "swash",
+]
+
+[[package]]
+name = "parley_data"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232313eddc02ac27f015e8f8eeb7facce8a896116df7e3eda1bfd9f600a9a39d"
+dependencies = [
+ "icu_properties",
 ]
 
 [[package]]
@@ -3774,10 +3870,12 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
+ "serde_core",
+ "writeable",
  "zerovec",
 ]
 
@@ -3812,7 +3910,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.4+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -3845,9 +3943,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.1"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c41efbf8f90ac44de7f3a868f0867851d261b56291732d0cbf7cceaaeb55a6"
+checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
  "bitflags 2.11.0",
  "getopts",
@@ -4032,9 +4130,9 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.35.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
+checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
 dependencies = [
  "bytemuck",
  "core_maths",
@@ -4099,9 +4197,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "resvg"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b563218631706d614e23059436526d005b50ab5f2d506b55a17eb65c5eb83419"
+checksum = "9be183ad6a216aa96f33e4c8033b0988b8b3ea6fd2359d19af5bac4643fd8e81"
 dependencies = [
  "gif 0.14.1",
  "image-webp",
@@ -4109,7 +4207,7 @@ dependencies = [
  "pico-args",
  "rgb",
  "svgtypes",
- "tiny-skia",
+ "tiny-skia 0.12.0",
  "usvg",
  "zune-jpeg",
 ]
@@ -4199,9 +4297,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -4309,14 +4407,14 @@ dependencies = [
  "log",
  "memmap2",
  "smithay-client-toolkit 0.19.2",
- "tiny-skia",
+ "tiny-skia 0.11.4",
 ]
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -4374,9 +4472,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -4408,9 +4506,19 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
 
 [[package]]
 name = "simd_helpers"
@@ -4420,6 +4528,12 @@ checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simplecss"
@@ -4461,14 +4575,14 @@ checksum = "6a71c01d325d40b1031dee67d251a5e0132e79e2a9ec272149a4f4a0d4b8b3be"
 dependencies = [
  "bitflags 2.11.0",
  "skia-bindings",
- "windows 0.62.2",
+ "windows",
 ]
 
 [[package]]
 name = "skrifa"
-version = "0.37.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c31071dedf532758ecf3fed987cdb4bd9509f900e026ab684b4ecb81ea49841"
+checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
 dependencies = [
  "bytemuck",
  "read-fonts",
@@ -4483,7 +4597,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slint"
 version = "1.16.0"
-source = "git+https://github.com/slint-ui/slint#31a7f21a81b494072288e30fc14a92b787c96ad4"
+source = "git+https://github.com/slint-ui/slint#e27d0d19e983baf71532de8b7a4a0ebce2026237"
 dependencies = [
  "const-field-offset",
  "i-slint-backend-selector",
@@ -4503,19 +4617,19 @@ dependencies = [
 [[package]]
 name = "slint-build"
 version = "1.16.0"
-source = "git+https://github.com/slint-ui/slint#31a7f21a81b494072288e30fc14a92b787c96ad4"
+source = "git+https://github.com/slint-ui/slint#e27d0d19e983baf71532de8b7a4a0ebce2026237"
 dependencies = [
  "derive_more",
  "fontique",
  "i-slint-compiler",
  "spin_on",
- "toml_edit 0.24.1+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
 name = "slint-macros"
 version = "1.16.0"
-source = "git+https://github.com/slint-ui/slint#31a7f21a81b494072288e30fc14a92b787c96ad4"
+source = "git+https://github.com/slint-ui/slint#e27d0d19e983baf71532de8b7a4a0ebce2026237"
 dependencies = [
  "i-slint-compiler",
  "proc-macro2",
@@ -4704,18 +4818,18 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -4729,15 +4843,15 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "695b5790b3131dafa99b3bbfd25a216edb3d216dad9ca208d4657bfb8f2abc3d"
 dependencies = [
- "kurbo 0.13.0",
+ "kurbo",
  "siphasher",
 ]
 
 [[package]]
 name = "swash"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47846491253e976bdd07d0f9cc24b7daf24720d11309302ccbbc6e6b6e53550a"
+checksum = "842f3cd369c2ba38966204f983eaa5e54a8e84a7d7159ed36ade2b6c335aae64"
 dependencies = [
  "skrifa",
  "yazi",
@@ -4780,9 +4894,9 @@ dependencies = [
 
 [[package]]
 name = "taffy"
-version = "0.7.7"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4f4d046dd956a47a7e1a2947083d7ac3e6aa3cfaaead36173ceaa5ab11878c"
+checksum = "41ba83ebaf2954d31d05d67340fd46cebe99da2b7133b0dd68d70c65473a437b"
 dependencies = [
  "arrayvec",
  "grid",
@@ -4792,9 +4906,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",
@@ -4924,8 +5038,22 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "log",
- "png 0.17.16",
- "tiny-skia-path",
+ "tiny-skia-path 0.11.4",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47ffee5eaaf5527f630fb0e356b90ebdec84d5d18d937c5e440350f88c5a91ea"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png 0.18.1",
+ "tiny-skia-path 0.12.0",
 ]
 
 [[package]]
@@ -4933,6 +5061,17 @@ name = "tiny-skia-path"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca365c3faccca67d06593c5980fa6c57687de727a03131735bb85f01fdeeb9"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -4954,9 +5093,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "serde_core",
@@ -4990,7 +5129,7 @@ dependencies = [
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -5004,52 +5143,40 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.24.1+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01f2eadbbc6b377a847be05f60791ef1058d9f696ecb51d2c07fe911d8569d8e"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.25.4+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
-dependencies = [
- "indexmap",
- "toml_datetime 1.0.0+spec-1.1.0",
- "toml_parser",
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -5217,9 +5344,9 @@ checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-vo"
@@ -5266,16 +5393,16 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "usvg"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e419dff010bb12512b0ae9e3d2f318dfbdf0167fde7eb05465134d4e8756076f"
+checksum = "d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de"
 dependencies = [
  "base64",
  "data-url",
  "flate2",
  "fontdb",
  "imagesize",
- "kurbo 0.13.0",
+ "kurbo",
  "log",
  "pico-args",
  "roxmltree",
@@ -5284,7 +5411,8 @@ dependencies = [
  "siphasher",
  "strict-num",
  "svgtypes",
- "tiny-skia-path",
+ "tiny-skia-path 0.12.0",
+ "ttf-parser 0.25.1",
  "unicode-bidi",
  "unicode-script",
  "unicode-vo",
@@ -5305,9 +5433,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "js-sys",
  "serde_core",
@@ -5345,8 +5473,8 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vtable"
-version = "0.3.0"
-source = "git+https://github.com/slint-ui/slint#31a7f21a81b494072288e30fc14a92b787c96ad4"
+version = "0.4.0"
+source = "git+https://github.com/slint-ui/slint#e27d0d19e983baf71532de8b7a4a0ebce2026237"
 dependencies = [
  "const-field-offset",
  "portable-atomic",
@@ -5356,8 +5484,8 @@ dependencies = [
 
 [[package]]
 name = "vtable-macro"
-version = "0.3.0"
-source = "git+https://github.com/slint-ui/slint#31a7f21a81b494072288e30fc14a92b787c96ad4"
+version = "0.4.0"
+source = "git+https://github.com/slint-ui/slint#e27d0d19e983baf71532de8b7a4a0ebce2026237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5400,9 +5528,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5413,23 +5541,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5437,9 +5561,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5450,9 +5574,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -5493,9 +5617,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa75f400b7f719bcd68b3f47cd939ba654cedeef690f486db71331eec4c6a406"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
 dependencies = [
  "cc",
  "downcast-rs",
@@ -5507,9 +5631,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.13"
+version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab51d9f7c071abeee76007e2b742499e535148035bb835f97aaed1338cf516c3"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
  "bitflags 2.11.0",
  "rustix 1.1.4",
@@ -5530,9 +5654,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-cursor"
-version = "0.31.13"
+version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b3298683470fbdc6ca40151dfc48c8f2fd4c41a26e13042f801f85002384091"
+checksum = "4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d"
 dependencies = [
  "rustix 1.1.4",
  "wayland-client",
@@ -5541,9 +5665,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.11"
+version = "0.32.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b23b5df31ceff1328f06ac607591d5ba360cf58f90c8fad4ac8d3a55a3c4aec7"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
 dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",
@@ -5566,9 +5690,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-misc"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "429b99200febaf95d4f4e46deff6fe4382bcff3280ee16a41cf887b3c3364984"
+checksum = "6e9567599ef23e09b8dad6e429e5738d4509dfc46b3b21f32841a304d16b29c8"
 dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",
@@ -5579,9 +5703,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-plasma"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d392fc283a87774afc9beefcd6f931582bb97fe0e6ced0b306a62cb1d026527c"
+checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
 dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",
@@ -5592,9 +5716,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-wlr"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78248e4cc0eff8163370ba5c158630dcae1f3497a586b826eca2ef5f348d6235"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",
@@ -5605,9 +5729,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.9"
+version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86287151a309799b821ca709b7345a048a2956af05957c89cb824ab919fa4e3"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -5616,9 +5740,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.10"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374f6b70e8e0d6bf9461a32988fd553b59ff630964924dad6e4a4eb6bd538d17"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
  "dlib",
  "log",
@@ -5628,9 +5752,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5644,6 +5768,22 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webbrowser"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe985f41e291eecef5e5c0770a18d28390addb03331c043964d9e916453d6f16"
+dependencies = [
+ "core-foundation 0.10.1",
+ "jni",
+ "log",
+ "ndk-context",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "url",
+ "web-sys",
 ]
 
 [[package]]
@@ -5663,22 +5803,12 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.62.2",
+ "windows-core",
  "windows-future",
  "windows-numerics",
 ]
@@ -5689,20 +5819,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
-dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
+ "windows-core",
 ]
 
 [[package]]
@@ -5711,11 +5828,11 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -5724,20 +5841,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
  "windows-threading",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -5745,17 +5851,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5785,17 +5880,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5809,30 +5895,11 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-strings"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -5878,21 +5945,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -5954,12 +6006,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -5978,12 +6024,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -5999,12 +6039,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6038,12 +6072,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -6059,12 +6087,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6086,12 +6108,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -6107,12 +6123,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6147,7 +6157,7 @@ dependencies = [
  "calloop 0.13.0",
  "cfg_aliases",
  "concurrent-queue",
- "core-foundation",
+ "core-foundation 0.9.4",
  "core-graphics",
  "cursor-icon",
  "dpi",
@@ -6189,6 +6199,15 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
@@ -6283,22 +6302,22 @@ dependencies = [
 
 [[package]]
 name = "write-fonts"
-version = "0.43.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "886614b5ce857341226aa091f3c285e450683894acaaa7887f366c361efef79d"
+checksum = "f12725b0845073e20b04e79b500dbfb465904d7cbd84883a1f1bbd084debc515"
 dependencies = [
  "font-types",
  "indexmap",
- "kurbo 0.12.0",
+ "kurbo",
  "log",
  "read-fonts",
 ]
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x11-clipboard"
@@ -6425,9 +6444,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -6436,9 +6455,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6475,7 +6494,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow",
+ "winnow 0.7.15",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -6503,7 +6522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
 dependencies = [
  "serde",
- "winnow",
+ "winnow 0.7.15",
  "zvariant",
 ]
 
@@ -6515,18 +6534,18 @@ checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6535,18 +6554,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6556,20 +6575,21 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
  "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "serde",
  "yoke",
@@ -6579,9 +6599,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6611,9 +6631,9 @@ dependencies = [
 
 [[package]]
 name = "zune-jpeg"
-version = "0.5.13"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec5f41c76397b7da451efd19915684f727d7e1d516384ca6bd0ec43ec94de23c"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
 ]
@@ -6628,7 +6648,7 @@ dependencies = [
  "enumflags2",
  "serde",
  "url",
- "winnow",
+ "winnow 0.7.15",
  "zvariant_derive",
  "zvariant_utils",
 ]
@@ -6656,5 +6676,5 @@ dependencies = [
  "quote",
  "serde",
  "syn",
- "winnow",
+ "winnow 0.7.15",
 ]

--- a/crates/lianli-daemon/src/fan_controller.rs
+++ b/crates/lianli-daemon/src/fan_controller.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use lianli_devices::traits::FanDevice;
 use lianli_devices::wireless::WirelessController;
 use lianli_shared::fan::{FanConfig, FanCurve, FanSpeed};
-use lianli_shared::sensors::{self, ResolvedSensor, TempSource};
+use lianli_shared::sensors::{self, ResolvedSensor, SensorInfo, SensorSource};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -45,9 +45,10 @@ impl FanController {
         let wireless = self.wireless.clone();
         let wired = Arc::clone(&self.wired_devices);
         let stop_flag = Arc::clone(&self.stop_flag);
+        let all_sensors = lianli_shared::sensors::enumerate_sensors();
 
         let thread = thread::spawn(move || {
-            fan_control_thread(config, curves, wireless, wired, stop_flag);
+            fan_control_thread(config, curves, wireless, wired, stop_flag,&all_sensors);
         });
 
         self.thread = Some(thread);
@@ -67,6 +68,7 @@ fn fan_control_thread(
     wireless: Option<Arc<WirelessController>>,
     wired: Arc<HashMap<String, Box<dyn FanDevice>>>,
     stop_flag: Arc<AtomicBool>,
+    all_sensors: &Vec<SensorInfo>,
 ) {
     let update_interval = Duration::from_millis(config.update_interval_ms);
     let mut last_update = Instant::now() - update_interval;
@@ -108,8 +110,8 @@ fn fan_control_thread(
 
     info!("Starting fan speed control loop ({} group(s))", config.speeds.len());
 
-    let mut temp_ema: HashMap<TempSource, f32> = HashMap::new();
-    let mut sensor_cache: HashMap<TempSource, ResolvedSensor> = HashMap::new();
+    let mut temp_ema: HashMap<SensorSource, f32> = HashMap::new();
+    let mut sensor_cache: HashMap<SensorSource, ResolvedSensor> = HashMap::new();
 
     // Initialize MB RPM sync state for all wired groups at startup.
     // Groups with MbSync speeds get sync enabled; others get it disabled.
@@ -173,7 +175,7 @@ fn fan_control_thread(
                 continue;
             }
 
-            let speeds = match calculate_fan_speeds(&group.speeds, &curves, &mut sensor_cache, &mut temp_ema) {
+            let speeds = match calculate_fan_speeds(&group.speeds, &curves, &mut sensor_cache, &mut temp_ema,all_sensors) {
                 Ok(speeds) => speeds,
                 Err(err) => {
                     warn!("Fan speed calculation failed for group {group_idx}: {err}");
@@ -254,8 +256,9 @@ const TEMP_EMA_ALPHA: f32 = 0.3;
 fn calculate_fan_speeds(
     fan_speeds: &[FanSpeed; 4],
     curves: &HashMap<String, FanCurve>,
-    sensor_cache: &mut HashMap<TempSource, ResolvedSensor>,
-    temp_ema: &mut HashMap<TempSource, f32>,
+    sensor_cache: &mut HashMap<SensorSource, ResolvedSensor>,
+    temp_ema: &mut HashMap<SensorSource, f32>,
+    all_sensors: &Vec<SensorInfo>,
 ) -> Result<[u8; 4]> {
     let mut pwm_values = [0u8; 4];
 
@@ -268,7 +271,7 @@ fn calculate_fan_speeds(
                     .ok_or_else(|| anyhow::anyhow!("Curve '{curve_name}' not found"))?;
 
                 let source = curve.effective_source();
-                let temp = smoothed_temperature(&source, sensor_cache, temp_ema)?;
+                let temp = smoothed_temperature(&source, sensor_cache, temp_ema,all_sensors)?;
                 let speed_percent = interpolate_curve(&curve.curve, temp);
                 let pwm = (speed_percent * 2.55) as u8;
 
@@ -282,20 +285,23 @@ fn calculate_fan_speeds(
 }
 
 fn smoothed_temperature(
-    source: &TempSource,
-    cache: &mut HashMap<TempSource, ResolvedSensor>,
-    ema: &mut HashMap<TempSource, f32>,
+    source: &SensorSource,
+    cache: &mut HashMap<SensorSource, ResolvedSensor>,
+    ema: &mut HashMap<SensorSource, f32>,
+    all_sensors: &Vec<SensorInfo>,
 ) -> Result<f32> {
     let resolved = match cache.get(source) {
         Some(r) => r.clone(),
         None => {
-            let r = sensors::resolve_sensor(source).context("sensor not found")?;
+            let sensor_info = all_sensors.iter().find(|s| s.source==*source);
+            let divider =sensor_info.map_or(1, |s| s.divider);
+            let r = sensors::resolve_sensor(source,divider).context("sensor not found")?;
             cache.insert(source.clone(), r.clone());
             r
         }
     };
 
-    match sensors::read_sensor_temp(&resolved) {
+    match sensors::read_sensor_value(&resolved) {
         Ok(temp) if temp > 0.0 && temp <= 100.0 => {
             let smoothed = match ema.get(source) {
                 Some(&prev) => TEMP_EMA_ALPHA * temp + (1.0 - TEMP_EMA_ALPHA) * prev,

--- a/crates/lianli-daemon/src/fan_controller.rs
+++ b/crates/lianli-daemon/src/fan_controller.rs
@@ -48,7 +48,7 @@ impl FanController {
         let all_sensors = lianli_shared::sensors::enumerate_sensors();
 
         let thread = thread::spawn(move || {
-            fan_control_thread(config, curves, wireless, wired, stop_flag,&all_sensors);
+            fan_control_thread(config, curves, wireless, wired, stop_flag, &all_sensors);
         });
 
         self.thread = Some(thread);
@@ -68,7 +68,7 @@ fn fan_control_thread(
     wireless: Option<Arc<WirelessController>>,
     wired: Arc<HashMap<String, Box<dyn FanDevice>>>,
     stop_flag: Arc<AtomicBool>,
-    all_sensors: &Vec<SensorInfo>,
+    all_sensors: &[SensorInfo],
 ) {
     let update_interval = Duration::from_millis(config.update_interval_ms);
     let mut last_update = Instant::now() - update_interval;
@@ -175,7 +175,7 @@ fn fan_control_thread(
                 continue;
             }
 
-            let speeds = match calculate_fan_speeds(&group.speeds, &curves, &mut sensor_cache, &mut temp_ema,all_sensors) {
+            let speeds = match calculate_fan_speeds(&group.speeds, &curves, &mut sensor_cache, &mut temp_ema, all_sensors) {
                 Ok(speeds) => speeds,
                 Err(err) => {
                     warn!("Fan speed calculation failed for group {group_idx}: {err}");
@@ -258,7 +258,7 @@ fn calculate_fan_speeds(
     curves: &HashMap<String, FanCurve>,
     sensor_cache: &mut HashMap<SensorSource, ResolvedSensor>,
     temp_ema: &mut HashMap<SensorSource, f32>,
-    all_sensors: &Vec<SensorInfo>,
+    all_sensors: &[SensorInfo],
 ) -> Result<[u8; 4]> {
     let mut pwm_values = [0u8; 4];
 
@@ -271,7 +271,7 @@ fn calculate_fan_speeds(
                     .ok_or_else(|| anyhow::anyhow!("Curve '{curve_name}' not found"))?;
 
                 let source = curve.effective_source();
-                let temp = smoothed_temperature(&source, sensor_cache, temp_ema,all_sensors)?;
+                let temp = smoothed_temperature(&source, sensor_cache, temp_ema, all_sensors)?;
                 let speed_percent = interpolate_curve(&curve.curve, temp);
                 let pwm = (speed_percent * 2.55) as u8;
 
@@ -288,14 +288,14 @@ fn smoothed_temperature(
     source: &SensorSource,
     cache: &mut HashMap<SensorSource, ResolvedSensor>,
     ema: &mut HashMap<SensorSource, f32>,
-    all_sensors: &Vec<SensorInfo>,
+    all_sensors: &[SensorInfo],
 ) -> Result<f32> {
     let resolved = match cache.get(source) {
         Some(r) => r.clone(),
         None => {
-            let sensor_info = all_sensors.iter().find(|s| s.source==*source);
-            let divider =sensor_info.map_or(1, |s| s.divider);
-            let r = sensors::resolve_sensor(source,divider).context("sensor not found")?;
+            let sensor_info = all_sensors.iter().find(|s| s.source == *source);
+            let divider = sensor_info.map_or(1, |s| s.divider);
+            let r = sensors::resolve_sensor(source, divider).context("sensor not found")?;
             cache.insert(source.clone(), r.clone());
             r
         }

--- a/crates/lianli-daemon/src/ipc_server.rs
+++ b/crates/lianli-daemon/src/ipc_server.rs
@@ -7,6 +7,7 @@ use crate::rgb_controller::RgbController;
 use crate::service::DaemonEvent;
 use lianli_shared::config::AppConfig;
 use lianli_shared::ipc::{DeviceInfo, IpcRequest, IpcResponse, TelemetrySnapshot};
+use lianli_shared::sensors::Unit;
 use parking_lot::Mutex;
 use std::fs;
 use std::io::{BufRead, BufReader, Write};
@@ -167,11 +168,14 @@ fn handle_request(request: IpcRequest, state: &Arc<Mutex<DaemonState>>, tx: Send
                     .map(|d| format!("{} (Coolant)", d.name))
                     .unwrap_or_else(|| format!("{device_id} (Coolant)"));
                 sensors.push(lianli_shared::sensors::SensorInfo {
-                    source: lianli_shared::sensors::TempSource::WirelessCoolant {
+                    source: lianli_shared::sensors::SensorSource::WirelessCoolant {
                         device_id: device_id.clone(),
                     },
-                    display_name: display,
-                    current_temp: Some(*temp),
+                    sensor_name: None,
+                    display_name: Some(display),
+                    unit: Unit::C,
+                    divider: 1,
+                    current_value: Some(*temp),
                 });
             }
             drop(ipc_state);

--- a/crates/lianli-daemon/src/service.rs
+++ b/crates/lianli-daemon/src/service.rs
@@ -12,6 +12,7 @@ use lianli_devices::detect::{
 };
 use lianli_media::sensor::FrameInfo;
 use lianli_shared::config::HidDriver;
+use lianli_shared::systeminfo::SysSensor;
 use lianli_transport::HidBackend;
 use lianli_devices::hydroshift_lcd::HydroShiftLcdController;
 use lianli_devices::slv3_lcd::Slv3LcdDevice;
@@ -229,6 +230,7 @@ impl ServiceManager {
                 break; // Daemon thread has ended. Time for us to die as well
             }
         });
+        SysSensor::init();
 
         for event in rx {
             match event {
@@ -864,6 +866,8 @@ impl ServiceManager {
             })
             .collect();
 
+        let all_sensors = lianli_shared::sensors::enumerate_sensors();
+
         if let Some(cfg) = &self.config {
             for (idx, device) in cfg.lcds.iter().enumerate() {
                 // Look up screen info by serial; fall back to WIRELESS_LCD (400×400) for
@@ -874,7 +878,7 @@ impl ServiceManager {
                     .and_then(|s| screen_map.get(s).copied())
                     .unwrap_or(ScreenInfo::WIRELESS_LCD);
                 let cfg_key = config_identity(device);
-                match prepare_media_asset(device, cfg.default_fps, &screen, screen.h264) {
+                match prepare_media_asset(device, cfg.default_fps, &screen, screen.h264,&all_sensors) {
                     Ok(asset_kind) => {
                         let device_id = device.device_id();
                         let asset = MediaAsset{kind: asset_kind, config_key: cfg_key};
@@ -1366,6 +1370,8 @@ struct ActiveTarget {
     lcd: LcdBackend,
     media: MediaRuntime,
     asset: Arc<MediaAsset>,
+    // This variable contains the last seen frame version. Each renderer holds a frame version counter which gets increased each time it actually writes into the frame. The first time it writes into the frame sets the frame version to 1
+    // By using this mechanism we are able to detect whether we actually need to send the frame via USB bus to the LCD, and thus we can save quite a lot of time by not sending frames which are already displayed.
     frame_counter: u64,
     consecutive_errors: u32,
 }

--- a/crates/lianli-daemon/src/service.rs
+++ b/crates/lianli-daemon/src/service.rs
@@ -878,7 +878,7 @@ impl ServiceManager {
                     .and_then(|s| screen_map.get(s).copied())
                     .unwrap_or(ScreenInfo::WIRELESS_LCD);
                 let cfg_key = config_identity(device);
-                match prepare_media_asset(device, cfg.default_fps, &screen, screen.h264,&all_sensors) {
+                match prepare_media_asset(device, cfg.default_fps, &screen, screen.h264, &all_sensors) {
                     Ok(asset_kind) => {
                         let device_id = device.device_id();
                         let asset = MediaAsset{kind: asset_kind, config_key: cfg_key};

--- a/crates/lianli-gui/src/backend.rs
+++ b/crates/lianli-gui/src/backend.rs
@@ -278,7 +278,7 @@ fn load_config(window: &slint::Weak<crate::MainWindow>, shared: &crate::Shared) 
                 w.set_lcd_entries(lcd_model);
                 let lcd_opts = conversions::lcd_device_options(&devices);
                 w.set_lcd_device_options(lcd_opts);
-                w.set_lcd_sensor_options(conversions::sensor_options_model(&sensors,false));
+                w.set_lcd_sensor_options(conversions::sensor_options_model(&sensors, false));
 
                 // Fan curves
                 let curves_model = conversions::fan_curves_to_model(&config.fan_curves, &sensors);
@@ -287,7 +287,7 @@ fn load_config(window: &slint::Weak<crate::MainWindow>, shared: &crate::Shared) 
                 w.set_curve_names(names_model);
                 let speed_opts = conversions::speed_options_model(&config.fan_curves, true);
                 w.set_fan_speed_options(speed_opts);
-                w.set_fan_sensor_options(conversions::sensor_options_model(&sensors,true));
+                w.set_fan_sensor_options(conversions::sensor_options_model(&sensors, true));
                 w.set_fan_update_interval(fan_update_interval);
 
                 // Fan groups

--- a/crates/lianli-gui/src/backend.rs
+++ b/crates/lianli-gui/src/backend.rs
@@ -278,6 +278,7 @@ fn load_config(window: &slint::Weak<crate::MainWindow>, shared: &crate::Shared) 
                 w.set_lcd_entries(lcd_model);
                 let lcd_opts = conversions::lcd_device_options(&devices);
                 w.set_lcd_device_options(lcd_opts);
+                w.set_lcd_sensor_options(conversions::sensor_options_model(&sensors,false));
 
                 // Fan curves
                 let curves_model = conversions::fan_curves_to_model(&config.fan_curves, &sensors);
@@ -286,7 +287,7 @@ fn load_config(window: &slint::Weak<crate::MainWindow>, shared: &crate::Shared) 
                 w.set_curve_names(names_model);
                 let speed_opts = conversions::speed_options_model(&config.fan_curves, true);
                 w.set_fan_speed_options(speed_opts);
-                w.set_sensor_options(conversions::sensor_options_model(&sensors));
+                w.set_fan_sensor_options(conversions::sensor_options_model(&sensors,true));
                 w.set_fan_update_interval(fan_update_interval);
 
                 // Fan groups

--- a/crates/lianli-gui/src/conversions.rs
+++ b/crates/lianli-gui/src/conversions.rs
@@ -4,8 +4,9 @@ use lianli_shared::config::{AppConfig, LcdConfig};
 use lianli_shared::device_id::DeviceFamily;
 use lianli_shared::fan::{FanConfig, FanCurve, FanSpeed};
 use lianli_shared::ipc::{DeviceInfo, TelemetrySnapshot};
-use lianli_shared::media::MediaType;
+use lianli_shared::media::{MediaType};
 use lianli_shared::rgb::{RgbDeviceCapabilities, RgbMode, RgbScope};
+use lianli_shared::sensors::Unit;
 use slint::{ModelRc, SharedString, VecModel};
 
 fn family_display_name(f: DeviceFamily) -> &'static str {
@@ -119,27 +120,22 @@ pub fn lcd_to_slint(
 ) -> super::LcdEntryData {
     let sensor = lcd.sensor.as_ref();
 
-    let (source_display, cmd) = sensor
-        .map(|s| match &s.source {
-            lianli_shared::media::SensorSourceConfig::Command { cmd } => {
-                ("Custom command".to_string(), cmd.clone())
-            }
-            lianli_shared::media::SensorSourceConfig::Constant { value } => {
-                ("Custom command".to_string(), format!("{value}"))
-            }
-            lianli_shared::media::SensorSourceConfig::Hwmon { .. }
-            | lianli_shared::media::SensorSourceConfig::NvidiaGpu { .. }
-            | lianli_shared::media::SensorSourceConfig::WirelessCoolant { .. } => {
-                let ts = s.source.to_temp_source();
-                let display = sensors
-                    .iter()
-                    .find(|si| si.source == ts)
-                    .map(|si| si.display_name.clone())
-                    .unwrap_or_else(|| "Custom command".to_string());
-                (display, String::new())
-            }
-        })
-        .unwrap_or_else(|| ("Custom command".to_string(), String::new()));
+    let mut sg_sensor_index = 0;
+    let mut cmd = "".to_string();
+    if let Some(sd) = sensor {
+        // Find sd.source in sensors: Return its index
+        let ts: lianli_shared::sensors::SensorSource = sd.source.to_sensor_source();
+
+        if let Some(idx) = sensors.iter().position(|si| si.source == ts) {
+            sg_sensor_index = idx;
+        } else {
+            sg_sensor_index = sensors.len();
+            cmd = match ts {
+                lianli_shared::sensors::SensorSource::Command { cmd } => cmd,
+                _ => String::new(),
+            };
+        }
+    };
 
     let text_color = sensor.map(|s| s.text_color).unwrap_or([255, 255, 255]);
     let bg_color = sensor.map(|s| s.background_color).unwrap_or([0, 0, 0]);
@@ -172,7 +168,7 @@ pub fn lcd_to_slint(
         rgb_b: b as i32,
         sensor_label: SharedString::from(sensor.map(|s| s.label.as_str()).unwrap_or("")),
         sensor_unit: SharedString::from(sensor.map(|s| s.unit.as_str()).unwrap_or("")),
-        sensor_source_display: SharedString::from(&source_display),
+        sg_sensor_index: sg_sensor_index as i32,
         sensor_command: SharedString::from(&cmd),
         sensor_font_path: SharedString::from(sensor.and_then(|s| s.font_path.as_ref()).map(|p| p.display().to_string()).unwrap_or_default()),
         sensor_decimal_places: sensor.map(|s| s.decimal_places as i32).unwrap_or(0),
@@ -307,22 +303,29 @@ pub fn fan_curve_to_slint(
     let mut sorted: Vec<(f32, f32)> = curve.curve.clone();
     sorted.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
 
-    let (display, index) = if let Some(ref source) = curve.temp_source {
-        match sensors.iter().position(|s| &s.source == source) {
-            Some(idx) => (sensors[idx].display_name.clone(), idx as i32),
-            None => ("Custom command".to_string(), sensors.len() as i32),
-        }
-    } else if !curve.temp_command.is_empty() {
-        ("Custom command".to_string(), sensors.len() as i32)
-    } else {
-        ("Custom command".to_string(), sensors.len() as i32)
-    };
+    let sensor = curve.temp_source.as_ref();
 
+    let mut sensor_index = 0;
+    let user_cmd = curve.temp_command.to_string();
+    if let Some(sd) = sensor {
+        // Find sd in sensors: Return its index
+        if let Some(idx) = sensors
+                .iter()
+                .filter(|s| s.unit == Unit::C)
+                .position(|si| si.source == *sd) {
+            sensor_index = idx;
+        } else {
+            sensor_index = sensors
+                            .iter()
+                            .filter(|s| s.unit == Unit::C)
+                            .count();
+        }
+    }
+    
     super::FanCurveData {
         name: SharedString::from(&curve.name),
-        temp_source_display: SharedString::from(&display),
-        temp_source_index: index,
-        temp_command: SharedString::from(&curve.temp_command),
+        temp_source_index: sensor_index as i32,
+        temp_command: SharedString::from(user_cmd),
         points: ModelRc::new(VecModel::from(points)),
         curve_segments: ModelRc::new(VecModel::from(build_curve_segments(&sorted))),
         clamp_segments: ModelRc::new(VecModel::from(build_clamp_segments(&sorted))),
@@ -339,12 +342,19 @@ pub fn fan_curves_to_model(
 
 pub fn sensor_options_model(
     sensors: &[lianli_shared::sensors::SensorInfo],
+    only_temp_sensors: bool,
 ) -> ModelRc<SharedString> {
     let mut items: Vec<SharedString> = sensors
         .iter()
-        .map(|s| SharedString::from(&s.display_name))
+        .filter(|s| !only_temp_sensors || s.unit == Unit::C)
+        .enumerate()
+        .map(|(i, s)| {
+            let display_name=format!("{}. {}", i + 1, s.get_display_name());
+            SharedString::from(display_name)
+        })
         .collect();
-    items.push(SharedString::from("Custom command"));
+    let display_name=format!("{}. {}", items.len()+1, "Custom command");
+    items.push(SharedString::from(display_name));
     ModelRc::new(VecModel::from(items))
 }
 

--- a/crates/lianli-gui/src/conversions.rs
+++ b/crates/lianli-gui/src/conversions.rs
@@ -349,11 +349,11 @@ pub fn sensor_options_model(
         .filter(|s| !only_temp_sensors || s.unit == Unit::C)
         .enumerate()
         .map(|(i, s)| {
-            let display_name=format!("{}. {}", i + 1, s.get_display_name());
+            let display_name = format!("{}. {}", i + 1, s.get_display_name());
             SharedString::from(display_name)
         })
         .collect();
-    let display_name=format!("{}. {}", items.len()+1, "Custom command");
+    let display_name = format!("{}. {}", items.len() + 1, "Custom command");
     items.push(SharedString::from(display_name));
     ModelRc::new(VecModel::from(items))
 }

--- a/crates/lianli-gui/src/main.rs
+++ b/crates/lianli-gui/src/main.rs
@@ -10,6 +10,8 @@ use lianli_shared::rgb::{
 };
 use slint::{Model, ModelRc, VecModel};
 use std::sync::{Arc, Mutex};
+use lianli_shared::sensors::Unit;
+use lianli_shared::sensors::SensorSource;
 
 slint::include_modules!();
 
@@ -587,20 +589,24 @@ fn wire_fan_callbacks(
             let display = display_name.to_string();
             {
                 let mut state = shared.lock().unwrap();
-                let source = if display == "Custom command" {
+                let source = if display.ends_with("Custom command") {
                     None
                 } else {
+                    let sensor_idx: usize = display.split('.').next().unwrap().parse().unwrap_or(0);
                     state
                         .available_sensors
                         .iter()
-                        .find(|s| s.display_name == display)
+                        .filter(|s| s.unit == Unit::C)
+                        .nth(sensor_idx-1) // Fetches the x-th element (0-based)
                         .map(|s| s.source.clone())
                 };
                 if let Some(ref mut c) = state.config {
                     if let Some(curve) = c.fan_curves.get_mut(idx as usize) {
                         curve.temp_source = source;
-                        if curve.temp_source.is_some() {
-                            curve.temp_command.clear();
+                        if curve.temp_source.is_none() {
+                            curve.temp_source = Some(SensorSource::Command {
+                                cmd: "".to_string(),
+                            },)
                         }
                     }
                 }
@@ -849,21 +855,27 @@ fn wire_lcd_callbacks(
                 let devices = state.devices.clone();
                 let resolved_sensor_source: Option<lianli_shared::media::SensorSourceConfig> = {
                     let val_str = val.to_string();
-                    if field_str == "sensor_source" && val_str != "Custom command" {
-                        state.available_sensors.iter()
-                            .find(|s| s.display_name == val_str)
-                            .map(|si| match &si.source {
-                                lianli_shared::sensors::TempSource::Hwmon { name, label, device_path } =>
-                                    lianli_shared::media::SensorSourceConfig::Hwmon {
+                    let sensor_idx: usize = val_str.split('.').next().unwrap().parse().unwrap_or(0);
+                    if field_str == "sensor_source" && !val_str.ends_with("Custom command") {
+                        if let Some(sensor) = state.available_sensors.get(sensor_idx-1) {
+                            match &sensor.source {
+                                lianli_shared::sensors::SensorSource::Hwmon { name, label, device_path } =>
+                                {
+                                    let ret = Some(lianli_shared::media::SensorSourceConfig::Hwmon {
                                         name: name.clone(), label: label.clone(), device_path: device_path.clone(),
-                                    },
-                                lianli_shared::sensors::TempSource::NvidiaGpu { gpu_index } =>
-                                    lianli_shared::media::SensorSourceConfig::NvidiaGpu { gpu_index: *gpu_index },
-                                lianli_shared::sensors::TempSource::Command { cmd } =>
-                                    lianli_shared::media::SensorSourceConfig::Command { cmd: cmd.clone() },
-                                lianli_shared::sensors::TempSource::WirelessCoolant { device_id } =>
-                                    lianli_shared::media::SensorSourceConfig::WirelessCoolant { device_id: device_id.clone() },
-                            })
+                                    });
+                                    ret
+                                },
+                                lianli_shared::sensors::SensorSource::NvidiaGpu { gpu_index } =>
+                                    Some(lianli_shared::media::SensorSourceConfig::NvidiaGpu {gpu_index: *gpu_index}),
+                                lianli_shared::sensors::SensorSource::Command { cmd } =>
+                                    Some(lianli_shared::media::SensorSourceConfig::Command { cmd: cmd.clone() }),
+                                lianli_shared::sensors::SensorSource::WirelessCoolant { device_id } =>
+                                    Some(lianli_shared::media::SensorSourceConfig::WirelessCoolant { device_id: device_id.clone() }),
+                            }
+                        } else {
+                            None
+                        }
                     } else {
                         None
                     }
@@ -890,7 +902,7 @@ fn wire_lcd_callbacks(
                                     "Sensor Gauge" => {
                                         lcd.sensor.get_or_insert_with(default_sensor);
                                         lianli_shared::media::MediaType::Sensor
-                                    }
+                                    } 
                                     _ => lcd.media_type,
                                 };
                             }

--- a/crates/lianli-gui/src/main.rs
+++ b/crates/lianli-gui/src/main.rs
@@ -11,7 +11,6 @@ use lianli_shared::rgb::{
 use slint::{Model, ModelRc, VecModel};
 use std::sync::{Arc, Mutex};
 use lianli_shared::sensors::Unit;
-use lianli_shared::sensors::SensorSource;
 
 slint::include_modules!();
 
@@ -592,21 +591,20 @@ fn wire_fan_callbacks(
                 let source = if display.ends_with("Custom command") {
                     None
                 } else {
-                    let sensor_idx: usize = display.split('.').next().unwrap().parse().unwrap_or(0);
-                    state
-                        .available_sensors
-                        .iter()
-                        .filter(|s| s.unit == Unit::C)
-                        .nth(sensor_idx-1) // Fetches the x-th element (0-based)
-                        .map(|s| s.source.clone())
+                    let sensor_idx: usize = display.split('.').next().and_then(|s| s.parse().ok()).unwrap_or(0);
+                    sensor_idx.checked_sub(1).and_then(|i| {
+                        state.available_sensors
+                            .iter()
+                            .filter(|s| s.unit == Unit::C)
+                            .nth(i)
+                            .map(|s| s.source.clone())
+                    })
                 };
                 if let Some(ref mut c) = state.config {
                     if let Some(curve) = c.fan_curves.get_mut(idx as usize) {
                         curve.temp_source = source;
-                        if curve.temp_source.is_none() {
-                            curve.temp_source = Some(SensorSource::Command {
-                                cmd: "".to_string(),
-                            },)
+                        if curve.temp_source.is_some() {
+                            curve.temp_command.clear();
                         }
                     }
                 }
@@ -855,9 +853,9 @@ fn wire_lcd_callbacks(
                 let devices = state.devices.clone();
                 let resolved_sensor_source: Option<lianli_shared::media::SensorSourceConfig> = {
                     let val_str = val.to_string();
-                    let sensor_idx: usize = val_str.split('.').next().unwrap().parse().unwrap_or(0);
-                    if field_str == "sensor_source" && !val_str.ends_with("Custom command") {
-                        if let Some(sensor) = state.available_sensors.get(sensor_idx-1) {
+                    let sensor_idx: usize = val_str.split('.').next().and_then(|s| s.parse().ok()).unwrap_or(0);
+                    if field_str == "sensor_source" && !val_str.ends_with("Custom command") && sensor_idx > 0 {
+                        if let Some(sensor) = state.available_sensors.get(sensor_idx - 1) {
                             match &sensor.source {
                                 lianli_shared::sensors::SensorSource::Hwmon { name, label, device_path } =>
                                 {
@@ -872,6 +870,7 @@ fn wire_lcd_callbacks(
                                     Some(lianli_shared::media::SensorSourceConfig::Command { cmd: cmd.clone() }),
                                 lianli_shared::sensors::SensorSource::WirelessCoolant { device_id } =>
                                     Some(lianli_shared::media::SensorSourceConfig::WirelessCoolant { device_id: device_id.clone() }),
+                                _ => None,
                             }
                         } else {
                             None

--- a/crates/lianli-gui/src/main.rs
+++ b/crates/lianli-gui/src/main.rs
@@ -870,7 +870,10 @@ fn wire_lcd_callbacks(
                                     Some(lianli_shared::media::SensorSourceConfig::Command { cmd: cmd.clone() }),
                                 lianli_shared::sensors::SensorSource::WirelessCoolant { device_id } =>
                                     Some(lianli_shared::media::SensorSourceConfig::WirelessCoolant { device_id: device_id.clone() }),
-                                _ => None,
+                                lianli_shared::sensors::SensorSource::CpuUsage => Some(lianli_shared::media::SensorSourceConfig::CpuUsage),
+                                lianli_shared::sensors::SensorSource::MemUsage => Some(lianli_shared::media::SensorSourceConfig::MemUsage),
+                                lianli_shared::sensors::SensorSource::MemUsed => Some(lianli_shared::media::SensorSourceConfig::MemUsed),
+                                lianli_shared::sensors::SensorSource::MemFree => Some(lianli_shared::media::SensorSourceConfig::MemFree),
                             }
                         } else {
                             None

--- a/crates/lianli-gui/ui/main.slint
+++ b/crates/lianli-gui/ui/main.slint
@@ -40,6 +40,7 @@ export component MainWindow inherits Window {
     // LCD properties
     in property <[LcdEntryData]> lcd-entries: [];
     in property <[string]> lcd-device-options: [];
+    in property <[string]> lcd-sensor-options: [];
     in property <bool> has-config: false;
 
     // RGB properties
@@ -50,7 +51,7 @@ export component MainWindow inherits Window {
     in property <[FanGroupData]> fan-groups: [];
     in property <[string]> curve-names: [];
     in property <[string]> fan-speed-options: [];
-    in property <[string]> sensor-options: [];
+    in property <[string]> fan-sensor-options: [];
     in property <int> fan-update-interval: 500;
 
     // Callbacks for Rust backend
@@ -124,7 +125,7 @@ export component MainWindow inherits Window {
             if root.current-page == 1: LcdPage {
                 lcd-entries: root.lcd-entries;
                 device-options: root.lcd-device-options;
-                sensor-options: root.sensor-options;
+                sensor-options: root.lcd-sensor-options;
                 has-config: root.has-config;
                 add-lcd => { root.add-lcd(); }
                 remove-lcd(idx) => { root.remove-lcd(idx); }
@@ -138,7 +139,7 @@ export component MainWindow inherits Window {
                 fan-groups: root.fan-groups;
                 curve-names: root.curve-names;
                 speed-options: root.fan-speed-options;
-                sensor-options: root.sensor-options;
+                sensor-options: root.fan-sensor-options;
                 update-interval: root.fan-update-interval;
                 has-config: root.has-config;
                 add-curve => { root.fan-add-curve(); }

--- a/crates/lianli-gui/ui/pages/devices.slint
+++ b/crates/lianli-gui/ui/pages/devices.slint
@@ -130,7 +130,7 @@ export component DevicesPage inherits VerticalLayout {
             alignment: start;
 
             // Device grid with wrapping
-            FlexBoxLayout {
+            FlexboxLayout {
                 vertical-stretch: 0;
                 spacing-horizontal: 12px;
                 spacing-vertical: 8px;

--- a/crates/lianli-gui/ui/pages/fans.slint
+++ b/crates/lianli-gui/ui/pages/fans.slint
@@ -8,7 +8,6 @@ export { CurvePoint, CurveSegment }
 
 export struct FanCurveData {
     name: string,
-    temp-source-display: string,
     temp-source-index: int,
     temp-command: string,
     points: [CurvePoint],
@@ -71,13 +70,13 @@ component FanCurveCard inherits Card {
             ComboBox {
                 horizontal-stretch: 1;
                 model: root.sensor-options;
-                current-value: root.curve.temp-source-display;
+                current-index: root.curve.temp-source-index;
                 selected(val) => { root.set-temp-source(root.index, val); }
             }
         }
 
         // Show command editor only for custom command
-        if root.curve.temp-source-display == "Custom command": HorizontalLayout {
+        if root.curve.temp-source-index == (root.sensor-options.length - 1): HorizontalLayout {
             spacing: 8px;
             Text { text: "Command:"; font-size: 12px; color: Theme.text-secondary; vertical-alignment: center; }
             LineEdit {

--- a/crates/lianli-gui/ui/pages/lcd.slint
+++ b/crates/lianli-gui/ui/pages/lcd.slint
@@ -28,7 +28,7 @@ export struct LcdEntryData {
     // Sensor fields
     sensor-label: string,
     sensor-unit: string,
-    sensor-source-display: string,
+    sg_sensor_index: int,
     sensor-command: string,
     sensor-font-path: string,
     sensor-decimal-places: int,
@@ -231,12 +231,12 @@ component LcdConfigCard inherits Card {
                 Text { text: "Sensor Source"; font-size: 11px; color: Theme.text-secondary; }
                 ComboBox {
                     model: root.sensor-options;
-                    current-value: root.lcd.sensor-source-display;
+                    current-index: root.lcd.sg_sensor-index;
                     selected(val) => { root.update-field(root.index, "sensor_source", val); }
                 }
             }
 
-            if root.lcd.sensor-source-display == "Custom command": VerticalLayout {
+            if root.lcd.sg_sensor-index == (root.sensor-options.length - 1): VerticalLayout {
                 spacing: 4px;
                 Text { text: "Command"; font-size: 11px; color: Theme.text-secondary; }
                 LineEdit {

--- a/crates/lianli-media/src/lib.rs
+++ b/crates/lianli-media/src/lib.rs
@@ -56,7 +56,7 @@ pub fn prepare_media_asset(
     default_fps: f32,
     screen: &ScreenInfo,
     h264: bool,
-    all_sensors: &Vec<SensorInfo>,
+    all_sensors: &[SensorInfo],
 ) -> Result<MediaAssetKind, MediaError> {
     match cfg.media_type {
         MediaType::Image => {

--- a/crates/lianli-media/src/lib.rs
+++ b/crates/lianli-media/src/lib.rs
@@ -4,6 +4,7 @@ pub mod sensor;
 pub mod video;
 
 pub use common::MediaError;
+use lianli_shared::sensors::SensorInfo;
 pub use sensor::SensorAsset;
 
 use lianli_shared::config::{ConfigKey, LcdConfig};
@@ -55,6 +56,7 @@ pub fn prepare_media_asset(
     default_fps: f32,
     screen: &ScreenInfo,
     h264: bool,
+    all_sensors: &Vec<SensorInfo>,
 ) -> Result<MediaAssetKind, MediaError> {
     match cfg.media_type {
         MediaType::Image => {
@@ -104,7 +106,7 @@ pub fn prepare_media_asset(
         }
         MediaType::Sensor => {
             let descriptor = cfg.sensor.as_ref().ok_or(MediaError::InvalidConfig("sensor entry requires a 'sensor' field".into()))?;
-            let asset = SensorAsset::new(descriptor, cfg.orientation, screen)?;
+            let asset = SensorAsset::new(descriptor, cfg.orientation, screen,all_sensors)?;
             Ok(MediaAssetKind::Sensor { asset })
         }
     }

--- a/crates/lianli-media/src/lib.rs
+++ b/crates/lianli-media/src/lib.rs
@@ -106,7 +106,7 @@ pub fn prepare_media_asset(
         }
         MediaType::Sensor => {
             let descriptor = cfg.sensor.as_ref().ok_or(MediaError::InvalidConfig("sensor entry requires a 'sensor' field".into()))?;
-            let asset = SensorAsset::new(descriptor, cfg.orientation, screen,all_sensors)?;
+            let asset = SensorAsset::new(descriptor, cfg.orientation, screen, all_sensors)?;
             Ok(MediaAssetKind::Sensor { asset })
         }
     }

--- a/crates/lianli-media/src/sensor.rs
+++ b/crates/lianli-media/src/sensor.rs
@@ -51,7 +51,7 @@ impl SensorAsset {
         descriptor: &SensorDescriptor,
         orientation: f32,
         screen: &ScreenInfo,
-        sensors: &Vec<SensorInfo>,
+        sensors: &[SensorInfo],
     ) -> Result<Arc<Self>, MediaError> {
         let mut ranges = descriptor.gauge_ranges.clone();
         if ranges.is_empty() {
@@ -83,9 +83,9 @@ impl SensorAsset {
             | SensorSourceConfig::NvidiaGpu { .. }
             | SensorSourceConfig::WirelessCoolant { .. } => {
                 let sensor_source = descriptor.source.to_sensor_source();
-                let sensor_info = sensors.iter().find(|s| s.source==sensor_source);
-                let divider =sensor_info.map_or(1, |s| s.divider);
-                match lianli_shared::sensors::resolve_sensor(&sensor_source,divider) {
+                let sensor_info = sensors.iter().find(|s| s.source == sensor_source);
+                let divider = sensor_info.map_or(1, |s| s.divider);
+                match lianli_shared::sensors::resolve_sensor(&sensor_source, divider) {
                     Some(resolved) => SensorSource::Resolved(resolved),
                     None => return Err(MediaError::Sensor("sensor not found on system".into())),
                 }

--- a/crates/lianli-media/src/sensor.rs
+++ b/crates/lianli-media/src/sensor.rs
@@ -2,6 +2,7 @@ use super::common::{apply_orientation, encode_jpeg, render_dimensions, MediaErro
 use lianli_shared::media::{SensorDescriptor, SensorRange, SensorSourceConfig};
 use lianli_shared::screen::ScreenInfo;
 use image::{ImageBuffer, Rgb, RgbImage};
+use lianli_shared::sensors::SensorInfo;
 use rusttype::{point, Font, Scale};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -50,6 +51,7 @@ impl SensorAsset {
         descriptor: &SensorDescriptor,
         orientation: f32,
         screen: &ScreenInfo,
+        sensors: &Vec<SensorInfo>,
     ) -> Result<Arc<Self>, MediaError> {
         let mut ranges = descriptor.gauge_ranges.clone();
         if ranges.is_empty() {
@@ -80,8 +82,10 @@ impl SensorAsset {
             | SensorSourceConfig::Hwmon { .. }
             | SensorSourceConfig::NvidiaGpu { .. }
             | SensorSourceConfig::WirelessCoolant { .. } => {
-                let temp_source = descriptor.source.to_temp_source();
-                match lianli_shared::sensors::resolve_sensor(&temp_source) {
+                let sensor_source = descriptor.source.to_sensor_source();
+                let sensor_info = sensors.iter().find(|s| s.source==sensor_source);
+                let divider =sensor_info.map_or(1, |s| s.divider);
+                match lianli_shared::sensors::resolve_sensor(&sensor_source,divider) {
                     Some(resolved) => SensorSource::Resolved(resolved),
                     None => return Err(MediaError::Sensor("sensor not found on system".into())),
                 }
@@ -245,7 +249,7 @@ impl SensorAsset {
         match &self.source {
             SensorSource::Constant(value) => Ok(*value),
             SensorSource::Resolved(resolved) => {
-                lianli_shared::sensors::read_sensor_temp(resolved)
+                lianli_shared::sensors::read_sensor_value(resolved)
                     .map_err(|e| MediaError::Sensor(e.to_string()))
             }
         }
@@ -467,7 +471,7 @@ fn draw_text_center_bitmap(
     }
     let glyph_width = 5 * scale;
     let spacing = scale;
-    let total_width = glyphs.len() as u32 * (glyph_width + spacing) - spacing;
+    let total_width = (glyphs.len() as u32 * (glyph_width + spacing) - spacing).min(width); // total_width must not be greater than width
     let start_x = ((width - total_width) / 2) as i32;
     let start_y = ((height as i32) / 2) + offset_y - ((7 * scale) as i32 / 2);
 

--- a/crates/lianli-media/src/sensor.rs
+++ b/crates/lianli-media/src/sensor.rs
@@ -81,7 +81,11 @@ impl SensorAsset {
             SensorSourceConfig::Command { .. }
             | SensorSourceConfig::Hwmon { .. }
             | SensorSourceConfig::NvidiaGpu { .. }
-            | SensorSourceConfig::WirelessCoolant { .. } => {
+            | SensorSourceConfig::WirelessCoolant { .. }
+            | SensorSourceConfig::CpuUsage
+            | SensorSourceConfig::MemUsage
+            | SensorSourceConfig::MemUsed
+            | SensorSourceConfig::MemFree => {
                 let sensor_source = descriptor.source.to_sensor_source();
                 let sensor_info = sensors.iter().find(|s| s.source == sensor_source);
                 let divider = sensor_info.map_or(1, |s| s.divider);

--- a/crates/lianli-shared/src/fan.rs
+++ b/crates/lianli-shared/src/fan.rs
@@ -1,26 +1,32 @@
-use crate::sensors::TempSource;
+use crate::sensors::SensorSource;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct FanCurve {
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub temp_source: Option<TempSource>,
+    pub temp_source: Option<SensorSource>,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub temp_command: String,
     pub curve: Vec<(f32, f32)>,
 }
 
 impl FanCurve {
-    pub fn effective_source(&self) -> TempSource {
+    pub fn effective_source(&self) -> SensorSource {
         if let Some(ref source) = self.temp_source {
-            source.clone()
+            if matches!(source, SensorSource::Command { .. }) {
+                SensorSource::Command {
+                    cmd: self.temp_command.clone(),
+                }
+            } else {
+                source.clone()
+            }
         } else if !self.temp_command.is_empty() {
-            TempSource::Command {
+            SensorSource::Command {
                 cmd: self.temp_command.clone(),
             }
         } else {
-            TempSource::Command {
+            SensorSource::Command {
                 cmd: "cat /sys/class/thermal/thermal_zone0/temp | awk '{print $1/1000}'".into(),
             }
         }

--- a/crates/lianli-shared/src/lib.rs
+++ b/crates/lianli-shared/src/lib.rs
@@ -6,3 +6,4 @@ pub mod media;
 pub mod rgb;
 pub mod screen;
 pub mod sensors;
+pub mod systeminfo;

--- a/crates/lianli-shared/src/media.rs
+++ b/crates/lianli-shared/src/media.rs
@@ -31,6 +31,14 @@ pub enum SensorSourceConfig {
     WirelessCoolant {
         device_id: String,
     },
+    #[serde(rename = "cpu_usage")]
+    CpuUsage,
+    #[serde(rename = "mem_usage")]
+    MemUsage,
+    #[serde(rename = "mem_used")]
+    MemUsed,
+    #[serde(rename = "mem_free")]
+    MemFree,
 }
 
 impl SensorSourceConfig {
@@ -55,6 +63,10 @@ impl SensorSourceConfig {
             Self::WirelessCoolant { device_id } => crate::sensors::SensorSource::WirelessCoolant {
                 device_id: device_id.clone(),
             },
+            Self::CpuUsage => crate::sensors::SensorSource::CpuUsage,
+            Self::MemUsage => crate::sensors::SensorSource::MemUsage,
+            Self::MemUsed => crate::sensors::SensorSource::MemUsed,
+            Self::MemFree => crate::sensors::SensorSource::MemFree,
         }
     }
 }
@@ -134,6 +146,10 @@ impl SensorDescriptor {
                     anyhow::bail!("wireless coolant device_id must not be empty");
                 }
             }
+            SensorSourceConfig::CpuUsage
+            | SensorSourceConfig::MemUsage
+            | SensorSourceConfig::MemUsed
+            | SensorSourceConfig::MemFree => {}
         }
 
         if self.update_interval_ms == 0 {

--- a/crates/lianli-shared/src/media.rs
+++ b/crates/lianli-shared/src/media.rs
@@ -19,8 +19,8 @@ pub enum SensorSourceConfig {
     Hwmon {
         name: String,
         label: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        device_path: Option<String>,
+        #[serde(default)]
+        device_path: String,
     },
     #[serde(rename = "nvidia_gpu")]
     NvidiaGpu {
@@ -34,25 +34,25 @@ pub enum SensorSourceConfig {
 }
 
 impl SensorSourceConfig {
-    pub fn to_temp_source(&self) -> crate::sensors::TempSource {
+    pub fn to_sensor_source(&self) -> crate::sensors::SensorSource {
         match self {
-            Self::Constant { value } => crate::sensors::TempSource::Command {
+            Self::Constant { value } => crate::sensors::SensorSource::Command {
                 cmd: format!("echo {value}"),
             },
-            Self::Command { cmd } => crate::sensors::TempSource::Command { cmd: cmd.clone() },
+            Self::Command { cmd } => crate::sensors::SensorSource::Command { cmd: cmd.clone() },
             Self::Hwmon {
                 name,
                 label,
                 device_path,
-            } => crate::sensors::TempSource::Hwmon {
+            } => crate::sensors::SensorSource::Hwmon {
                 name: name.clone(),
                 label: label.clone(),
                 device_path: device_path.clone(),
             },
-            Self::NvidiaGpu { gpu_index } => crate::sensors::TempSource::NvidiaGpu {
+            Self::NvidiaGpu { gpu_index } => crate::sensors::SensorSource::NvidiaGpu {
                 gpu_index: *gpu_index,
             },
-            Self::WirelessCoolant { device_id } => crate::sensors::TempSource::WirelessCoolant {
+            Self::WirelessCoolant { device_id } => crate::sensors::SensorSource::WirelessCoolant {
                 device_id: device_id.clone(),
             },
         }

--- a/crates/lianli-shared/src/sensors.rs
+++ b/crates/lianli-shared/src/sensors.rs
@@ -110,8 +110,6 @@ pub fn enumerate_sensors() -> Vec<SensorInfo> {
     
     let mut mem_idx: usize = 0;
     let mut gfx_idx: usize = 0;
-    let mut display_name: String;
-
     let gpu_names = get_amd_gpu_names();
 
     sensors.push(SensorInfo {

--- a/crates/lianli-shared/src/sensors.rs
+++ b/crates/lianli-shared/src/sensors.rs
@@ -536,15 +536,16 @@ pub fn resolve_sensor(source: &SensorSource, divider: usize) -> Option<ResolvedS
                         let fname = file.file_name().to_string_lossy().to_string();
                         if fname.ends_with("_input") {
                             let prefix = fname.strip_suffix("_input").unwrap();
-                            // Match by prefix (new format) or by label file content (old format)
                             if prefix == label {
                                 return Some(ResolvedSensor::SysfsFile { path: file.path(), divider });
                             }
+                            // Old config format: label is human-readable (e.g. "Package id 0")
                             let file_label = std::fs::read_to_string(path.join(format!("{prefix}_label")))
                                 .map(|l| l.trim().to_string())
                                 .unwrap_or_default();
                             if file_label == *label {
-                                return Some(ResolvedSensor::SysfsFile { path: file.path(), divider });
+                                let actual_divider = get_unit(prefix).1;
+                                return Some(ResolvedSensor::SysfsFile { path: file.path(), divider: actual_divider });
                             }
                         }
                     }

--- a/crates/lianli-shared/src/sensors.rs
+++ b/crates/lianli-shared/src/sensors.rs
@@ -680,7 +680,9 @@ pub fn get_mem_usage(content: &str) -> f32 {
     let mem_total = extract_mem_value(content, "MemTotal:");
     let mem_avail = extract_mem_value(content, "MemAvailable:");
     if let (Some(total), Some(avail)) = (mem_total, mem_avail) {
-        return 100.0 - avail * 100.0 / total;
+        if total > 0.0 {
+            return 100.0 - avail * 100.0 / total;
+        }
     }
     0.0
 }

--- a/crates/lianli-shared/src/sensors.rs
+++ b/crates/lianli-shared/src/sensors.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::collections::HashMap;
 
-use crate::systeminfo::{SysSensor};
+use crate::systeminfo::SysSensor;
 
 /// SensorSource stores the information of a sensor in a way so that we can store it in a file, reboot, reload the file and are still able to find the sensor.
 /// In order to actually read the sensor value the implemented way is to create a ResolvedSensor from SensorSource and use that.
@@ -29,19 +29,21 @@ pub enum SensorSource {
     },
 }
 
-/// Defines the name of a sensor in human readable format. 
-
-#[derive(Debug,Clone,Serialize,Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SensorName {
-    // Name of device in human readable form. A device can have several sensors attached to it
     device_name: String,
-    // Name of the sensor in human readable form. The combination of device_name/sensor_name is unique (well, it should be...programmer is responsible for that!)
     sensor_name: String,
 }
 
-#[derive(Debug,Clone,Serialize,Deserialize,PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum Unit {
-    C /*°Celsius*/, RPM /* Rounds per Minute, i.e. fan speed */, V /* Voltage in mV */, FREQ /* Frequence in Mhz */, PERCENT /* Percent value from 0% to 100% */, SIZE /* Mem Size in GB */, WO /* Without any unit */
+    C,
+    RPM,
+    V,
+    FREQ,
+    PERCENT,
+    SIZE,
+    WO,
 }
 
 impl std::fmt::Display for Unit {
@@ -53,7 +55,7 @@ impl std::fmt::Display for Unit {
             Unit::FREQ => "Mhz",
             Unit::SIZE => "MB",
             Unit::PERCENT => "%",
-            Unit::WO => "", // element without any unit...each sensor which is not recognized will receive this "unit"
+            Unit::WO => "",
         };
         write!(f, "{}", symbol)
     }
@@ -72,15 +74,13 @@ pub struct SensorInfo {
 
 impl SensorInfo {
     pub fn get_display_name(&self) -> String {
-        // Logik: Nutze display_name, falls vorhanden, 
-        // ansonsten sensor_name, ansonsten einen Standardwert.
         self.display_name
-            .clone() // Da wir einen String zurückgeben wollen
+            .clone()
             .unwrap_or_else(|| {
                 self.sensor_name
                     .as_ref()
-                    .map(|s| format!("{}: {} in {}", s.device_name, s.sensor_name,self.unit)) // Annahme: SensorName ist ein Enum/Struct mit ToString
-                    .unwrap_or_else(|| "Unbekannter Sensor".to_string())
+                    .map(|s| format!("{}: {} in {}", s.device_name, s.sensor_name, self.unit))
+                    .unwrap_or_else(|| "Unknown Sensor".to_string())
             })
     }
 }
@@ -105,8 +105,8 @@ pub enum ResolvedSensor {
 pub fn enumerate_sensors() -> Vec<SensorInfo> {
     let mut sensors = Vec::new();
     
-    let mut mem_idx:usize = 0; // Index in order to enumerate our different DRAM modules
-    let mut gfx_idx:usize = 0; // Index in order to enumerate our different GPU's
+    let mut mem_idx: usize = 0;
+    let mut gfx_idx: usize = 0;
     let mut display_name: String;
 
     let gpu_names = get_amd_gpu_names();
@@ -119,7 +119,7 @@ pub fn enumerate_sensors() -> Vec<SensorInfo> {
             label: "Usage".to_string(),
             device_path: "direct:cpu_usage".to_string(),
         },
-        sensor_name: Some(SensorName{device_name:"CPU".to_string(),sensor_name:"Usage".to_string()}),
+        sensor_name: Some(SensorName { device_name: "CPU".to_string(), sensor_name: "Usage".to_string() }),
         display_name: None,
         divider: 100,
         unit: Unit::PERCENT,
@@ -133,7 +133,7 @@ pub fn enumerate_sensors() -> Vec<SensorInfo> {
             label: "Usage".to_string(),
             device_path: "direct:mem_usage".to_string(),
         },
-        sensor_name: Some(SensorName{device_name:"RAM".to_string(),sensor_name:"Usage".to_string()}),
+        sensor_name: Some(SensorName { device_name: "RAM".to_string(), sensor_name:"Usage".to_string() }),
         display_name: None,
         divider: 1,
         unit: Unit::PERCENT,
@@ -147,9 +147,9 @@ pub fn enumerate_sensors() -> Vec<SensorInfo> {
             label: "Used".to_string(),
             device_path: "direct:mem_used".to_string(),
         },
-        sensor_name: Some(SensorName{device_name:"RAM".to_string(),sensor_name:"Used".to_string()}),
+        sensor_name: Some(SensorName { device_name: "RAM".to_string(), sensor_name:"Used".to_string() }),
         display_name: None,
-        divider: 1024*1024,
+        divider: 1024 * 1024,
         unit: Unit::SIZE,
         current_value: Some(0.0),
     });
@@ -161,9 +161,9 @@ pub fn enumerate_sensors() -> Vec<SensorInfo> {
             label: "Free".to_string(),
             device_path: "direct:mem_free".to_string(),
         },
-        sensor_name: Some(SensorName{device_name:"RAM".to_string(),sensor_name:"Free".to_string()}),
+        sensor_name: Some(SensorName { device_name: "RAM".to_string(), sensor_name:"Free".to_string() }),
         display_name: None,
-        divider: 1024*1024,
+        divider: 1024 * 1024,
         unit: Unit::SIZE,
         current_value: Some(0.0),
     });
@@ -193,7 +193,7 @@ pub fn enumerate_sensors() -> Vec<SensorInfo> {
             let pci_id = get_pci_id_from_path(path.clone());
             let pci_id_stripped = pci_id.strip_prefix("0000:").unwrap_or(&pci_id).to_string();
 
-            (display_name,mem_idx,gfx_idx) = get_display_name(&path, &pci_id_stripped, &gpu_names,mem_idx,gfx_idx);
+            (display_name, mem_idx, gfx_idx) = get_display_name(&path, &pci_id_stripped, &gpu_names, mem_idx, gfx_idx);
 
             if display_name == "ignore" {
                 // This element is to ignore (for example ACPI thermal zone is a quite unreliable temperature sensor, so omitting it is recommended)
@@ -206,14 +206,7 @@ pub fn enumerate_sensors() -> Vec<SensorInfo> {
                 .ok()
                 .and_then(|p| p.file_name().map(|f| f.to_string_lossy().to_string()));
 
-            // Find all *_input files
             if let Ok(files) = std::fs::read_dir(&path) {
-                if let Some(busy_percent_path) = Some(entry.path().join("device").join("mem_busy_percent")) {
-                    if busy_percent_path.exists() {
-                        // File contains VRAM used for AMD graphics cards
-                    }
-
-                }
                 let mut device_sensors: Vec<SensorInfo> = Vec::new();
 
                 for file in files.flatten() {
@@ -225,10 +218,10 @@ pub fn enumerate_sensors() -> Vec<SensorInfo> {
                         let label = std::fs::read_to_string(path.join(format!("{}_label", prefix)))
                             .map(|s| s.trim().to_string())
                             .unwrap_or_else(|_| "".to_string());
-                        let display_label = get_label_name(&prefix.to_string(),&label);
-                        let (unit,divider) = get_unit(prefix);
+                        let display_label = get_label_name(prefix, &label);
+                        let (unit, divider) = get_unit(prefix);
                         let value = read_sysfs_file(&file.path());
-                        let sensor_name = Some(SensorName{device_name:display_name.clone(),sensor_name:display_label});
+                        let sensor_name = Some(SensorName { device_name: display_name.clone(), sensor_name: display_label });
                         let device_path = if let Some(dev) = &device_path {
                             if dev.starts_with("DEADBEEF") { // virtual devices (for example my motherboard from Gigabyte links to "DEADBEEF-2001-0000-00A0-C90629100000")
                                 pci_id.to_string()
@@ -243,12 +236,12 @@ pub fn enumerate_sensors() -> Vec<SensorInfo> {
                             source: SensorSource::Hwmon {
                                 name: name.clone(),
                                 label: prefix.to_string(),
-                                device_path: device_path,
+                                device_path,
                             },
-                            sensor_name: sensor_name,
+                            sensor_name,
                             display_name: None,
-                            divider: divider,
-                            unit: unit,
+                            divider,
+                            unit,
                             current_value: value,
                         });
                     }
@@ -334,20 +327,17 @@ pub fn get_pci_id_from_path(hwmon_path: PathBuf) -> String {
 /// retrieves human readable description of a metric and returns default values for this metric
 /// Returns desc, unit, divider
 
-fn get_unit(
-    prefix: &str,
-) -> (Unit,usize) {
-    // format_metrics_name translates from e.g. k10temp to CPU, and from Tctl to Control temperature of Tccd1 to Temperature of Die 1
+fn get_unit(prefix: &str) -> (Unit, usize) {
     if prefix.starts_with("temp") {
-        (Unit::C,1000)
+        (Unit::C, 1000)
     } else if prefix.starts_with("fan") {
-        (Unit::RPM,1)
+        (Unit::RPM, 1)
     } else if prefix.starts_with("in") {
-        (Unit::V,1)
+        (Unit::V, 1)
     } else if prefix.starts_with("freq") {
-        (Unit::FREQ,1000*1000)
+        (Unit::FREQ, 1000 * 1000)
     } else {
-        (Unit::WO,1)
+        (Unit::WO, 1)
     }
 }
 
@@ -355,7 +345,7 @@ fn get_unit(
 /// prefix is the name of the sensor file (without _input), and label is the content of the <prefix>_label file
 /// Note that label can be empty!
 
-pub fn get_label_name(prefix: &String, label: &String) -> String {
+pub fn get_label_name(prefix: &str, label: &str) -> String {
     let lower_label = label.to_lowercase();
     let lower_prefix = prefix.to_lowercase();
     // Dynamic replacements for CCDs and Cores
@@ -384,27 +374,24 @@ pub fn get_label_name(prefix: &String, label: &String) -> String {
     } else if let Some(idx) = lower_prefix.find("fan") {
         format!("Fan {}", &lower_prefix[idx + 3..])
     } else if label.is_empty() {
-        prefix.clone() // use prefix
+        prefix.to_string()
     } else {
-        label.clone() // use label
+        label.to_string()
     };
 
-    return new_label;
+    new_label
 }
 
 
 fn get_amd_gpu_names() -> HashMap<String, String> {
     let mut gpus = HashMap::new();
 
-    // 1. call lspci
-    let output = Command::new("lspci")
-        .output()
-        .expect("Error: lspci not found");
-
-    // 2. convert output to string
+    let output = match Command::new("lspci").output() {
+        Ok(o) => o,
+        Err(_) => return gpus,
+    };
     let stdout = String::from_utf8_lossy(&output.stdout);
 
-    // 3. parse line by line (replacement for grep command)
     for line in stdout.lines() {
         let line_lower = line.to_lowercase();
 
@@ -425,7 +412,7 @@ fn get_amd_gpu_names() -> HashMap<String, String> {
         }
     }
 
-    return clean_common_prefixes(gpus);
+    clean_common_prefixes(gpus)
 }
 
 
@@ -433,7 +420,7 @@ fn get_amd_gpu_names() -> HashMap<String, String> {
 // For example, if all values contain the prefix "VGA compatible controller: <blah blah>", then the prefix "VGA compatible controller: " will be removed
 
 fn clean_common_prefixes(mut gpus: HashMap<String, String>) -> HashMap<String, String> {
-    if gpus.len()<=1 {
+    if gpus.len() <= 1 {
         return gpus;
     }
 
@@ -469,17 +456,17 @@ fn clean_common_prefixes(mut gpus: HashMap<String, String>) -> HashMap<String, S
 
 pub fn get_display_name(
     hwmon_path: &Path,
-    pci_id_stripped: &String,
+    pci_id_stripped: &str,
     gpu_names: &HashMap<String, String>,
     mem_idx: usize,
     gfx_idx: usize,
-) -> (String,usize,usize) {
+) -> (String, usize, usize) {
     // First of all, check for file device/model and return that in case it exists and contains something
     // This will display for example the type and name of the nvme-SSD
     let model_path = hwmon_path.join("device").join("model");
 
     if let Ok(model_name) = std::fs::read_to_string(model_path) {
-        return (model_name.trim().to_string(),mem_idx,gfx_idx);
+        return (model_name.trim().to_string(), mem_idx, gfx_idx);
     }
 
     // Fallback: Read the normal 'name' file
@@ -488,49 +475,49 @@ pub fn get_display_name(
         let name = generic_name.trim();
         // If the name is only "nvme", then make it a little prettier
         if name == "nvme" {
-            return ("NVMe Storage Device".to_string(),mem_idx,gfx_idx);
+            return ("NVMe Storage Device".to_string(), mem_idx, gfx_idx);
         }
         // AMD processors have k10temp, Intel have coretemp
         if name == "k10temp" || name == "coretemp" {
-            return ("CPU".to_string(),mem_idx,gfx_idx);
+            return ("CPU".to_string(), mem_idx, gfx_idx);
         }
         // AMD gpus (internal or external) are named amdgpu
         if name == "amdgpu" {
-            if gfx_idx>0 {
+            if gfx_idx > 0 {
                 // The first graphics card is the main card. If there is a second graphics card, then it's the internal graphics chip, which is of no interest as not used.
                 // Well, if somebody has more than one PCI graphics card, then we won't display the second one, I know, but in most cases the second one is just the internal graphics chip.
-                return ("ignore".to_string(),mem_idx,gfx_idx);
+                return ("ignore".to_string(), mem_idx, gfx_idx);
             }
             if let Some(name) = gpu_names.get(pci_id_stripped) {
-                return (name.clone(),mem_idx,gfx_idx+1);
+                return (name.clone(), mem_idx, gfx_idx + 1);
             }
         }
         // NVidia gpus either don't appear at all, or appear as nouveau (if that driver is used)
         if name == "nouveau" {
-            return ("NVidia GPU".to_string(),mem_idx,gfx_idx+1);
+            return ("NVidia GPU".to_string(), mem_idx, gfx_idx + 1);
         }
         let common_drivers = ["nct", "it8", "f71", "gigabyte_wmi", "w83"];
         if common_drivers.iter().any(|&d| name.starts_with(d)) {
-            return ("Motherboard".to_string(),mem_idx,gfx_idx);
+            return ("Motherboard".to_string(), mem_idx, gfx_idx);
         }
         if name.starts_with("spd") {
-            return (format!("DDR5 RAM Module {}",mem_idx+1),mem_idx+1,gfx_idx);
+            return (format!("DDR5 RAM Module {}",mem_idx+1), mem_idx + 1, gfx_idx);
         }
         if name.starts_with("ee1004") {
-            return (format!("DDR4 RAM Module {}",mem_idx+1),mem_idx+1,gfx_idx);
+            return (format!("DDR4 RAM Module {}",mem_idx+1), mem_idx + 1, gfx_idx);
         }
         if name.starts_with("jc42") {
-            return (format!("DDR3/ECC RAM Module {}",mem_idx+1),mem_idx+1,gfx_idx);
+            return (format!("DDR3/ECC RAM Module {}",mem_idx+1), mem_idx + 1, gfx_idx);
         }
         if name == "acpitz" {
             // Notoriously inaccurate sensor: ACPI Thermal Zone, best to just ignore it...
-            return ("ignore".to_string(),mem_idx,gfx_idx);
+            return ("ignore".to_string(), mem_idx, gfx_idx);
         }
 
-        return (name.to_string(),mem_idx,gfx_idx);
+        (name.to_string(), mem_idx, gfx_idx)
+    } else {
+        ("Unknown Device".to_string(), mem_idx, gfx_idx)
     }
-
-    ("Unknown Device".to_string(),mem_idx,gfx_idx)
 }
 
 pub fn resolve_sensor(source: &SensorSource, divider: usize) -> Option<ResolvedSensor> {
@@ -540,14 +527,14 @@ pub fn resolve_sensor(source: &SensorSource, divider: usize) -> Option<ResolvedS
             label,
             device_path,
         } => {
-            if device_path=="direct:cpu_usage" {
-                return Some(ResolvedSensor::SysfsFile{path: Path::new("/sys/class/hwmon").to_path_buf(),device_path: device_path.clone(), divider: divider});
+            if device_path == "direct:cpu_usage" {
+                return Some(ResolvedSensor::SysfsFile { path: Path::new("/sys/class/hwmon").to_path_buf(), device_path: device_path.clone(), divider });
             } else if device_path=="direct:mem_usage" {
-                return Some(ResolvedSensor::SysfsFile{path: Path::new("/proc/meminfo").to_path_buf(),device_path: device_path.clone(), divider: divider});
+                return Some(ResolvedSensor::SysfsFile { path: Path::new("/proc/meminfo").to_path_buf(), device_path: device_path.clone(), divider });
             } else if device_path=="direct:mem_used" {
-                return Some(ResolvedSensor::SysfsFile{path: Path::new("/proc/meminfo").to_path_buf(),device_path: device_path.clone(), divider: divider});
+                return Some(ResolvedSensor::SysfsFile { path: Path::new("/proc/meminfo").to_path_buf(), device_path: device_path.clone(), divider });
             } else if device_path=="direct:mem_free" {
-                return Some(ResolvedSensor::SysfsFile{path: Path::new("/proc/meminfo").to_path_buf(),device_path: device_path.clone(), divider: divider});
+                return Some(ResolvedSensor::SysfsFile { path: Path::new("/proc/meminfo").to_path_buf(), device_path: device_path.clone(), divider });
             }
             let hwmon_dir = Path::new("/sys/class/hwmon");
             let entries = std::fs::read_dir(hwmon_dir).ok()?;
@@ -569,10 +556,9 @@ pub fn resolve_sensor(source: &SensorSource, divider: usize) -> Option<ResolvedS
                     get_pci_id_from_path(path.clone())
                 };
 
-                if curr_device_path != *device_path  {
+                if curr_device_path != *device_path {
                     continue;
                 }
-                
 
                 // Search *_input files for matching label
                 if let Ok(files) = std::fs::read_dir(&path) {
@@ -580,8 +566,8 @@ pub fn resolve_sensor(source: &SensorSource, divider: usize) -> Option<ResolvedS
                         let fname = file.file_name().to_string_lossy().to_string();
                         if fname.ends_with("_input") {
                             let prefix = fname.strip_suffix("_input").unwrap();
-                            if &prefix == label {
-                                return Some(ResolvedSensor::SysfsFile{path: file.path(),device_path: device_path.clone(),divider: divider});
+                            if prefix == label {
+                                return Some(ResolvedSensor::SysfsFile { path: file.path(), device_path: device_path.clone(), divider });
                             }
                         }
                     }
@@ -604,24 +590,24 @@ pub fn resolve_sensor(source: &SensorSource, divider: usize) -> Option<ResolvedS
 
 pub fn read_sensor_value(resolved: &ResolvedSensor) -> anyhow::Result<f32> {
     match resolved {
-        ResolvedSensor::SysfsFile {path, device_path, divider} => {
-            if device_path=="direct:cpu_usage" {
+        ResolvedSensor::SysfsFile { path, device_path, divider } => {
+            if device_path == "direct:cpu_usage" {
                 let ret = SysSensor::get_cpu_usage();
-                return Ok((ret as f32)/(*divider as f32));
+                return Ok((ret as f32) / (*divider as f32));
             }
             let content = std::fs::read_to_string(path)
                 .map_err(|e| anyhow::anyhow!("reading {}: {e}", path.display()))?;
 
-            if device_path=="direct:mem_usage" {
+            if device_path == "direct:mem_usage" {
                 return Ok(get_mem_usage(&content));
             }
-            if device_path=="direct:mem_used" {
+            if device_path == "direct:mem_used" {
                 let total = extract_mem_value(&content, "MemTotal:").unwrap_or(0.0);
                 let avail = extract_mem_value(&content, "MemAvailable:").unwrap_or(0.0);
-                return Ok((total-avail)/(*divider as f32));
+                return Ok((total - avail) / (*divider as f32));
             }
-            if device_path=="direct:mem_free" {
-                return Ok(extract_mem_value(&content, "MemAvailable:").unwrap_or(0.0)/(*divider as f32));
+            if device_path == "direct:mem_free" {
+                return Ok(extract_mem_value(&content, "MemAvailable:").unwrap_or(0.0) / (*divider as f32));
             }
             let raw_value: f32 = content
                 .trim()
@@ -703,20 +689,11 @@ fn read_sysfs_file(path: &Path) -> Option<f32> {
     Some(value)
 }
 
-pub fn get_mem_usage(content: &String) -> f32 {
-    // convert into string, then extract the data. Contents is as follows (/proc/meminfo)
-    /*
-    MemTotal:       31893084 kB
-    MemFree:        12764544 kB
-    MemAvailable:   26270984 kB
-    Buffers:          ...
-        */
+pub fn get_mem_usage(content: &str) -> f32 {
     let mem_total = extract_mem_value(content, "MemTotal:");
-    let mem_free = extract_mem_value(content, "MemAvailable:");
-    if let Some(total) = mem_total {
-        if let Some(free) = mem_free {
-            return 100.0-free * 100.0 / total;
-        }
+    let mem_avail = extract_mem_value(content, "MemAvailable:");
+    if let (Some(total), Some(avail)) = (mem_total, mem_avail) {
+        return 100.0 - avail * 100.0 / total;
     }
     0.0
 }

--- a/crates/lianli-shared/src/sensors.rs
+++ b/crates/lianli-shared/src/sensors.rs
@@ -27,6 +27,10 @@ pub enum SensorSource {
     WirelessCoolant {
         device_id: String,
     },
+    CpuUsage,
+    MemUsage,
+    MemUsed,
+    MemFree,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -91,15 +95,14 @@ impl SensorInfo {
 
 #[derive(Debug, Clone)]
 pub enum ResolvedSensor {
-    SysfsFile { 
-        path: PathBuf, 
-        device_path: String, // from SensorSource, used in order to define what to read from the sysfsfile: basic hwmon entries are easy, just read the file, it contains a number. But the file /proc/meminfo contains more than just a number
+    SysfsFile {
+        path: PathBuf,
         divider: usize,
     },
     NvidiaGpu(u32),
     ShellCommand(String),
-    /// Runtime file written by daemon, contains plain °C value (not millidegrees).
     RuntimeFile(PathBuf),
+    Virtual { source: SensorSource, divider: usize },
 }
 
 pub fn enumerate_sensors() -> Vec<SensorInfo> {
@@ -111,58 +114,34 @@ pub fn enumerate_sensors() -> Vec<SensorInfo> {
 
     let gpu_names = get_amd_gpu_names();
 
-    // First of all, add some default sensors:
-    // CPU Usage
     sensors.push(SensorInfo {
-        source: SensorSource::Hwmon {
-            name: "CPU".to_string(),
-            label: "Usage".to_string(),
-            device_path: "direct:cpu_usage".to_string(),
-        },
-        sensor_name: Some(SensorName { device_name: "CPU".to_string(), sensor_name: "Usage".to_string() }),
-        display_name: None,
+        source: SensorSource::CpuUsage,
+        sensor_name: None,
+        display_name: Some("CPU: Usage".to_string()),
         divider: 100,
         unit: Unit::PERCENT,
         current_value: Some(0.0),
     });
-
-    // RAM Usage in percent
     sensors.push(SensorInfo {
-        source: SensorSource::Hwmon {
-            name: "RAM".to_string(),
-            label: "Usage".to_string(),
-            device_path: "direct:mem_usage".to_string(),
-        },
-        sensor_name: Some(SensorName { device_name: "RAM".to_string(), sensor_name:"Usage".to_string() }),
-        display_name: None,
+        source: SensorSource::MemUsage,
+        sensor_name: None,
+        display_name: Some("RAM: Usage".to_string()),
         divider: 1,
         unit: Unit::PERCENT,
         current_value: Some(0.0),
     });
-
-    // RAM Used in MB
     sensors.push(SensorInfo {
-        source: SensorSource::Hwmon {
-            name: "RAM".to_string(),
-            label: "Used".to_string(),
-            device_path: "direct:mem_used".to_string(),
-        },
-        sensor_name: Some(SensorName { device_name: "RAM".to_string(), sensor_name:"Used".to_string() }),
-        display_name: None,
+        source: SensorSource::MemUsed,
+        sensor_name: None,
+        display_name: Some("RAM: Used".to_string()),
         divider: 1024 * 1024,
         unit: Unit::SIZE,
         current_value: Some(0.0),
     });
-
-    // RAM Free in MB
     sensors.push(SensorInfo {
-        source: SensorSource::Hwmon {
-            name: "RAM".to_string(),
-            label: "Free".to_string(),
-            device_path: "direct:mem_free".to_string(),
-        },
-        sensor_name: Some(SensorName { device_name: "RAM".to_string(), sensor_name:"Free".to_string() }),
-        display_name: None,
+        source: SensorSource::MemFree,
+        sensor_name: None,
+        display_name: Some("RAM: Free".to_string()),
         divider: 1024 * 1024,
         unit: Unit::SIZE,
         current_value: Some(0.0),
@@ -193,13 +172,13 @@ pub fn enumerate_sensors() -> Vec<SensorInfo> {
             let pci_id = get_pci_id_from_path(path.clone());
             let pci_id_stripped = pci_id.strip_prefix("0000:").unwrap_or(&pci_id).to_string();
 
-            (display_name, mem_idx, gfx_idx) = get_display_name(&path, &pci_id_stripped, &gpu_names, mem_idx, gfx_idx);
-
-            if display_name == "ignore" {
-                // This element is to ignore (for example ACPI thermal zone is a quite unreliable temperature sensor, so omitting it is recommended)
-                // I know, this is not rustic, but it works for me!!
-                continue;
-            }
+            let result = get_display_name(&path, &pci_id_stripped, &gpu_names, mem_idx, gfx_idx);
+            mem_idx = result.1;
+            gfx_idx = result.2;
+            let display_name = match result.0 {
+                Some(name) => name,
+                None => continue,
+            };
 
 
             let device_path = std::fs::read_link(path.join("device"))
@@ -220,7 +199,7 @@ pub fn enumerate_sensors() -> Vec<SensorInfo> {
                             .unwrap_or_else(|_| "".to_string());
                         let display_label = get_label_name(prefix, &label);
                         let (unit, divider) = get_unit(prefix);
-                        let value = read_sysfs_file(&file.path());
+                        let value = read_sysfs_file(&file.path()).map(|v| v / divider as f32);
                         let sensor_name = Some(SensorName { device_name: display_name.clone(), sensor_name: display_label });
                         let device_path = if let Some(dev) = &device_path {
                             if dev.starts_with("DEADBEEF") { // virtual devices (for example my motherboard from Gigabyte links to "DEADBEEF-2001-0000-00A0-C90629100000")
@@ -460,114 +439,114 @@ pub fn get_display_name(
     gpu_names: &HashMap<String, String>,
     mem_idx: usize,
     gfx_idx: usize,
-) -> (String, usize, usize) {
+) -> (Option<String>, usize, usize) {
     // First of all, check for file device/model and return that in case it exists and contains something
     // This will display for example the type and name of the nvme-SSD
     let model_path = hwmon_path.join("device").join("model");
 
     if let Ok(model_name) = std::fs::read_to_string(model_path) {
-        return (model_name.trim().to_string(), mem_idx, gfx_idx);
+        return (Some(model_name.trim().to_string()), mem_idx, gfx_idx);
     }
 
-    // Fallback: Read the normal 'name' file
-    // Path: /sys/class/hwmon/hwmonX/name
     if let Ok(generic_name) = std::fs::read_to_string(hwmon_path.join("name")) {
         let name = generic_name.trim();
-        // If the name is only "nvme", then make it a little prettier
         if name == "nvme" {
-            return ("NVMe Storage Device".to_string(), mem_idx, gfx_idx);
+            return (Some("NVMe Storage Device".to_string()), mem_idx, gfx_idx);
         }
-        // AMD processors have k10temp, Intel have coretemp
         if name == "k10temp" || name == "coretemp" {
-            return ("CPU".to_string(), mem_idx, gfx_idx);
+            return (Some("CPU".to_string()), mem_idx, gfx_idx);
         }
-        // AMD gpus (internal or external) are named amdgpu
         if name == "amdgpu" {
-            if gfx_idx > 0 {
-                // The first graphics card is the main card. If there is a second graphics card, then it's the internal graphics chip, which is of no interest as not used.
-                // Well, if somebody has more than one PCI graphics card, then we won't display the second one, I know, but in most cases the second one is just the internal graphics chip.
-                return ("ignore".to_string(), mem_idx, gfx_idx);
+            if let Some(gpu_name) = gpu_names.get(pci_id_stripped) {
+                return (Some(gpu_name.clone()), mem_idx, gfx_idx + 1);
             }
-            if let Some(name) = gpu_names.get(pci_id_stripped) {
-                return (name.clone(), mem_idx, gfx_idx + 1);
-            }
+            return (Some(format!("AMD GPU {}", gfx_idx)), mem_idx, gfx_idx + 1);
         }
-        // NVidia gpus either don't appear at all, or appear as nouveau (if that driver is used)
         if name == "nouveau" {
-            return ("NVidia GPU".to_string(), mem_idx, gfx_idx + 1);
+            return (Some("NVidia GPU".to_string()), mem_idx, gfx_idx + 1);
         }
         let common_drivers = ["nct", "it8", "f71", "gigabyte_wmi", "w83"];
         if common_drivers.iter().any(|&d| name.starts_with(d)) {
-            return ("Motherboard".to_string(), mem_idx, gfx_idx);
+            return (Some("Motherboard".to_string()), mem_idx, gfx_idx);
         }
         if name.starts_with("spd") {
-            return (format!("DDR5 RAM Module {}",mem_idx+1), mem_idx + 1, gfx_idx);
+            return (Some(format!("DDR5 RAM Module {}", mem_idx + 1)), mem_idx + 1, gfx_idx);
         }
         if name.starts_with("ee1004") {
-            return (format!("DDR4 RAM Module {}",mem_idx+1), mem_idx + 1, gfx_idx);
+            return (Some(format!("DDR4 RAM Module {}", mem_idx + 1)), mem_idx + 1, gfx_idx);
         }
         if name.starts_with("jc42") {
-            return (format!("DDR3/ECC RAM Module {}",mem_idx+1), mem_idx + 1, gfx_idx);
+            return (Some(format!("DDR3/ECC RAM Module {}", mem_idx + 1)), mem_idx + 1, gfx_idx);
         }
         if name == "acpitz" {
-            // Notoriously inaccurate sensor: ACPI Thermal Zone, best to just ignore it...
-            return ("ignore".to_string(), mem_idx, gfx_idx);
+            return (None, mem_idx, gfx_idx);
         }
 
-        (name.to_string(), mem_idx, gfx_idx)
+        (Some(name.to_string()), mem_idx, gfx_idx)
     } else {
-        ("Unknown Device".to_string(), mem_idx, gfx_idx)
+        (Some("Unknown Device".to_string()), mem_idx, gfx_idx)
     }
 }
 
 pub fn resolve_sensor(source: &SensorSource, divider: usize) -> Option<ResolvedSensor> {
     match source {
+        SensorSource::CpuUsage | SensorSource::MemUsage
+        | SensorSource::MemUsed | SensorSource::MemFree => {
+            Some(ResolvedSensor::Virtual { source: source.clone(), divider })
+        }
         SensorSource::Hwmon {
-            name: _,
+            name,
             label,
             device_path,
         } => {
-            if device_path == "direct:cpu_usage" {
-                return Some(ResolvedSensor::SysfsFile { path: Path::new("/sys/class/hwmon").to_path_buf(), device_path: device_path.clone(), divider });
-            } else if device_path=="direct:mem_usage" {
-                return Some(ResolvedSensor::SysfsFile { path: Path::new("/proc/meminfo").to_path_buf(), device_path: device_path.clone(), divider });
-            } else if device_path=="direct:mem_used" {
-                return Some(ResolvedSensor::SysfsFile { path: Path::new("/proc/meminfo").to_path_buf(), device_path: device_path.clone(), divider });
-            } else if device_path=="direct:mem_free" {
-                return Some(ResolvedSensor::SysfsFile { path: Path::new("/proc/meminfo").to_path_buf(), device_path: device_path.clone(), divider });
-            }
             let hwmon_dir = Path::new("/sys/class/hwmon");
             let entries = std::fs::read_dir(hwmon_dir).ok()?;
 
             for entry in entries.flatten() {
                 let path = entry.path();
 
-                let device_path_symlink = std::fs::read_link(path.join("device"))
-                    .ok()
-                    .and_then(|p| p.file_name().map(|f| f.to_string_lossy().to_string()));
-                
-                let curr_device_path = if let Some(dev) = &device_path_symlink {
-                    if dev.starts_with("DEADBEEF") { // virtual devices like my motherboard links to "DEADBEEF-2001-0000-00A0-C90629100000"
-                        get_pci_id_from_path(path.clone())
-                    } else {
-                        dev.to_string()
+                // Match by device_path (PCI ID) when available, otherwise by hwmon name
+                if device_path.is_empty() {
+                    let hw_name = std::fs::read_to_string(path.join("name"))
+                        .ok()
+                        .map(|n| n.trim().to_string());
+                    if hw_name.as_deref() != Some(name) {
+                        continue;
                     }
                 } else {
-                    get_pci_id_from_path(path.clone())
-                };
+                    let device_path_symlink = std::fs::read_link(path.join("device"))
+                        .ok()
+                        .and_then(|p| p.file_name().map(|f| f.to_string_lossy().to_string()));
 
-                if curr_device_path != *device_path {
-                    continue;
+                    let curr_device_path = if let Some(dev) = &device_path_symlink {
+                        if dev.starts_with("DEADBEEF") {
+                            get_pci_id_from_path(path.clone())
+                        } else {
+                            dev.to_string()
+                        }
+                    } else {
+                        get_pci_id_from_path(path.clone())
+                    };
+
+                    if curr_device_path != *device_path {
+                        continue;
+                    }
                 }
 
-                // Search *_input files for matching label
                 if let Ok(files) = std::fs::read_dir(&path) {
                     for file in files.flatten() {
                         let fname = file.file_name().to_string_lossy().to_string();
                         if fname.ends_with("_input") {
                             let prefix = fname.strip_suffix("_input").unwrap();
+                            // Match by prefix (new format) or by label file content (old format)
                             if prefix == label {
-                                return Some(ResolvedSensor::SysfsFile { path: file.path(), device_path: device_path.clone(), divider });
+                                return Some(ResolvedSensor::SysfsFile { path: file.path(), divider });
+                            }
+                            let file_label = std::fs::read_to_string(path.join(format!("{prefix}_label")))
+                                .map(|l| l.trim().to_string())
+                                .unwrap_or_default();
+                            if file_label == *label {
+                                return Some(ResolvedSensor::SysfsFile { path: file.path(), divider });
                             }
                         }
                     }
@@ -590,30 +569,39 @@ pub fn resolve_sensor(source: &SensorSource, divider: usize) -> Option<ResolvedS
 
 pub fn read_sensor_value(resolved: &ResolvedSensor) -> anyhow::Result<f32> {
     match resolved {
-        ResolvedSensor::SysfsFile { path, device_path, divider } => {
-            if device_path == "direct:cpu_usage" {
-                let ret = SysSensor::get_cpu_usage();
-                return Ok((ret as f32) / (*divider as f32));
-            }
+        ResolvedSensor::SysfsFile { path, divider, .. } => {
             let content = std::fs::read_to_string(path)
                 .map_err(|e| anyhow::anyhow!("reading {}: {e}", path.display()))?;
-
-            if device_path == "direct:mem_usage" {
-                return Ok(get_mem_usage(&content));
-            }
-            if device_path == "direct:mem_used" {
-                let total = extract_mem_value(&content, "MemTotal:").unwrap_or(0.0);
-                let avail = extract_mem_value(&content, "MemAvailable:").unwrap_or(0.0);
-                return Ok((total - avail) / (*divider as f32));
-            }
-            if device_path == "direct:mem_free" {
-                return Ok(extract_mem_value(&content, "MemAvailable:").unwrap_or(0.0) / (*divider as f32));
-            }
             let raw_value: f32 = content
                 .trim()
                 .parse()
                 .map_err(|e| anyhow::anyhow!("parsing {}: {e}", path.display()))?;
             Ok(raw_value / (*divider as f32))
+        }
+        ResolvedSensor::Virtual { source, divider } => {
+            match source {
+                SensorSource::CpuUsage => {
+                    Ok(SysSensor::get_cpu_usage() as f32 / *divider as f32)
+                }
+                SensorSource::MemUsage => {
+                    let content = std::fs::read_to_string("/proc/meminfo")
+                        .map_err(|e| anyhow::anyhow!("reading /proc/meminfo: {e}"))?;
+                    Ok(get_mem_usage(&content))
+                }
+                SensorSource::MemUsed => {
+                    let content = std::fs::read_to_string("/proc/meminfo")
+                        .map_err(|e| anyhow::anyhow!("reading /proc/meminfo: {e}"))?;
+                    let total = extract_mem_value(&content, "MemTotal:").unwrap_or(0.0);
+                    let avail = extract_mem_value(&content, "MemAvailable:").unwrap_or(0.0);
+                    Ok((total - avail) / *divider as f32)
+                }
+                SensorSource::MemFree => {
+                    let content = std::fs::read_to_string("/proc/meminfo")
+                        .map_err(|e| anyhow::anyhow!("reading /proc/meminfo: {e}"))?;
+                    Ok(extract_mem_value(&content, "MemAvailable:").unwrap_or(0.0) / *divider as f32)
+                }
+                _ => anyhow::bail!("unexpected virtual sensor source"),
+            }
         }
         ResolvedSensor::NvidiaGpu(index) => {
             let output = Command::new("nvidia-smi")

--- a/crates/lianli-shared/src/sensors.rs
+++ b/crates/lianli-shared/src/sensors.rs
@@ -1,15 +1,21 @@
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::collections::HashMap;
+
+use crate::systeminfo::{SysSensor};
+
+/// SensorSource stores the information of a sensor in a way so that we can store it in a file, reboot, reload the file and are still able to find the sensor.
+/// In order to actually read the sensor value the implemented way is to create a ResolvedSensor from SensorSource and use that.
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
-pub enum TempSource {
+pub enum SensorSource {
     Hwmon {
         name: String,
         label: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        device_path: Option<String>,
+        #[serde(default)]
+        device_path: String,
     },
     NvidiaGpu {
         #[serde(default)]
@@ -23,16 +29,73 @@ pub enum TempSource {
     },
 }
 
+/// Defines the name of a sensor in human readable format. 
+
+#[derive(Debug,Clone,Serialize,Deserialize)]
+pub struct SensorName {
+    // Name of device in human readable form. A device can have several sensors attached to it
+    device_name: String,
+    // Name of the sensor in human readable form. The combination of device_name/sensor_name is unique (well, it should be...programmer is responsible for that!)
+    sensor_name: String,
+}
+
+#[derive(Debug,Clone,Serialize,Deserialize,PartialEq)]
+pub enum Unit {
+    C /*°Celsius*/, RPM /* Rounds per Minute, i.e. fan speed */, V /* Voltage in mV */, FREQ /* Frequence in Mhz */, PERCENT /* Percent value from 0% to 100% */, SIZE /* Mem Size in GB */, WO /* Without any unit */
+}
+
+impl std::fmt::Display for Unit {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let symbol = match self {
+            Unit::C => "°C",
+            Unit::RPM => "RPM",
+            Unit::V => "mV",
+            Unit::FREQ => "Mhz",
+            Unit::SIZE => "MB",
+            Unit::PERCENT => "%",
+            Unit::WO => "", // element without any unit...each sensor which is not recognized will receive this "unit"
+        };
+        write!(f, "{}", symbol)
+    }
+}
+
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SensorInfo {
-    pub source: TempSource,
-    pub display_name: String,
-    pub current_temp: Option<f32>,
+    pub source: SensorSource,
+    pub sensor_name: Option<SensorName>,
+    pub display_name: Option<String>,
+    pub divider: usize,
+    pub unit: Unit,
+    pub current_value: Option<f32>,
 }
+
+impl SensorInfo {
+    pub fn get_display_name(&self) -> String {
+        // Logik: Nutze display_name, falls vorhanden, 
+        // ansonsten sensor_name, ansonsten einen Standardwert.
+        self.display_name
+            .clone() // Da wir einen String zurückgeben wollen
+            .unwrap_or_else(|| {
+                self.sensor_name
+                    .as_ref()
+                    .map(|s| format!("{}: {} in {}", s.device_name, s.sensor_name,self.unit)) // Annahme: SensorName ist ein Enum/Struct mit ToString
+                    .unwrap_or_else(|| "Unbekannter Sensor".to_string())
+            })
+    }
+}
+
+/// ResolvedSensor is created from a SensorSource: SensorSource stores the information of a sensor in a way so that we can store it in a file, reboot, reload the file and still are able to find the sensor.
+/// But in order to actually read the sensor we need to look into SensorSource thoroughly to find the real path, etc. This is how ResolvedSensor comes into play:
+/// It's created from a SensorSource and enables us to read a sensor as fast as possible.
 
 #[derive(Debug, Clone)]
 pub enum ResolvedSensor {
-    SysfsFile(PathBuf),
+    SysfsFile { 
+        path: PathBuf, 
+        device_path: String, // from SensorSource, used in order to define what to read from the sysfsfile: basic hwmon entries are easy, just read the file, it contains a number. But the file /proc/meminfo contains more than just a number
+        divider: usize,
+    },
     NvidiaGpu(u32),
     ShellCommand(String),
     /// Runtime file written by daemon, contains plain °C value (not millidegrees).
@@ -41,84 +104,161 @@ pub enum ResolvedSensor {
 
 pub fn enumerate_sensors() -> Vec<SensorInfo> {
     let mut sensors = Vec::new();
-    let mut seen: Vec<(String, String)> = Vec::new();
-    let mut raw_entries: Vec<RawHwmonEntry> = Vec::new();
+    
+    let mut mem_idx:usize = 0; // Index in order to enumerate our different DRAM modules
+    let mut gfx_idx:usize = 0; // Index in order to enumerate our different GPU's
+    let mut display_name: String;
+
+    let gpu_names = get_amd_gpu_names();
+
+    // First of all, add some default sensors:
+    // CPU Usage
+    sensors.push(SensorInfo {
+        source: SensorSource::Hwmon {
+            name: "CPU".to_string(),
+            label: "Usage".to_string(),
+            device_path: "direct:cpu_usage".to_string(),
+        },
+        sensor_name: Some(SensorName{device_name:"CPU".to_string(),sensor_name:"Usage".to_string()}),
+        display_name: None,
+        divider: 100,
+        unit: Unit::PERCENT,
+        current_value: Some(0.0),
+    });
+
+    // RAM Usage in percent
+    sensors.push(SensorInfo {
+        source: SensorSource::Hwmon {
+            name: "RAM".to_string(),
+            label: "Usage".to_string(),
+            device_path: "direct:mem_usage".to_string(),
+        },
+        sensor_name: Some(SensorName{device_name:"RAM".to_string(),sensor_name:"Usage".to_string()}),
+        display_name: None,
+        divider: 1,
+        unit: Unit::PERCENT,
+        current_value: Some(0.0),
+    });
+
+    // RAM Used in MB
+    sensors.push(SensorInfo {
+        source: SensorSource::Hwmon {
+            name: "RAM".to_string(),
+            label: "Used".to_string(),
+            device_path: "direct:mem_used".to_string(),
+        },
+        sensor_name: Some(SensorName{device_name:"RAM".to_string(),sensor_name:"Used".to_string()}),
+        display_name: None,
+        divider: 1024*1024,
+        unit: Unit::SIZE,
+        current_value: Some(0.0),
+    });
+
+    // RAM Free in MB
+    sensors.push(SensorInfo {
+        source: SensorSource::Hwmon {
+            name: "RAM".to_string(),
+            label: "Free".to_string(),
+            device_path: "direct:mem_free".to_string(),
+        },
+        sensor_name: Some(SensorName{device_name:"RAM".to_string(),sensor_name:"Free".to_string()}),
+        display_name: None,
+        divider: 1024*1024,
+        unit: Unit::SIZE,
+        current_value: Some(0.0),
+    });
+
 
     // Scan hwmon devices
-    let hwmon_dir = Path::new("/sys/class/hwmon");
-    if let Ok(entries) = std::fs::read_dir(hwmon_dir) {
-        for entry in entries.flatten() {
+    let hwmon_path = "/sys/class/hwmon/";
+    if let Ok(entries) = std::fs::read_dir(hwmon_path) {
+        let mut sorted_entries: Vec<_> = entries.flatten().collect();
+        // Sort, so that hwmon<x> is numerically correct sorted (especially hwmon10 after hwmon9)
+        
+        sorted_entries.sort_by_cached_key(|entry| {
+            entry
+                .file_name()
+                .to_string_lossy()
+                .strip_prefix("hwmon")
+                .and_then(|s| s.parse::<u32>().ok())
+                .unwrap_or(u32::MAX)
+        });
+        for entry in sorted_entries {
             let path = entry.path();
             let name = match std::fs::read_to_string(path.join("name")) {
                 Ok(n) => n.trim().to_string(),
                 Err(_) => continue,
             };
 
+            let pci_id = get_pci_id_from_path(path.clone());
+            let pci_id_stripped = pci_id.strip_prefix("0000:").unwrap_or(&pci_id).to_string();
+
+            (display_name,mem_idx,gfx_idx) = get_display_name(&path, &pci_id_stripped, &gpu_names,mem_idx,gfx_idx);
+
+            if display_name == "ignore" {
+                // This element is to ignore (for example ACPI thermal zone is a quite unreliable temperature sensor, so omitting it is recommended)
+                // I know, this is not rustic, but it works for me!!
+                continue;
+            }
+
+
             let device_path = std::fs::read_link(path.join("device"))
                 .ok()
                 .and_then(|p| p.file_name().map(|f| f.to_string_lossy().to_string()));
 
-            // Find all temp*_input files
+            // Find all *_input files
             if let Ok(files) = std::fs::read_dir(&path) {
+                if let Some(busy_percent_path) = Some(entry.path().join("device").join("mem_busy_percent")) {
+                    if busy_percent_path.exists() {
+                        // File contains VRAM used for AMD graphics cards
+                    }
+
+                }
+                let mut device_sensors: Vec<SensorInfo> = Vec::new();
+
                 for file in files.flatten() {
                     let fname = file.file_name().to_string_lossy().to_string();
-                    if fname.starts_with("temp") && fname.ends_with("_input") {
+                    if fname.ends_with("_input") {
+
+                        // Extract prefix (filename might be freq1_input). Prefix contains useful hints for what kind of value it is (Frequency, Voltage, Power, °C etc)
                         let prefix = fname.strip_suffix("_input").unwrap();
-                        let label_path = path.join(format!("{prefix}_label"));
-                        let label = std::fs::read_to_string(&label_path)
-                            .map(|l| l.trim().to_string())
-                            .unwrap_or_else(|_| prefix.to_string());
+                        let label = std::fs::read_to_string(path.join(format!("{}_label", prefix)))
+                            .map(|s| s.trim().to_string())
+                            .unwrap_or_else(|_| "".to_string());
+                        let display_label = get_label_name(&prefix.to_string(),&label);
+                        let (unit,divider) = get_unit(prefix);
+                        let value = read_sysfs_file(&file.path());
+                        let sensor_name = Some(SensorName{device_name:display_name.clone(),sensor_name:display_label});
+                        let device_path = if let Some(dev) = &device_path {
+                            if dev.starts_with("DEADBEEF") { // virtual devices (for example my motherboard from Gigabyte links to "DEADBEEF-2001-0000-00A0-C90629100000")
+                                pci_id.to_string()
+                            } else {
+                                dev.to_string()
+                            }
+                        } else {
+                            pci_id.to_string()
+                        };
 
-                        let temp = read_sysfs_temp(&file.path());
-
-                        seen.push((name.clone(), label.clone()));
-                        raw_entries.push(RawHwmonEntry {
-                            name: name.clone(),
-                            label,
-                            device_path: device_path.clone(),
-                            sysfs_path: file.path(),
-                            temp,
+                        device_sensors.push(SensorInfo {
+                            source: SensorSource::Hwmon {
+                                name: name.clone(),
+                                label: prefix.to_string(),
+                                device_path: device_path,
+                            },
+                            sensor_name: sensor_name,
+                            display_name: None,
+                            divider: divider,
+                            unit: unit,
+                            current_value: value,
                         });
                     }
                 }
+
+                device_sensors.sort_by_cached_key(|s| s.get_display_name());
+                sensors.extend(device_sensors);
+
             }
         }
-    }
-
-    // Detect name+label collisions and include device_path only where needed
-    for entry in &raw_entries {
-        let collision = seen
-            .iter()
-            .filter(|(n, l)| n == &entry.name && l == &entry.label)
-            .count()
-            > 1;
-
-        let dp = if collision {
-            entry.device_path.clone()
-        } else {
-            None
-        };
-
-        let display = if collision {
-            format!(
-                "{} / {} ({})",
-                entry.name,
-                entry.label,
-                dp.as_deref().unwrap_or("?")
-            )
-        } else {
-            format!("{} / {}", entry.name, entry.label)
-        };
-
-        sensors.push(SensorInfo {
-            source: TempSource::Hwmon {
-                name: entry.name.clone(),
-                label: entry.label.clone(),
-                device_path: dp,
-            },
-            display_name: display,
-            current_temp: entry.temp,
-        });
     }
 
     // Check for NVIDIA GPU
@@ -136,59 +276,312 @@ pub fn enumerate_sensors() -> Vec<SensorInfo> {
                     let temp: Option<f32> = parts[2].trim().parse().ok();
 
                     sensors.push(SensorInfo {
-                        source: TempSource::NvidiaGpu { gpu_index },
-                        display_name: format!("{gpu_name} (GPU)"),
-                        current_temp: temp,
+                        source: SensorSource::NvidiaGpu { gpu_index },
+                        sensor_name: None,
+                        display_name: Some(format!("{gpu_name} (GPU)")),
+                        current_value: temp,
+                        unit: Unit::C,
+                        divider: 1,
                     });
                 }
             }
         }
     }
-
     sensors
 }
 
-pub fn resolve_sensor(source: &TempSource) -> Option<ResolvedSensor> {
+
+pub fn get_pci_id_from_path(hwmon_path: PathBuf) -> String {
+    // 1. Resolve that 'device'-link in the hwmon-folder
+    // canonicalize() creates a true absolute path from a symlink
+    let device_path = hwmon_path.join("device");
+
+    let opt_full_path = std::fs::canonicalize(device_path).ok();
+    if opt_full_path.is_none() {
+        return "None".to_string();
+    }
+
+    let full_path = opt_full_path.unwrap();
+
+    // 2. Iterate over the components of path from right to left
+    // A path might look as follows: /sys/devices/pci0000:00/0000:00:01.1/0000:04:00.0/nvme/nvme1
+    for component in full_path.ancestors() {
+        if let Some(name_os) = component.file_name() {
+            let name = name_os.to_string_lossy();
+
+            // Validation: A PCI-ID has the format Domain:Bus:Device.Function
+            // Let's check for these typical separators and minimum length (e.g. 00:00.0)
+            if name.contains(':') && name.contains('.') && name.len() >= 7 {
+                return name.into_owned();
+            }
+        }
+
+        // stop if we are about to leave the kernel device tree
+        if component == Path::new("/sys/devices") {
+            break;
+        }
+    }
+
+    let name = std::fs::read_to_string(hwmon_path.join("name"))
+        .unwrap_or_else(|_| "unknown".to_string())
+        .trim()
+        .to_string();
+
+    // We'll return "platform:NAME", in order to make it distinguishable from our PCI-IDs
+    format!("platform:{}", name)
+}
+
+/// retrieves human readable description of a metric and returns default values for this metric
+/// Returns desc, unit, divider
+
+fn get_unit(
+    prefix: &str,
+) -> (Unit,usize) {
+    // format_metrics_name translates from e.g. k10temp to CPU, and from Tctl to Control temperature of Tccd1 to Temperature of Die 1
+    if prefix.starts_with("temp") {
+        (Unit::C,1000)
+    } else if prefix.starts_with("fan") {
+        (Unit::RPM,1)
+    } else if prefix.starts_with("in") {
+        (Unit::V,1)
+    } else if prefix.starts_with("freq") {
+        (Unit::FREQ,1000*1000)
+    } else {
+        (Unit::WO,1)
+    }
+}
+
+/// Creates a meaningful name (human readable) for a sensor
+/// prefix is the name of the sensor file (without _input), and label is the content of the <prefix>_label file
+/// Note that label can be empty!
+
+pub fn get_label_name(prefix: &String, label: &String) -> String {
+    let lower_label = label.to_lowercase();
+    let lower_prefix = prefix.to_lowercase();
+    // Dynamic replacements for CCDs and Cores
+    let new_label = if lower_label.ends_with("ctl") {
+        "Control Temp".to_string()
+    } else if lower_label.ends_with("package id 0") {
+        "Control Temp".to_string()
+    } else if lower_label.ends_with("junction") && lower_prefix.starts_with("temp") {
+        "Hotspot Temp".to_string()
+    } else if lower_label.ends_with("edge") && lower_prefix.starts_with("temp") {
+        "Edge Temp".to_string()
+    } else if lower_label.ends_with("mem") && lower_prefix.starts_with("temp") {
+        "VRAM Temp".to_string()
+    } else if lower_label.ends_with("sclk") && lower_prefix.starts_with("freq") {
+        "System Clock".to_string()
+    } else if lower_label.ends_with("mclk") && lower_prefix.starts_with("freq") {
+        "Memory Clock".to_string()
+    } else if lower_label.ends_with("vddgfx") && lower_prefix.starts_with("in") {
+        "GPU Voltage".to_string()
+    } else if let Some(idx) = lower_label.find("ccd") {
+        format!("Temp Die {}", &lower_label[idx + 3..])
+    } else if let Some(idx) = lower_label.find("core ") {
+        format!("Temp Core {}", &lower_label[idx + 5..])
+    } else if let Some(idx) = lower_label.find("fan") {
+        format!("Fan {}", &lower_label[idx + 3..])
+    } else if let Some(idx) = lower_prefix.find("fan") {
+        format!("Fan {}", &lower_prefix[idx + 3..])
+    } else if label.is_empty() {
+        prefix.clone() // use prefix
+    } else {
+        label.clone() // use label
+    };
+
+    return new_label;
+}
+
+
+fn get_amd_gpu_names() -> HashMap<String, String> {
+    let mut gpus = HashMap::new();
+
+    // 1. call lspci
+    let output = Command::new("lspci")
+        .output()
+        .expect("Error: lspci not found");
+
+    // 2. convert output to string
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // 3. parse line by line (replacement for grep command)
+    for line in stdout.lines() {
+        let line_lower = line.to_lowercase();
+
+        // Now let's filter: Must contain "vga" (or "display"/"3d") and "amd"
+        if (line_lower.contains("vga") || line_lower.contains("display"))
+            && line_lower.contains("amd")
+        {
+            // The PCI-address is always at the beginning (first 7-12 chars)
+            // Example : "03:00.0 VGA compatible controller: ..."
+            if let Some((addr, full_desc)) = line.split_once(' ') {
+                let clean_name = if let Some((_, actual_name)) = full_desc.split_once(": ") {
+                    actual_name.trim()
+                } else {
+                    full_desc.trim()
+                };
+                gpus.insert(addr.to_string(), clean_name.to_string());
+            }
+        }
+    }
+
+    return clean_common_prefixes(gpus);
+}
+
+
+// Helper method: Looks at all the values in the hash map. If all of them share a single prefix, then remove the prefix
+// For example, if all values contain the prefix "VGA compatible controller: <blah blah>", then the prefix "VGA compatible controller: " will be removed
+
+fn clean_common_prefixes(mut gpus: HashMap<String, String>) -> HashMap<String, String> {
+    if gpus.is_empty() {
+        return gpus;
+    }
+
+    // 1. step: Find the prefix common to all values:
+
+    let values: Vec<&String> = gpus.values().collect();
+    // We'll use the first name as base for our comparison
+    let mut common_prefix = values[0].clone();
+
+    for name in values.iter().skip(1) {
+        // Now we shorten the common prefix until it's also a common prefix from 'name'
+        while !name.starts_with(&common_prefix) && !common_prefix.is_empty() {
+            common_prefix.pop();
+        }
+    }
+    // Ok, common prefix found!
+
+    // 2. step: Remove the common prefix from all values
+    if !common_prefix.is_empty() {
+        let prefix_len = common_prefix.len();
+        for value in gpus.values_mut() {
+            *value = value[prefix_len..].trim().to_string();
+        }
+    }
+
+    gpus
+}
+
+// Creates a human readable name from this path
+// Needs the current pci id in order to find the name of the graphics card
+// Needs the number of found graphics cards in order to process only the first one (main graphics card, external one) and ignore the second one (secondary graphics card, CPU with built-in GPU)
+// Needs the number of RAM modules found so far to enumerate the RAM modules.
+
+pub fn get_display_name(
+    hwmon_path: &Path,
+    pci_id_stripped: &String,
+    gpu_names: &HashMap<String, String>,
+    mem_idx: usize,
+    gfx_idx: usize,
+) -> (String,usize,usize) {
+    // First of all, check for file device/model and return that in case it exists and contains something
+    // This will display for example the type and name of the nvme-SSD
+    let model_path = hwmon_path.join("device").join("model");
+
+    if let Ok(model_name) = std::fs::read_to_string(model_path) {
+        return (model_name.trim().to_string(),mem_idx,gfx_idx);
+    }
+
+    // Fallback: Read the normal 'name' file
+    // Path: /sys/class/hwmon/hwmonX/name
+    if let Ok(generic_name) = std::fs::read_to_string(hwmon_path.join("name")) {
+        let name = generic_name.trim();
+        // If the name is only "nvme", then make it a little prettier
+        if name == "nvme" {
+            return ("NVMe Storage Device".to_string(),mem_idx,gfx_idx);
+        }
+        // AMD processors have k10temp, Intel have coretemp
+        if name == "k10temp" || name == "coretemp" {
+            return ("CPU".to_string(),mem_idx,gfx_idx);
+        }
+        // AMD gpus (internal or external) are named amdgpu
+        if name == "amdgpu" {
+            if gfx_idx>0 {
+                // The first graphics card is the main card. If there is a second graphics card, then it's the internal graphics chip, which is of no interest as not used.
+                // Well, if somebody has more than one PCI graphics card, then we won't display the second one, I know, but in most cases the second one is just the internal graphics chip.
+                return ("ignore".to_string(),mem_idx,gfx_idx);
+            }
+            if let Some(name) = gpu_names.get(pci_id_stripped) {
+                return (name.clone(),mem_idx,gfx_idx+1);
+            }
+        }
+        // NVidia gpus either don't appear at all, or appear as nouveau (if that driver is used)
+        if name == "nouveau" {
+            return ("NVidia GPU".to_string(),mem_idx,gfx_idx+1);
+        }
+        let common_drivers = ["nct", "it8", "f71", "gigabyte_wmi", "w83"];
+        if common_drivers.iter().any(|&d| name.starts_with(d)) {
+            return ("Motherboard".to_string(),mem_idx,gfx_idx);
+        }
+        if name.starts_with("spd") {
+            return (format!("DDR5 RAM Module {}",mem_idx+1),mem_idx+1,gfx_idx);
+        }
+        if name.starts_with("ee1004") {
+            return (format!("DDR4 RAM Module {}",mem_idx+1),mem_idx+1,gfx_idx);
+        }
+        if name.starts_with("jc42") {
+            return (format!("DDR3/ECC RAM Module {}",mem_idx+1),mem_idx+1,gfx_idx);
+        }
+        if name == "acpitz" {
+            // Notoriously inaccurate sensor: ACPI Thermal Zone, best to just ignore it...
+            return ("ignore".to_string(),mem_idx,gfx_idx);
+        }
+
+        return (name.to_string(),mem_idx,gfx_idx);
+    }
+
+    ("Unknown Device".to_string(),mem_idx,gfx_idx)
+}
+
+pub fn resolve_sensor(source: &SensorSource, divider: usize) -> Option<ResolvedSensor> {
     match source {
-        TempSource::Hwmon {
-            name,
+        SensorSource::Hwmon {
+            name: _,
             label,
             device_path,
         } => {
+            if device_path=="direct:cpu_usage" {
+                return Some(ResolvedSensor::SysfsFile{path: Path::new("/sys/class/hwmon").to_path_buf(),device_path: device_path.clone(), divider: divider});
+            } else if device_path=="direct:mem_usage" {
+                return Some(ResolvedSensor::SysfsFile{path: Path::new("/proc/meminfo").to_path_buf(),device_path: device_path.clone(), divider: divider});
+            } else if device_path=="direct:mem_used" {
+                return Some(ResolvedSensor::SysfsFile{path: Path::new("/proc/meminfo").to_path_buf(),device_path: device_path.clone(), divider: divider});
+            } else if device_path=="direct:mem_free" {
+                return Some(ResolvedSensor::SysfsFile{path: Path::new("/proc/meminfo").to_path_buf(),device_path: device_path.clone(), divider: divider});
+            }
             let hwmon_dir = Path::new("/sys/class/hwmon");
             let entries = std::fs::read_dir(hwmon_dir).ok()?;
 
             for entry in entries.flatten() {
                 let path = entry.path();
-                let hw_name = std::fs::read_to_string(path.join("name"))
+
+                let device_path_symlink = std::fs::read_link(path.join("device"))
                     .ok()
-                    .map(|n| n.trim().to_string())?;
-                if &hw_name != name {
+                    .and_then(|p| p.file_name().map(|f| f.to_string_lossy().to_string()));
+                
+                let curr_device_path = if let Some(dev) = &device_path_symlink {
+                    if dev.starts_with("DEADBEEF") { // virtual devices like my motherboard links to "DEADBEEF-2001-0000-00A0-C90629100000"
+                        get_pci_id_from_path(path.clone())
+                    } else {
+                        dev.to_string()
+                    }
+                } else {
+                    get_pci_id_from_path(path.clone())
+                };
+
+                if curr_device_path != *device_path  {
                     continue;
                 }
+                
 
-                if let Some(ref dp) = device_path {
-                    let actual_dp = std::fs::read_link(path.join("device"))
-                        .ok()
-                        .and_then(|p| p.file_name().map(|f| f.to_string_lossy().to_string()));
-                    if actual_dp.as_deref() != Some(dp.as_str()) {
-                        continue;
-                    }
-                }
-
-                // Search temp*_input files for matching label
+                // Search *_input files for matching label
                 if let Ok(files) = std::fs::read_dir(&path) {
                     for file in files.flatten() {
                         let fname = file.file_name().to_string_lossy().to_string();
-                        if fname.starts_with("temp") && fname.ends_with("_input") {
+                        if fname.ends_with("_input") {
                             let prefix = fname.strip_suffix("_input").unwrap();
-                            let label_path = path.join(format!("{prefix}_label"));
-                            let file_label = std::fs::read_to_string(&label_path)
-                                .map(|l| l.trim().to_string())
-                                .unwrap_or_else(|_| prefix.to_string());
-
-                            if &file_label == label {
-                                return Some(ResolvedSensor::SysfsFile(file.path()));
+                            if &prefix == label {
+                                return Some(ResolvedSensor::SysfsFile{path: file.path(),device_path: device_path.clone(),divider: divider});
                             }
                         }
                     }
@@ -196,9 +589,9 @@ pub fn resolve_sensor(source: &TempSource) -> Option<ResolvedSensor> {
             }
             None
         }
-        TempSource::NvidiaGpu { gpu_index } => Some(ResolvedSensor::NvidiaGpu(*gpu_index)),
-        TempSource::Command { cmd } => Some(ResolvedSensor::ShellCommand(cmd.clone())),
-        TempSource::WirelessCoolant { device_id } => {
+        SensorSource::NvidiaGpu { gpu_index } => Some(ResolvedSensor::NvidiaGpu(*gpu_index)),
+        SensorSource::Command { cmd } => Some(ResolvedSensor::ShellCommand(cmd.clone())),
+        SensorSource::WirelessCoolant { device_id } => {
             let path = coolant_runtime_path(device_id);
             if path.exists() {
                 Some(ResolvedSensor::RuntimeFile(path))
@@ -209,16 +602,32 @@ pub fn resolve_sensor(source: &TempSource) -> Option<ResolvedSensor> {
     }
 }
 
-pub fn read_sensor_temp(resolved: &ResolvedSensor) -> anyhow::Result<f32> {
+pub fn read_sensor_value(resolved: &ResolvedSensor) -> anyhow::Result<f32> {
     match resolved {
-        ResolvedSensor::SysfsFile(path) => {
+        ResolvedSensor::SysfsFile {path, device_path, divider} => {
+            if device_path=="direct:cpu_usage" {
+                let ret = SysSensor::get_cpu_usage();
+                return Ok((ret as f32)/(*divider as f32));
+            }
             let content = std::fs::read_to_string(path)
                 .map_err(|e| anyhow::anyhow!("reading {}: {e}", path.display()))?;
-            let millidegrees: f32 = content
+
+            if device_path=="direct:mem_usage" {
+                return Ok(get_mem_usage(&content));
+            }
+            if device_path=="direct:mem_used" {
+                let total = extract_mem_value(&content, "MemTotal:").unwrap_or(0.0);
+                let avail = extract_mem_value(&content, "MemAvailable:").unwrap_or(0.0);
+                return Ok((total-avail)/(*divider as f32));
+            }
+            if device_path=="direct:mem_free" {
+                return Ok(extract_mem_value(&content, "MemAvailable:").unwrap_or(0.0)/(*divider as f32));
+            }
+            let raw_value: f32 = content
                 .trim()
                 .parse()
                 .map_err(|e| anyhow::anyhow!("parsing {}: {e}", path.display()))?;
-            Ok(millidegrees / 1000.0)
+            Ok(raw_value / (*divider as f32))
         }
         ResolvedSensor::NvidiaGpu(index) => {
             let output = Command::new("nvidia-smi")
@@ -274,15 +683,6 @@ pub fn read_sensor_temp(resolved: &ResolvedSensor) -> anyhow::Result<f32> {
     }
 }
 
-#[allow(dead_code)]
-struct RawHwmonEntry {
-    name: String,
-    label: String,
-    device_path: Option<String>,
-    sysfs_path: PathBuf,
-    temp: Option<f32>,
-}
-
 /// Runtime path for a wireless coolant temperature file.
 pub fn coolant_runtime_path(device_id: &str) -> PathBuf {
     let runtime_dir = std::env::var("XDG_RUNTIME_DIR")
@@ -297,8 +697,32 @@ pub fn write_coolant_temp(device_id: &str, temp_c: f32) {
     let _ = std::fs::write(&path, format!("{temp_c}"));
 }
 
-fn read_sysfs_temp(path: &Path) -> Option<f32> {
+fn read_sysfs_file(path: &Path) -> Option<f32> {
     let content = std::fs::read_to_string(path).ok()?;
-    let millidegrees: f32 = content.trim().parse().ok()?;
-    Some(millidegrees / 1000.0)
+    let value: f32 = content.trim().parse().ok()?;
+    Some(value)
+}
+
+pub fn get_mem_usage(content: &String) -> f32 {
+    // convert into string, then extract the data. Contents is as follows (/proc/meminfo)
+    /*
+    MemTotal:       31893084 kB
+    MemFree:        12764544 kB
+    MemAvailable:   26270984 kB
+    Buffers:          ...
+        */
+    let mem_total = extract_mem_value(content, "MemTotal:");
+    let mem_free = extract_mem_value(content, "MemAvailable:");
+    if let Some(total) = mem_total {
+        if let Some(free) = mem_free {
+            return 100.0-free * 100.0 / total;
+        }
+    }
+    0.0
+}
+
+fn extract_mem_value(input: &str, target: &str) -> Option<f32> {
+    let line = input.lines().find(|l| l.starts_with(target))?;
+    let parts: Vec<&str> = line.split_whitespace().collect();
+    parts.get(1)?.parse::<f32>().ok()
 }

--- a/crates/lianli-shared/src/sensors.rs
+++ b/crates/lianli-shared/src/sensors.rs
@@ -433,7 +433,7 @@ fn get_amd_gpu_names() -> HashMap<String, String> {
 // For example, if all values contain the prefix "VGA compatible controller: <blah blah>", then the prefix "VGA compatible controller: " will be removed
 
 fn clean_common_prefixes(mut gpus: HashMap<String, String>) -> HashMap<String, String> {
-    if gpus.is_empty() {
+    if gpus.len()<=1 {
         return gpus;
     }
 

--- a/crates/lianli-shared/src/systeminfo.rs
+++ b/crates/lianli-shared/src/systeminfo.rs
@@ -1,0 +1,130 @@
+use std::fs::File;
+use std::os::unix::fs::FileExt;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant};
+
+// SysSensor is a singleton.
+// It can be used as follows: At the very beginning of daemon start SysSensor::init() is called which initializes the singleton
+// After that the CPU usage values get refreshed 3 times per second automatically.
+// You can retrieve the stored values at any time by SysSensor::get_cpu_usage();
+
+pub struct SysSensor {
+    // list of usage per core (cpu0, cpu1, ...)
+    per_core_usage: Arc<Vec<AtomicU32>>,
+    last_global_usage: AtomicU32,
+}
+
+pub static INSTANCE: OnceLock<SysSensor> = OnceLock::new();
+
+impl SysSensor {
+    pub fn init() {
+        INSTANCE.get_or_init(|| {
+            // Let's retrieve the number of CPU cores in the system
+            let core_count = std::fs::read_to_string("/proc/cpuinfo")
+                .unwrap_or_default()
+                .matches("processor")
+                .count()
+                .max(1);
+
+            let per_core = Arc::new((0..core_count).map(|_| AtomicU32::new(0)).collect());
+
+            let sensor = Self {
+                per_core_usage: per_core,
+                last_global_usage: AtomicU32::new(0),
+            };
+
+            thread::spawn(|| Self::worker_loop());
+            sensor
+        });
+    }
+
+    pub fn get_core_usage() -> Vec<u32> {
+        if let Some(s) = INSTANCE.get() {
+            let cores: Vec<u32> = s
+                .per_core_usage
+                .iter()
+                .map(|c| (c.load(Ordering::Relaxed) / 100) as u32)
+                .collect();
+
+            cores
+        } else {
+            vec![]
+        }
+    }
+
+    /// ranges from 0 to 10000 (i.e. multiplied by 100 to be able to have 2 decimal places after the percent value (e.g. 78.67%), so mathematically 4 decimals...)
+    pub fn get_cpu_usage() -> u32 {
+        if let Some(s) = INSTANCE.get() {
+            s.last_global_usage.load(Ordering::Relaxed)
+        } else {
+            0
+        }
+    }
+
+    fn worker_loop() {
+        // CPU Usage and usage per core calculation.
+
+        let mut stat_file = File::open("/proc/stat").ok();
+        let mut buffer = [0u8; 4096];
+
+        // Mem for the previous ticks (global and per core)
+        let mut last_stats: Vec<(u64, u64)> = vec![];
+
+        loop {
+            let start_time = Instant::now();
+
+            if let Some(ref mut f) = stat_file {
+                if let Ok(n) = f.read_at(&mut buffer, 0) {
+                    let s = std::str::from_utf8(&buffer[..n]).unwrap_or("");
+                    let cpu_lines: Vec<&str> = s.lines().filter(|l| l.starts_with("cpu")).collect();
+
+                    // Initialize last_stats if necessary
+                    if last_stats.len() < cpu_lines.len() {
+                        last_stats = vec![(0, 0); cpu_lines.len()];
+                    }
+
+                    for (i, line) in cpu_lines.iter().enumerate() {
+                        let parts: Vec<u64> = line
+                            .split_whitespace()
+                            .skip(1)
+                            .filter_map(|p| p.parse().ok())
+                            .collect();
+
+                        let idle = parts.get(3).copied().unwrap_or(0);
+                        let total: u64 = parts.iter().sum();
+
+                        let (prev_total, prev_idle) = last_stats[i];
+                        let total_delta = total.saturating_sub(prev_total);
+                        let idle_delta = idle.saturating_sub(prev_idle);
+                        last_stats[i] = (total, idle);
+
+                        if total_delta > 0 {
+                            let usage = (1.0 - (idle_delta as f32 / total_delta as f32)) * 100.0;
+                            let val = (usage * 100.0) as u32;
+
+                            if i == 0 {
+                                // Global cpu usage (first line "cpu ")
+                                if let Some(inst) = INSTANCE.get() {
+                                    inst.last_global_usage.store(val, Ordering::Relaxed);
+                                }
+                            } else {
+                                // Core usage (lines "cpu0", "cpu1", ...)
+                                if let Some(inst) = INSTANCE.get() {
+                                    if let Some(atomic) = inst.per_core_usage.get(i - 1) {
+                                        atomic.store(val, Ordering::Relaxed);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            let sleep_dur = Duration::from_millis(333).saturating_sub(start_time.elapsed());
+
+            thread::sleep(sleep_dur);
+        }
+    }
+}

--- a/crates/lianli-shared/src/systeminfo.rs
+++ b/crates/lianli-shared/src/systeminfo.rs
@@ -92,7 +92,8 @@ impl SysSensor {
                             .filter_map(|p| p.parse().ok())
                             .collect();
 
-                        let idle = parts.get(3).copied().unwrap_or(0);
+                        let idle = parts.get(3).copied().unwrap_or(0)
+                            + parts.get(4).copied().unwrap_or(0);
                         let total: u64 = parts.iter().sum();
 
                         let (prev_total, prev_idle) = last_stats[i];

--- a/crates/lianli-shared/src/systeminfo.rs
+++ b/crates/lianli-shared/src/systeminfo.rs
@@ -45,7 +45,7 @@ impl SysSensor {
             let cores: Vec<u32> = s
                 .per_core_usage
                 .iter()
-                .map(|c| (c.load(Ordering::Relaxed) / 100) as u32)
+                .map(|c| c.load(Ordering::Relaxed))
                 .collect();
 
             cores

--- a/crates/lianli-shared/src/systeminfo.rs
+++ b/crates/lianli-shared/src/systeminfo.rs
@@ -16,7 +16,7 @@ pub struct SysSensor {
     last_global_usage: AtomicU32,
 }
 
-pub static INSTANCE: OnceLock<SysSensor> = OnceLock::new();
+static INSTANCE: OnceLock<SysSensor> = OnceLock::new();
 
 impl SysSensor {
     pub fn init() {


### PR DESCRIPTION
So finally I have reworked the sensors:
Now not only temperatures are available, but all sensors in hwmon directories.

I had to add a unit and divider for each sensor, so one knows whether it's a voltage, a fan rpm, a percent value or a temperature.

Additionally a few more sensors were added: CPU Usage, Memory Usage, Mem Free in GB, Mem Used in GB, GPU Mem Used, GPU Usage (only for AMD graphics cards).

I tried to resolve the sensor names so we do not need to read "k10temp, TCtl", but "CPU - Control Temperature", and not nvme1.Composite, but "Samsung SSD 970 EVO 1TB: Composite in °C"

In order to calculate a CPU usage I added a new thread which takes user time and idle time 3 times per second and calculates the cpu usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CPU and memory sensors (usage/used/free) and a background CPU usage monitor.

* **Improvements**
  * Separate sensor selection models for LCD vs Fans.
  * More robust sensor discovery, unit/divider handling, and normalized sensor values.
  * Improved fan control smoothing and more accurate sensor readings.

* **Bug Fixes**
  * Clamped fallback text rendering to available width.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->