### PR TITLE
feat(rgb): add per-LED color control and named preset save/load

### DIFF
--- a/crates/lianli-daemon/src/ipc_server.rs
+++ b/crates/lianli-daemon/src/ipc_server.rs
@@ -9,6 +9,7 @@ use crate::template_store;
 use lianli_media::CustomAsset;
 use lianli_shared::config::AppConfig;
 use lianli_shared::ipc::{DeviceInfo, IpcRequest, IpcResponse, TelemetrySnapshot};
+use lianli_shared::rgb::RgbPreset;
 use lianli_shared::screen::ScreenInfo;
 use lianli_shared::sensors::Unit;
 use lianli_shared::template::LcdTemplate;
@@ -466,6 +467,155 @@ fn handle_request(
                     Err(e) => IpcResponse::error(format!("preview render failed: {e}")),
                 },
                 Err(e) => IpcResponse::error(format!("preview asset creation failed: {e}")),
+            }
+        }
+
+        IpcRequest::SetLedColor {
+            device_id,
+            zone,
+            led_index,
+            color,
+        } => {
+            let state = state.lock();
+            if let Some(ref rgb) = state.rgb_controller {
+                let mut rgb = rgb.lock();
+                let mut colors = match rgb.get_zone_colors(&device_id, zone) {
+                    Some(c) => c,
+                    None => {
+                        return IpcResponse::error(format!(
+                            "zone {zone} not found on device {device_id}"
+                        ));
+                    }
+                };
+                let idx = led_index as usize;
+                if idx >= colors.len() {
+                    return IpcResponse::error(format!(
+                        "LED index {led_index} out of range (zone has {} LEDs)",
+                        colors.len()
+                    ));
+                }
+                colors[idx] = color;
+                match rgb.set_direct_colors(&device_id, zone, &colors) {
+                    Ok(()) => IpcResponse::ok(serde_json::json!(null)),
+                    Err(e) => IpcResponse::error(format!("RGB direct error: {e}")),
+                }
+            } else {
+                IpcResponse::error("RGB controller not initialized")
+            }
+        }
+
+        IpcRequest::SaveRgbPreset { name, device_id } => {
+            let zones = {
+                let state = state.lock();
+                if let Some(ref rgb) = state.rgb_controller {
+                    rgb.lock().get_all_zone_colors(&device_id)
+                } else {
+                    return IpcResponse::error("RGB controller not initialized");
+                }
+            };
+            let zones = match zones {
+                Some(z) => z,
+                None => {
+                    return IpcResponse::error(format!(
+                        "device {device_id} not found or has no wireless state"
+                    ));
+                }
+            };
+            let preset = RgbPreset {
+                name: name.clone(),
+                device_id,
+                zones,
+            };
+            let mut state = state.lock();
+            let app_config = state.config.get_or_insert_with(AppConfig::default);
+            // Upsert by (name, device_id) composite key — presets are device-scoped
+            // so "Rainbow" on device A doesn't collide with "Rainbow" on device B.
+            if let Some(existing) = app_config
+                .rgb_presets
+                .iter_mut()
+                .find(|p| p.name == name && p.device_id == preset.device_id)
+            {
+                *existing = preset;
+            } else {
+                app_config.rgb_presets.push(preset);
+            }
+            let cfg_clone = app_config.clone();
+            match write_config(&state.config_path, &cfg_clone) {
+                Ok(()) => {
+                    tx.send(DaemonEvent::IpcUpdate).ok();
+                    info!("RGB preset '{name}' saved");
+                    IpcResponse::ok(serde_json::json!(null))
+                }
+                Err(e) => IpcResponse::error(format!("failed to write config: {e}")),
+            }
+        }
+
+        IpcRequest::DeleteRgbPreset { name, device_id } => {
+            let mut state = state.lock();
+            let app_config = state.config.get_or_insert_with(AppConfig::default);
+            let before = app_config.rgb_presets.len();
+            app_config
+                .rgb_presets
+                .retain(|p| !(p.name == name && p.device_id == device_id));
+            if app_config.rgb_presets.len() == before {
+                return IpcResponse::error(format!("preset '{name}' not found for {device_id}"));
+            }
+            let cfg_clone = app_config.clone();
+            match write_config(&state.config_path, &cfg_clone) {
+                Ok(()) => {
+                    tx.send(DaemonEvent::IpcUpdate).ok();
+                    info!("RGB preset '{name}' deleted");
+                    IpcResponse::ok(serde_json::json!(null))
+                }
+                Err(e) => IpcResponse::error(format!("failed to write config: {e}")),
+            }
+        }
+
+        IpcRequest::ListRgbPresets => {
+            let state = state.lock();
+            let presets = state
+                .config
+                .as_ref()
+                .map(|c| c.rgb_presets.clone())
+                .unwrap_or_default();
+            IpcResponse::ok(&presets)
+        }
+
+        IpcRequest::ApplyRgbPreset { name, device_id } => {
+            let preset = {
+                let state = state.lock();
+                state.config.as_ref().and_then(|c| {
+                    c.rgb_presets
+                        .iter()
+                        .find(|p| p.name == name && p.device_id == device_id)
+                        .cloned()
+                })
+            };
+            let preset = match preset {
+                Some(p) => p,
+                None => {
+                    return IpcResponse::error(format!("preset '{name}' not found for {device_id}"))
+                }
+            };
+            let state = state.lock();
+            if let Some(ref rgb) = state.rgb_controller {
+                let mut rgb = rgb.lock();
+                for zone_entry in &preset.zones {
+                    if let Err(e) = rgb.set_direct_colors(
+                        &preset.device_id,
+                        zone_entry.zone,
+                        &zone_entry.colors,
+                    ) {
+                        return IpcResponse::error(format!(
+                            "failed to apply preset zone {}: {e}",
+                            zone_entry.zone
+                        ));
+                    }
+                }
+                info!("RGB preset '{name}' applied to {}", preset.device_id);
+                IpcResponse::ok(serde_json::json!(null))
+            } else {
+                IpcResponse::error("RGB controller not initialized")
             }
         }
 

--- a/crates/lianli-daemon/src/rgb_controller.rs
+++ b/crates/lianli-daemon/src/rgb_controller.rs
@@ -6,7 +6,9 @@
 
 use lianli_devices::traits::RgbDevice;
 use lianli_devices::wireless::{WirelessController, WirelessFanType};
-use lianli_shared::rgb::{RgbAppConfig, RgbDeviceCapabilities, RgbEffect, RgbMode, RgbZoneInfo};
+use lianli_shared::rgb::{
+    RgbAppConfig, RgbDeviceCapabilities, RgbEffect, RgbMode, RgbPresetZone, RgbZoneInfo,
+};
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -385,6 +387,52 @@ impl RgbController {
                 }
             }
         }
+    }
+
+    /// Compute zone count and LEDs-per-zone for a wireless device state.
+    ///
+    /// Override-based devices (V150, Strimer, LC217, Led88) are single-zone
+    /// with all LEDs in one flat buffer — matches `WirelessRgbState::new`.
+    fn zone_layout(state: &WirelessRgbState) -> (usize, usize) {
+        if state.fan_type.total_led_count_override().is_some() {
+            return (1, state.led_state.len());
+        }
+        let total_zones = if state.fan_type.is_aio() {
+            state.fan_count as usize + 1
+        } else {
+            state.fan_count as usize
+        };
+        (total_zones, state.leds_per_fan as usize)
+    }
+
+    /// Get the current per-LED color buffer for a wireless device zone.
+    pub fn get_zone_colors(&self, device_id: &str, zone: u8) -> Option<Vec<[u8; 3]>> {
+        let state = self.wireless_state.get(device_id)?;
+        let (_, leds_in_zone) = Self::zone_layout(state);
+        let start = zone as usize * leds_in_zone;
+        let end = (start + leds_in_zone).min(state.led_state.len());
+        if start >= state.led_state.len() {
+            return None;
+        }
+        Some(state.led_state[start..end].to_vec())
+    }
+
+    /// Get all zone colors for a wireless device (for saving presets).
+    pub fn get_all_zone_colors(&self, device_id: &str) -> Option<Vec<RgbPresetZone>> {
+        let state = self.wireless_state.get(device_id)?;
+        let (total_zones, leds_in_zone) = Self::zone_layout(state);
+        let mut zones = Vec::new();
+        for z in 0..total_zones {
+            let start = z * leds_in_zone;
+            let end = (start + leds_in_zone).min(state.led_state.len());
+            if start < state.led_state.len() {
+                zones.push(RgbPresetZone {
+                    zone: z as u8,
+                    colors: state.led_state[start..end].to_vec(),
+                });
+            }
+        }
+        Some(zones)
     }
 
     /// Check if a device_id refers to a wireless device.

--- a/crates/lianli-shared/src/config.rs
+++ b/crates/lianli-shared/src/config.rs
@@ -1,6 +1,6 @@
 use crate::fan::{FanConfig, FanCurve};
 use crate::media::{DoublegaugeDescriptor, MediaType, SensorDescriptor, SensorSourceConfig};
-use crate::rgb::RgbAppConfig;
+use crate::rgb::{RgbAppConfig, RgbPreset};
 use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::to_string;
@@ -132,6 +132,8 @@ pub struct AppConfig {
     pub fans: Option<FanConfig>,
     #[serde(default)]
     pub rgb: Option<RgbAppConfig>,
+    #[serde(default)]
+    pub rgb_presets: Vec<RgbPreset>,
 }
 
 impl Default for AppConfig {
@@ -143,6 +145,7 @@ impl Default for AppConfig {
             fan_curves: Vec::new(),
             fans: None,
             rgb: None,
+            rgb_presets: Vec::new(),
         }
     }
 }

--- a/crates/lianli-shared/src/ipc.rs
+++ b/crates/lianli-shared/src/ipc.rs
@@ -43,6 +43,34 @@ pub enum IpcRequest {
         /// RGB triplets, one per LED.
         colors: Vec<[u8; 3]>,
     },
+    /// Set a single LED's color by index within a zone.
+    /// Convenience wrapper around SetRgbDirect that modifies one LED
+    /// without requiring the caller to track the full zone state.
+    SetLedColor {
+        device_id: String,
+        zone: u8,
+        led_index: u16,
+        color: [u8; 3],
+    },
+    /// Save current direct-mode colors as a named preset.
+    SaveRgbPreset {
+        name: String,
+        device_id: String,
+    },
+    /// Delete a named RGB preset. Scoped by (name, device_id) to match save.
+    DeleteRgbPreset {
+        name: String,
+        device_id: String,
+    },
+    /// List all saved RGB presets.
+    ListRgbPresets,
+    /// Apply a named preset (sends stored colors to device).
+    /// Scoped by (name, device_id) to avoid ambiguity when multiple devices
+    /// share the same preset name.
+    ApplyRgbPreset {
+        name: String,
+        device_id: String,
+    },
     /// Enable/disable motherboard ARGB sync for a device.
     SetMbRgbSync {
         device_id: String,

--- a/crates/lianli-shared/src/rgb.rs
+++ b/crates/lianli-shared/src/rgb.rs
@@ -307,6 +307,21 @@ impl Default for RgbAppConfig {
     }
 }
 
+/// A single zone's colors within a named RGB preset.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RgbPresetZone {
+    pub zone: u8,
+    pub colors: Vec<[u8; 3]>,
+}
+
+/// A named per-LED color preset that can be saved to config and applied later.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RgbPreset {
+    pub name: String,
+    pub device_id: String,
+    pub zones: Vec<RgbPresetZone>,
+}
+
 /// Information about an RGB zone, reported to GUI/OpenRGB.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RgbZoneInfo {


### PR DESCRIPTION
## Summary

Adds the ability to set individual LED colors on any fan/zone and persist named per-LED color configurations across daemon restarts.

The existing `SetRgbDirect` endpoint requires the caller to send a complete color array for the entire zone on every update. This works for OpenRGB (which maintains its own state) but is impractical for a GUI color picker or script that wants to paint one LED at a time. These additions fill that gap.

## New IPC endpoints

| Request | Description |
|---------|-------------|
| `SetLedColor { device_id, zone, led_index, color }` | Set a single LED by index within a fan zone. Reads the current zone buffer, patches one entry, and sends the updated frame. Bounds-checked against the zone's LED count. |
| `SaveRgbPreset { name, device_id }` | Snapshot all zone colors from the live RGB state buffer into a named preset persisted in `config.json`. Upserts by name. |
| `DeleteRgbPreset { name }` | Remove a saved preset by name. |
| `ListRgbPresets` | Return all saved presets from config. |
| `ApplyRgbPreset { name }` | Load a preset and push its per-zone colors to the device via `set_direct_colors`. |

### Addressing model

```
device_id  →  zone (= fan index)  →  led_index (= LED within that fan)
```

- **Regular fans:** zone 0 = fan 1, zone 1 = fan 2, ..., up to `fan_count`
- **AIO (HydroShift):** zone 0 = pump head (24 LEDs), zone 1+ = fans
- **RGB-only (Strimer/LC217):** zone 0 = entire strip

Each zone has `leds_per_fan` LEDs (24 for CL, 26 for TL, 40 for SLV3, etc.).

### Example: paint fan 2, LED 7 green on a wireless SL group

```json
{
  "method": "SetLedColor",
  "params": {
    "device_id": "wireless:c8:b4:ef:62:32:e1",
    "zone": 1,
    "led_index": 7,
    "color": [0, 255, 0]
  }
}
```

### Example: save and restore a layout

```json
{ "method": "SaveRgbPreset", "params": { "name": "My Layout", "device_id": "wireless:c8:b4:ef:62:32:e1" } }

// Later (even after daemon restart):
{ "method": "ApplyRgbPreset", "params": { "name": "My Layout" } }
```

## New types

```rust
pub struct RgbPresetZone {
    pub zone: u8,
    pub colors: Vec<[u8; 3]>,
}

pub struct RgbPreset {
    pub name: String,
    pub device_id: String,
    pub zones: Vec<RgbPresetZone>,
}
```

## Config persistence

`AppConfig` gains `rgb_presets: Vec<RgbPreset>` with `#[serde(default)]` — existing configs unaffected. Presets are written to `~/.config/lianli/config.json` alongside fan curves and LCD settings.

## Files changed

| File | Change |
|------|--------|
| `crates/lianli-shared/src/rgb.rs` | `RgbPresetZone` and `RgbPreset` structs |
| `crates/lianli-shared/src/config.rs` | `rgb_presets` field on `AppConfig` + Default |
| `crates/lianli-shared/src/ipc.rs` | 5 new `IpcRequest` variants |
| `crates/lianli-daemon/src/rgb_controller.rs` | `get_zone_colors()` and `get_all_zone_colors()` read methods |
| `crates/lianli-daemon/src/ipc_server.rs` | Handlers for all 5 new endpoints |

## Design notes

- **`SetLedColor` is a read-modify-write**: it reads the zone's current LED buffer, patches one index, then calls `set_direct_colors` to send the full frame. For bulk painting, callers should prefer `SetRgbDirect` with the full color array.

- **Presets are device-scoped**: a preset stores the `device_id` it was captured from. Applying it to a different device would fail at the `set_direct_colors` lookup — zone counts and LED counts differ between device types, so cross-device application would produce garbled colors.

- **No GUI changes in this PR**: the IPC layer is the foundation. A visual per-LED editor is a natural follow-up.

## Test plan

- [ ] Start daemon, connect wireless fan group
- [ ] `SetLedColor` with valid zone/index → LED changes color, other LEDs unaffected
- [ ] `SetLedColor` with out-of-range `led_index` → error response with LED count
- [ ] `SaveRgbPreset` after painting LEDs → preset appears in `config.json`
- [ ] Restart daemon → `ListRgbPresets` still returns the preset
- [ ] `ApplyRgbPreset` → device LEDs restore to saved colors
- [ ] `DeleteRgbPreset` → preset removed, subsequent Apply fails
- [ ] `SaveRgbPreset` with same name → upserts, not duplicates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Set an individual LED’s color by device, zone, and index for precise control.
  * Save current LED configurations as named, device-scoped presets.
  * List, delete, and apply saved RGB presets to restore stored color layouts across device zones.

* **Bug Fixes / Reliability**
  * Better validation and clearer error feedback for missing controllers, missing zones, out-of-range indices, and write failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->