### PR TITLE
Fixed set fan speed and pump pwm errors, small improvements

### DIFF
--- a/crates/lianli-devices/src/galahad2_trinity.rs
+++ b/crates/lianli-devices/src/galahad2_trinity.rs
@@ -292,10 +292,13 @@ impl Galahad2TrinityController {
     }
 }
 
+fn duty_to_percent(duty: u8) -> u8 {
+    ((duty as u32 * 100) / 255) as u8
+}
+
 impl FanDevice for Galahad2TrinityController {
     fn set_fan_speed(&self, _slot: u8, duty: u8) -> Result<()> {
-        // Single fan channel, duty 0-100%
-        let pwm = duty.min(100);
+        let pwm = duty_to_percent(duty);
         self.send_a_command(CMD_SET_FAN_PWM, &[0x00, pwm])?;
         debug!("Set fan PWM to {pwm}%");
         Ok(())
@@ -325,7 +328,7 @@ impl FanDevice for Galahad2TrinityController {
     }
 
     fn set_pump_speed(&self, duty: u8) -> Result<()> {
-        let pwm = duty.min(100);
+        let pwm = duty_to_percent(duty);
         self.send_a_command(CMD_SET_PUMP_PWM, &[0x00, pwm])?;
         debug!("Set pump PWM to {pwm}%");
         Ok(())

--- a/crates/lianli-devices/src/hydroshift_lcd.rs
+++ b/crates/lianli-devices/src/hydroshift_lcd.rs
@@ -761,16 +761,21 @@ impl AioLcdRgbController {
     }
 
     fn send_rgb_command(&self, cmd: u8, data: &[u8]) -> Result<()> {
+        let max_payload = A_PACKET_SIZE - A_HEADER_LEN;
+        if data.len() > max_payload {
+            bail!(
+                "AIO LCD RGB: command {cmd:#04x} payload too large ({} > {max_payload})",
+                data.len()
+            );
+        }
         let mut pkt = [0u8; A_PACKET_SIZE];
         pkt[0] = REPORT_ID_A;
         pkt[1] = cmd;
         pkt[5] = data.len() as u8;
-        let copy_len = data.len().min(58);
-        pkt[A_HEADER_LEN..A_HEADER_LEN + copy_len].copy_from_slice(&data[..copy_len]);
+        pkt[A_HEADER_LEN..A_HEADER_LEN + data.len()].copy_from_slice(data);
 
         let mut dev = self.device.lock();
         dev.write(&pkt).context("AIO LCD RGB: write")?;
-        // Command does not sent a response, as such finished
         Ok(())
     }
 }

--- a/crates/lianli-devices/src/hydroshift_lcd.rs
+++ b/crates/lianli-devices/src/hydroshift_lcd.rs
@@ -303,39 +303,40 @@ impl HydroShiftLcdController {
         Ok(data_len == 1 && buf[B_HEADER_LEN] == 0)
     }
 
-    /// Reset device (A-command 0x8E). Returns true on success.
+    /// Reset device (A-command 0x8E). Device may emit a transient status byte `2`
+    /// before the final `1` — both must be drained.
     pub fn reset_device(&self) -> bool {
-        let mut dev = self.device.lock();
-        let _ = match self.write_a_command_internal(&mut *dev, CMD_RESET_DEVICE, &[]) {
-            Ok(_) => true,
-            Err(e) => {
-                warn!("AIO LCD: reset device failed: {}", e);
-                return false;
-            }
-        };
+        const MAX_ATTEMPTS: u32 = 20;
 
-        // Loop reading until we get a firmware response, discarding stale responses
-        // from a previous session (e.g. 0x81 handshake, 0x8E reset) as they arrive.
+        let mut dev = self.device.lock();
+        if let Err(e) = self.write_a_command_internal(&mut *dev, CMD_RESET_DEVICE, &[]) {
+            warn!("AIO LCD: reset device failed: {e}");
+            return false;
+        }
+
         let mut buf = [0u8; A_PACKET_SIZE];
-        loop {
+        for _ in 0..MAX_ATTEMPTS {
             let n = match dev.read_timeout(&mut buf, 1000) {
-                Ok(written) => written,
+                Ok(n) => n,
                 Err(e) => {
-                    warn!("AIO LCD: reset device - read response 1: {}", e);
+                    warn!("AIO LCD: reset device read failed: {e}");
                     return false;
                 }
             };
-            debug!(
-                "Reset device:  response {n} bytes, raw={:02x?}",
-                &buf[..n.min(20)]
-            );
-            if buf[1] == CMD_RESET_DEVICE && buf[6]==1 {
-                debug!("device-reset successful");
-                return true;
+            if n == 0 {
+                warn!("AIO LCD: reset device timed out");
+                return false;
             }
-            // If we have buf[1] == CMD_RESET_DEVICE and buf[6]==2, then the LCD tells us that it needs more time to complete the reset
-        };
-
+            if n > A_HEADER_LEN && buf[1] == CMD_RESET_DEVICE {
+                match buf[A_HEADER_LEN] {
+                    1 => return true,
+                    2 => continue,
+                    _ => {}
+                }
+            }
+        }
+        warn!("AIO LCD: reset device did not converge after {MAX_ATTEMPTS} reads");
+        false
     }
 
     /// Check LCD availability and attempt recovery if unavailable.
@@ -410,7 +411,7 @@ impl HydroShiftLcdController {
 
     fn send_a_command(&self, cmd: u8, data: &[u8], timeout_ms: i32) -> Result<Vec<u8>> {
         let mut dev = self.device.lock();
-        self.write_a_command_internal(&mut *dev,cmd,data)?;
+        self.write_a_command_internal(&mut *dev, cmd, data)?;
 
         let mut buf = [0u8; A_PACKET_SIZE];
         let n = dev
@@ -437,18 +438,24 @@ impl HydroShiftLcdController {
         self.write_a_command_internal(&mut *dev, cmd, data)
     }
 
-    fn write_a_command_internal(&self, dev: &mut HidBackend,cmd: u8, data: &[u8]) -> Result<()> {
+    fn write_a_command_internal(&self, dev: &mut HidBackend, cmd: u8, data: &[u8]) -> Result<()> {
+        let max_payload = A_PACKET_SIZE - A_HEADER_LEN;
+        if data.len() > max_payload {
+            bail!(
+                "AIO LCD: A-command {cmd:#04x} payload too large ({} > {max_payload})",
+                data.len()
+            );
+        }
         let mut pkt = [0u8; A_PACKET_SIZE];
         pkt[0] = REPORT_ID_A;
         pkt[1] = cmd;
         pkt[5] = data.len() as u8;
-        let copy_len = data.len().min(58);
-        pkt[A_HEADER_LEN..A_HEADER_LEN + copy_len].copy_from_slice(&data[..copy_len]);
+        pkt[A_HEADER_LEN..A_HEADER_LEN + data.len()].copy_from_slice(data);
 
         let written = dev.write(&pkt).context("AIO LCD: write A-command")?;
         debug!(
             "A-cmd {cmd:#04x}: wrote {written} bytes, payload={:02x?}",
-            &data[..copy_len]
+            data
         );
         Ok(())
     }
@@ -501,9 +508,13 @@ impl HydroShiftLcdController {
     }
 }
 
+fn duty_to_percent(duty: u8) -> u8 {
+    ((duty as u32 * 100) / 255) as u8
+}
+
 impl FanDevice for HydroShiftLcdController {
     fn set_fan_speed(&self, _slot: u8, duty: u8) -> Result<()> {
-        let pwm = duty.min(100);
+        let pwm = duty_to_percent(duty);
         self.write_a_command(CMD_SET_FAN_PWM, &[0x00, pwm])?;
         debug!("Set fan PWM to {pwm}%");
         Ok(())
@@ -533,8 +544,7 @@ impl FanDevice for HydroShiftLcdController {
     }
 
     fn set_pump_speed(&self, duty: u8) -> Result<()> {
-        // Duty ranges from 0 to 255, but pump speed ranges from 0 to 100
-        let pwm= (duty as i32*100/255).clamp(0,100) as u8;
+        let pwm = duty_to_percent(duty);
         self.write_a_command(CMD_SET_PUMP_PWM, &[0x00, pwm])?;
         debug!("Set pump PWM to {pwm}%");
         Ok(())

--- a/crates/lianli-devices/src/hydroshift_lcd.rs
+++ b/crates/lianli-devices/src/hydroshift_lcd.rs
@@ -39,9 +39,15 @@ const C_MAX_PAYLOAD: usize = C_PACKET_SIZE - C_HEADER_LEN; // 501
 const READ_TIMEOUT_MS: i32 = 1000;
 const INIT_READ_TIMEOUT_MS: i32 = 3000;
 
-// A-Commands
+// List of all known A-Commands. Currently not used A-Commands are prefixed by _
 const CMD_HANDSHAKE: u8 = 0x81;
+// 0x82 might be CMD_GET_PUMP_LIGHT
+const CMD_SET_PUMP_LIGHT: u8 = 0x83;
+const _CMD_GET_FANLIGHT_INFO: u8 = 0x84;
+const CMD_SET_FAN_LIGHT: u8 = 0x85;
 const CMD_GET_FIRMWARE: u8 = 0x86;
+const _CMD_GET_SERIAL_NUMBER: u8 = 0x88;
+const _CMD_SET_SERIAL_NUMBER: u8 = 0x89;
 const CMD_SET_PUMP_PWM: u8 = 0x8A;
 const CMD_SET_FAN_PWM: u8 = 0x8B;
 
@@ -180,7 +186,7 @@ impl HydroShiftLcdController {
         match self.read_firmware_internal(INIT_READ_TIMEOUT_MS) {
             Ok(fw) => {
                 if let Some(ver) = parse_firmware_version(&fw) {
-                    if ver > (1, 2) {
+                    if ver > (1, 3) {
                         info!("  Firmware: {fw} (using 512-byte frame mode)");
                         self.use_c_command = true;
                     } else {
@@ -241,8 +247,8 @@ impl HydroShiftLcdController {
         };
 
         debug!(
-            "Handshake: fan={}rpm pump={}rpm temp={:.1}°C",
-            hs.fan_rpm, hs.pump_rpm, hs.coolant_temp
+            "Handshake: fan={}rpm pump={}rpm temp_valid={} temp={:.1}°C",
+            hs.fan_rpm, hs.pump_rpm, hs.temp_valid, hs.coolant_temp
         );
         self.last_handshake = Some(hs.clone());
         Ok(hs)
@@ -299,13 +305,37 @@ impl HydroShiftLcdController {
 
     /// Reset device (A-command 0x8E). Returns true on success.
     pub fn reset_device(&self) -> bool {
-        match self.send_a_command(CMD_RESET_DEVICE, &[], READ_TIMEOUT_MS) {
-            Ok(resp) if resp.len() > A_HEADER_LEN && resp[1] == CMD_RESET_DEVICE => {
-                let data_len = resp[5] as usize;
-                data_len == 1 && resp[A_HEADER_LEN] == 1
+        let mut dev = self.device.lock();
+        let _ = match self.write_a_command_internal(&mut *dev, CMD_RESET_DEVICE, &[]) {
+            Ok(_) => true,
+            Err(e) => {
+                warn!("AIO LCD: reset device failed: {}", e);
+                return false;
             }
-            _ => false,
-        }
+        };
+
+        // Loop reading until we get a firmware response, discarding stale responses
+        // from a previous session (e.g. 0x81 handshake, 0x8E reset) as they arrive.
+        let mut buf = [0u8; A_PACKET_SIZE];
+        loop {
+            let n = match dev.read_timeout(&mut buf, 1000) {
+                Ok(written) => written,
+                Err(e) => {
+                    warn!("AIO LCD: reset device - read response 1: {}", e);
+                    return false;
+                }
+            };
+            debug!(
+                "Reset device:  response {n} bytes, raw={:02x?}",
+                &buf[..n.min(20)]
+            );
+            if buf[1] == CMD_RESET_DEVICE && buf[6]==1 {
+                debug!("device-reset successful");
+                return true;
+            }
+            // If we have buf[1] == CMD_RESET_DEVICE and buf[6]==2, then the LCD tells us that it needs more time to complete the reset
+        };
+
     }
 
     /// Check LCD availability and attempt recovery if unavailable.
@@ -337,11 +367,7 @@ impl HydroShiftLcdController {
     fn read_firmware_internal(&self, timeout_ms: i32) -> Result<String> {
         let mut dev = self.device.lock();
 
-        let mut pkt = [0u8; A_PACKET_SIZE];
-        pkt[0] = REPORT_ID_A;
-        pkt[1] = CMD_GET_FIRMWARE;
-        let written = dev.write(&pkt).context("AIO LCD: write firmware request")?;
-        debug!("firmware request: wrote {written} bytes");
+        self.write_a_command_internal(&mut *dev, CMD_GET_FIRMWARE, &[])?;
 
         // Loop reading until we get a firmware response, discarding stale responses
         // from a previous session (e.g. 0x81 handshake, 0x8E reset) as they arrive.
@@ -383,19 +409,8 @@ impl HydroShiftLcdController {
     }
 
     fn send_a_command(&self, cmd: u8, data: &[u8], timeout_ms: i32) -> Result<Vec<u8>> {
-        let mut pkt = [0u8; A_PACKET_SIZE];
-        pkt[0] = REPORT_ID_A;
-        pkt[1] = cmd;
-        pkt[5] = data.len() as u8;
-        let copy_len = data.len().min(58);
-        pkt[A_HEADER_LEN..A_HEADER_LEN + copy_len].copy_from_slice(&data[..copy_len]);
-
         let mut dev = self.device.lock();
-        let written = dev.write(&pkt).context("AIO LCD: write A-command")?;
-        debug!(
-            "A-cmd {cmd:#04x}: wrote {written} bytes, payload={:02x?}",
-            &data[..copy_len]
-        );
+        self.write_a_command_internal(&mut *dev,cmd,data)?;
 
         let mut buf = [0u8; A_PACKET_SIZE];
         let n = dev
@@ -412,6 +427,30 @@ impl HydroShiftLcdController {
         }
 
         Ok(buf[..n].to_vec())
+    }
+
+    /// General write_a_command method in case self.device is not locked:
+    /// It writes an A-Command
+    /// It locks the HidBackend and frees it afterwards. Do NOT call this method if the device is already locked!
+    pub fn write_a_command(&self, cmd: u8, data: &[u8]) -> Result<()> {
+        let mut dev = self.device.lock();
+        self.write_a_command_internal(&mut *dev, cmd, data)
+    }
+
+    fn write_a_command_internal(&self, dev: &mut HidBackend,cmd: u8, data: &[u8]) -> Result<()> {
+        let mut pkt = [0u8; A_PACKET_SIZE];
+        pkt[0] = REPORT_ID_A;
+        pkt[1] = cmd;
+        pkt[5] = data.len() as u8;
+        let copy_len = data.len().min(58);
+        pkt[A_HEADER_LEN..A_HEADER_LEN + copy_len].copy_from_slice(&data[..copy_len]);
+
+        let written = dev.write(&pkt).context("AIO LCD: write A-command")?;
+        debug!(
+            "A-cmd {cmd:#04x}: wrote {written} bytes, payload={:02x?}",
+            &data[..copy_len]
+        );
+        Ok(())
     }
 
     fn send_b_command(&self, cmd: u8, data: &[u8]) -> Result<()> {
@@ -456,9 +495,7 @@ impl HydroShiftLcdController {
                 break;
             }
         }
-
-        let mut buf = [0u8; 512];
-        let _ = dev.read_timeout(&mut buf, 20);
+        // command does not send any response, as such, finished.
 
         Ok(())
     }
@@ -467,7 +504,7 @@ impl HydroShiftLcdController {
 impl FanDevice for HydroShiftLcdController {
     fn set_fan_speed(&self, _slot: u8, duty: u8) -> Result<()> {
         let pwm = duty.min(100);
-        self.send_a_command(CMD_SET_FAN_PWM, &[0x00, pwm], READ_TIMEOUT_MS)?;
+        self.write_a_command(CMD_SET_FAN_PWM, &[0x00, pwm])?;
         debug!("Set fan PWM to {pwm}%");
         Ok(())
     }
@@ -496,8 +533,9 @@ impl FanDevice for HydroShiftLcdController {
     }
 
     fn set_pump_speed(&self, duty: u8) -> Result<()> {
-        let pwm = duty.min(100);
-        self.send_a_command(CMD_SET_PUMP_PWM, &[0x00, pwm], READ_TIMEOUT_MS)?;
+        // Duty ranges from 0 to 255, but pump speed ranges from 0 to 100
+        let pwm= (duty as i32*100/255).clamp(0,100) as u8;
+        self.write_a_command(CMD_SET_PUMP_PWM, &[0x00, pwm])?;
         debug!("Set pump PWM to {pwm}%");
         Ok(())
     }
@@ -644,8 +682,6 @@ fn parse_firmware_version(fw: &str) -> Option<(u32, u32)> {
     None
 }
 
-const CMD_SET_PUMP_LIGHT: u8 = 0x83;
-const CMD_SET_FAN_LIGHT: u8 = 0x85;
 const FAN_LED_COUNT: u16 = 24;
 
 pub struct AioLcdRgbController {
@@ -714,7 +750,7 @@ impl AioLcdRgbController {
         Ok(())
     }
 
-    fn send_rgb_command(&self, cmd: u8, data: &[u8]) -> Result<Vec<u8>> {
+    fn send_rgb_command(&self, cmd: u8, data: &[u8]) -> Result<()> {
         let mut pkt = [0u8; A_PACKET_SIZE];
         pkt[0] = REPORT_ID_A;
         pkt[1] = cmd;
@@ -724,15 +760,8 @@ impl AioLcdRgbController {
 
         let mut dev = self.device.lock();
         dev.write(&pkt).context("AIO LCD RGB: write")?;
-
-        let mut buf = [0u8; A_PACKET_SIZE];
-        let n = dev
-            .read_timeout(&mut buf, READ_TIMEOUT_MS)
-            .context("AIO LCD RGB: read")?;
-        if n == 0 {
-            bail!("AIO LCD RGB: no response to {cmd:#04x}");
-        }
-        Ok(buf[..n].to_vec())
+        // Command does not sent a response, as such finished
+        Ok(())
     }
 }
 

--- a/crates/lianli-devices/src/traits.rs
+++ b/crates/lianli-devices/src/traits.rs
@@ -3,6 +3,9 @@ use lianli_shared::rgb::{RgbEffect, RgbMode, RgbScope, RgbZoneInfo};
 use lianli_shared::screen::ScreenInfo;
 
 /// A device that can control fan speeds.
+///
+/// `duty` values passed to `set_fan_speed`, `set_fan_speeds`, and `set_pump_speed`
+/// are raw PWM in the range 0-255. Implementations scale to device-native units.
 pub trait FanDevice: Send + Sync {
     fn set_fan_speed(&self, slot: u8, duty: u8) -> Result<()>;
     fn set_fan_speeds(&self, duties: &[u8]) -> Result<()>;
@@ -37,7 +40,7 @@ pub trait FanDevice: Send + Sync {
         false
     }
 
-    /// Set pump speed (0-100% duty). Only for devices where `has_pump_control()` is true.
+    /// Only for devices where `has_pump_control()` is true.
     fn set_pump_speed(&self, _duty: u8) -> Result<()> {
         anyhow::bail!("Pump speed control not supported by this device")
     }

--- a/crates/lianli-gui/ui/windows/template_editor.slint
+++ b/crates/lianli-gui/ui/windows/template_editor.slint
@@ -325,16 +325,25 @@ export component TemplateEditorWindow inherits Window {
             Rectangle {
                 width: 5px;
                 background: gray;
-                
+
                 splitter-touch := TouchArea {
                     mouse-cursor: ew-resize;
-                    
+                    property <length> drag-start-width: 0px;
+
+                    pointer-event(ev) => {
+                        if (ev.button == PointerEventButton.left && ev.kind == PointerEventKind.down) {
+                            self.drag-start-width = root.right-width;
+                        }
+                    }
+
                     moved => {
                         if (self.pressed) {
-                            root.right-width -= self.mouse-x - self.pressed-x;
-                            
-                            if (root.right-width < 554px) { root.right-width = 554px; } // Right pane should be 554px min.
-                            else if (root.right-width > root.width - 240px - 100px) {root.right-width = root.width - 240px - 100px;} // If right pane is too large (left and middle pane would be too small), then limit it.
+                            root.right-width = self.drag-start-width - (self.mouse-x - self.pressed-x);
+                            if (root.right-width < 554px) {
+                                root.right-width = 554px;
+                            } else if (root.right-width > root.width - 240px - 5px - 100px) {
+                                root.right-width = root.width - 240px - 5px - 100px;
+                            }
                         }
                     }
                 }

--- a/crates/lianli-gui/ui/windows/template_editor.slint
+++ b/crates/lianli-gui/ui/windows/template_editor.slint
@@ -330,8 +330,8 @@ export component TemplateEditorWindow inherits Window {
                     mouse-cursor: ew-resize;
                     property <length> drag-start-width: 0px;
 
-                    pointer-event(ev) => {
-                        if (ev.button == PointerEventButton.left && ev.kind == PointerEventKind.down) {
+                    changed pressed => {
+                        if (self.pressed) {
                             self.drag-start-width = root.right-width;
                         }
                     }

--- a/crates/lianli-gui/ui/windows/template_editor.slint
+++ b/crates/lianli-gui/ui/windows/template_editor.slint
@@ -19,6 +19,7 @@ export component TemplateEditorWindow inherits Window {
     background: Palette.background;
     icon: @image-url("../../../../assets/icons/icon.png");
 
+    in-out property <length> right-width: 554px;
     in-out property <string> template-id: "";
     in-out property <string> template-name: "Untitled";
     in-out property <int> base-width: 480;
@@ -240,7 +241,7 @@ export component TemplateEditorWindow inherits Window {
 
         HorizontalLayout {
             Rectangle {
-                width: 220px;
+                width: 240px;
                 background: Theme.sidebar-background;
                 border-width: 0px;
                 border-color: Theme.border;
@@ -321,8 +322,26 @@ export component TemplateEditorWindow inherits Window {
                 }
             }
 
+            Rectangle {
+                width: 5px;
+                background: gray;
+                
+                splitter-touch := TouchArea {
+                    mouse-cursor: ew-resize;
+                    
+                    moved => {
+                        if (self.pressed) {
+                            root.right-width -= self.mouse-x - self.pressed-x;
+                            
+                            if (root.right-width < 554px) { root.right-width = 554px; } // Right pane should be 554px min.
+                            else if (root.right-width > root.width - 240px - 100px) {root.right-width = root.width - 240px - 100px;} // If right pane is too large (left and middle pane would be too small), then limit it.
+                        }
+                    }
+                }
+            }
+
             PropertiesPanel {
-                width: 554px;
+                width: root.right-width;
                 selected-index: root.selected-index;
                 selected-widget: root.selected-widget;
                 selected-ranges: root.selected-ranges;

--- a/crates/lianli-shared/src/systeminfo.rs
+++ b/crates/lianli-shared/src/systeminfo.rs
@@ -131,7 +131,7 @@ impl SysSensor {
                 }
             }
 
-            let sleep_dur = Duration::from_millis(333).saturating_sub(start_time.elapsed());
+            let sleep_dur = Duration::from_millis(100).saturating_sub(start_time.elapsed());
 
             thread::sleep(sleep_dur);
         }


### PR DESCRIPTION
Another small PR:

As mentioned in an issue my system did not work correctly: All sensor updates were very slow. This was caused by the set fan speed and set pump speed methods which always returned an error because they did not receive any response within 1 sec. This of course blocked all LCD updates, so the LCD updates were performed once per second.

When looking at the L-Connect-3 software I found out that these set-pwm-commands are fire-and-forget commands: They do not produce any result, as such, of course each read ran into a timeout, because there simply was nothing to read. I introduced new method write_a_command to just write a command in addition to that send_a_command which writes and reads a response.

Additionally I improved the device_reset method: Although even the L-Connect software does not handle it correctly (which i think is just an error): A device reset command sometimes returns a payload of 1 byte with content "2": This result MUST be read and one MUST continue to read, as soon after that it returns another result with a payload of 1 byte with content "1". The L-Connect software on Windows just reads a single result and returns true, if the payload contains the byte "1" and false otherwise. But if the payload byte is "2" the L-Connect software returns (with "false") and gets out of sync, as following commands will read that other device-reset-response with payload byte "1".
I did not find out when and why the device reset command returns payload byte "2", but sometimes it does that. But it always returns a response with payload byte "1" finally.

I added a split pane to the template editor: When I resize the template editor it keeps the left and right panels the same size and just increases the width of the middle pane. But, some sensor names (especially those GPU sensor names which are prefixed by a very long graphics card name) are so long that one cannot determine what it is as the combobox is too small. Using that split pane I can now resize the right pane so I can see the complete sensor name.

Feel free to take from this PR what you actually like.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Template editor properties panel is now resizable via a draggable splitter.
  - Device controls expanded with additional commands and support for 0–255 PWM duty values.

* **Bug Fixes**
  - More reliable device reset and handshake handling.

* **Performance**
  - System monitoring refreshes CPU usage more frequently.

* **Documentation**
  - Clarified fan/pump duty parameter semantics (now documented as raw 0–255 PWM).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->