### PR TITLE
Send master-clock heartbeat (RF 0x14) to prevent fan RPM spikes

### DIFF
--- a/crates/lianli-daemon/src/fan_controller.rs
+++ b/crates/lianli-daemon/src/fan_controller.rs
@@ -71,7 +71,9 @@ fn fan_control_thread(
     all_sensors: &[SensorInfo],
 ) {
     let update_interval = Duration::from_millis(config.update_interval_ms);
+    let heartbeat_interval = Duration::from_secs(1);
     let mut last_update = Instant::now() - update_interval;
+    let mut last_heartbeat = Instant::now() - heartbeat_interval;
 
     // Wait briefly for wireless discovery if we have wireless
     if let Some(ref w) = wireless {
@@ -148,6 +150,20 @@ fn fan_control_thread(
 
     while !stop_flag.load(Ordering::Relaxed) {
         let now = Instant::now();
+
+        // Broadcast master clock heartbeat (RF 0x14) once per second regardless
+        // of the user-configured fan update interval. Without this packet the
+        // fan firmware appears to enter an autonomous fallback that briefly
+        // spikes RPM. L-Connect sends this every second.
+        if now.duration_since(last_heartbeat) >= heartbeat_interval {
+            if let Some(ref w) = wireless {
+                if let Err(err) = w.send_master_clock() {
+                    debug!("master clock send failed: {err}");
+                }
+            }
+            last_heartbeat = now;
+        }
+
         let since_last = now.duration_since(last_update);
         if since_last < update_interval {
             thread::sleep(Duration::from_millis(100));

--- a/crates/lianli-devices/src/wireless/controller.rs
+++ b/crates/lianli-devices/src/wireless/controller.rs
@@ -2,7 +2,7 @@ use super::discovery::{poll_and_discover, DiscoveredDevice};
 use super::transport::{open_any, with_transport_recovery};
 use super::{
     CMD_RESET, CMD_RX_LCD_MODE, CMD_RX_QUERY_34, CMD_RX_QUERY_37, CMD_VIDEO_START, RF_CHUNKS,
-    RF_CHUNK_SIZE, RX_IDS, TX_IDS, USB_CMD_GET_MAC, USB_CMD_SEND_RF,
+    RF_CHUNK_SIZE, RF_DATA_SIZE, RF_SELECT, RX_IDS, TX_IDS, USB_CMD_GET_MAC, USB_CMD_SEND_RF,
 };
 use anyhow::{bail, Context, Result};
 use lianli_transport::usb::{UsbTransport, USB_TIMEOUT};
@@ -293,6 +293,44 @@ impl WirelessController {
         Ok(())
     }
 
+    /// Broadcast a "master clock" sync packet (RF sub-command 0x14) carrying
+    /// 220 bytes of CPU/GPU info. L-Connect sends this once per second; missing
+    /// it appears to put the fan firmware into an autonomous fallback that
+    /// occasionally spikes RPM. We send all-zero info bytes — the firmware
+    /// only seems to need the heartbeat itself.
+    pub fn send_master_clock(&self) -> Result<()> {
+        let tx = self.tx.as_ref().context("TX device not connected")?;
+        let master_mac = *self.master_mac.lock();
+        let master_ch = *self.master_channel.lock();
+
+        let mut rf_data = vec![0u8; RF_DATA_SIZE];
+        rf_data[0] = RF_SELECT;
+        rf_data[1] = 0x14;
+        rf_data[8..14].copy_from_slice(&master_mac);
+        // rf_data[14..234] = cpuInfoParam (220 bytes, leave zero)
+
+        with_transport_recovery(tx, &TX_IDS, "TX", |handle| {
+            for chunk_idx in 0..RF_CHUNKS as u8 {
+                let mut packet = vec![0u8; 64];
+                packet[0] = USB_CMD_SEND_RF;
+                packet[1] = chunk_idx;
+                packet[2] = master_ch;
+                packet[3] = 0xFF;
+
+                let start = chunk_idx as usize * RF_CHUNK_SIZE;
+                let end = start + RF_CHUNK_SIZE;
+                packet[4..64].copy_from_slice(&rf_data[start..end]);
+
+                handle
+                    .write(&packet, USB_TIMEOUT)
+                    .context("sending master clock packet")?;
+                thread::sleep(Duration::from_millis(1));
+            }
+            Ok(())
+        })?;
+        Ok(())
+    }
+
     pub fn send_rx_sequence(&self) -> Result<()> {
         if let Some(rx) = &self.rx {
             for (cmd, capture) in [
@@ -442,9 +480,11 @@ impl WirelessController {
     }
 
     pub fn stop(&mut self) {
-        self.poll_stop.store(true, Ordering::SeqCst);
-        if let Some(handle) = self.poll_thread.take() {
-            let _ = handle.join();
+        if self.poll_thread.is_some() {
+            self.poll_stop.store(true, Ordering::SeqCst);
+            if let Some(handle) = self.poll_thread.take() {
+                let _ = handle.join();
+            }
         }
         self.tx.take();
         self.rx.take();


### PR DESCRIPTION
  L-Connect 3 broadcasts a 240-byte master-clock packet on the master
  channel (rx=0xFF) once per second, regardless of any user action:

    RF_SELECT (0x12), 0x14, [unused], master_mac (6), cpu_info (220)

  Without it, the wireless fan firmware appears to enter an autonomous
  fallback mode that periodically drives RPM to physically higher values
  (observed: ~2x baseline RPM, sustained 5-10s, decaying back) on
  SL-Infinity fans, even though the daemon's commanded PWM stays
  constant and the device echoes that PWM in current_pwm.

  Reverse-engineered from lianli.slv3.dll's SyncMasterClock() in
  L-Connect 3 v0.5.5. The 220-byte cpu_info payload is documented in
  the function comment as a future enhancement: populating it would let
  LCD-equipped fans render CPU/GPU info via firmware as an alternative
  to the daemon's frame-streaming pipeline. We send zeros; the firmware
  only seems to need the heartbeat itself.

  Decoupled from FanConfig.update_interval_ms so users with infrequent
  PWM updates (e.g. 10s) still get the keepalive at 1Hz.

  Drive-by: fix WirelessController::stop() to no-op when poll_thread is
  None. Drop on a clone (which sets poll_thread = None in Clone) was
  unconditionally setting the shared poll_stop atomic, killing the real
  poll thread whenever a clone went out of scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added periodic master clock synchronization broadcast from the fan controller to wireless devices, enabling improved timing coordination across the system.

* **Bug Fixes**
  * Enhanced device polling thread shutdown safety with additional guard checks during termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->