### PR TITLE
Keep wireless fan PWM refreshed

### DIFF
--- a/crates/lianli-devices/src/wireless/fan_speed.rs
+++ b/crates/lianli-devices/src/wireless/fan_speed.rs
@@ -4,9 +4,22 @@ use super::fan_type::WirelessFanType;
 use super::{RF_CHUNKS, RF_CHUNK_SIZE, RF_DATA_SIZE, RF_PWM_CMD, RF_SELECT, USB_CMD_SEND_RF};
 use anyhow::{Context, Result};
 use lianli_transport::usb::USB_TIMEOUT;
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::sync::OnceLock;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tracing::debug;
+
+// Wireless fans can revert to hardware-default speed if PWM traffic goes quiet.
+// Keep sending steady-state targets periodically even when the reported PWM
+// already matches the requested value.
+const PWM_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(1);
+
+fn pwm_last_sent() -> &'static Mutex<HashMap<[u8; 6], Instant>> {
+    static LAST_SENT: OnceLock<Mutex<HashMap<[u8; 6], Instant>>> = OnceLock::new();
+    LAST_SENT.get_or_init(|| Mutex::new(HashMap::new()))
+}
 
 impl WirelessController {
     /// Set fan PWM values for a specific device identified by MAC address.
@@ -56,7 +69,12 @@ impl WirelessController {
             .any(|(target, reported)| {
                 target.abs_diff(*reported) > 5 || (*target <= 10 && *reported != *target)
             });
-        if !needs_send {
+        let now = Instant::now();
+        let force_keepalive = pwm_last_sent()
+            .lock()
+            .get(mac)
+            .map_or(true, |t| now.duration_since(*t) >= PWM_KEEPALIVE_INTERVAL);
+        if !needs_send && !force_keepalive {
             return Ok(());
         }
 
@@ -89,6 +107,8 @@ impl WirelessController {
             }
             Ok(())
         })?;
+
+        pwm_last_sent().lock().insert(*mac, Instant::now());
 
         debug!(
             "Set fan PWM for {} (rx={}, ch={}): {:?}",


### PR DESCRIPTION
## Summary
- keep sending wireless fan PWM packets periodically even when reported PWM already matches the requested target
- preserve immediate sends when target and reported PWM differ
- prevent wireless fans from falling back to hardware-default/full-speed behavior when steady-state PWM traffic goes quiet

## Background
On Lian Li SL-INF wireless fans, I observed frequent short max-RPM spikes while fan control was otherwise targeting a low steady PWM. The controller would report the expected PWM/RPM most of the time, but because the daemon skipped writes when the reported PWM matched the target, it could stop sending fan speed packets during steady state. These fans appear to treat that silence as a loss of active fan control and briefly fall back to their hardware default, which is effectively full speed.

## Fix
Track the last successful PWM send per wireless device MAC. If the target PWM differs from the reported PWM, behavior is unchanged and the packet is sent immediately. If the target already matches the reported PWM, send a refresh packet at most once per second.

A 1s refresh interval fixed the frequent max-RPM spikes on SL-INF wireless without flooding the wireless controller.

## Verification
- cargo fmt --check
- SLINT_NO_QT=1 cargo build -p lianli-devices
- local runtime test on SL-INF wireless fans: steady ~34% PWM with no max-RPM bursts observed during the test window

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced wireless fan speed control reliability by ensuring periodic refresh of fan speed commands to connected devices, preventing control signals from becoming unresponsive when fan speeds remain unchanged for extended periods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sgtaziz/lian-li-linux/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->