### PR TITLE
Add custom gradient stops for radial gauges

### DIFF
--- a/crates/lianli-gui/src/editor.rs
+++ b/crates/lianli-gui/src/editor.rs
@@ -8,11 +8,13 @@ mod preview;
 mod reflect;
 
 use crate::conversions;
-use crate::{EditorRange, EditorWidget, MainWindow, Shared, TemplateEditorWindow};
+use crate::{
+    EditorGradientStop, EditorRange, EditorWidget, MainWindow, Shared, TemplateEditorWindow,
+};
 use lianli_shared::fonts::{cached_system_fonts, DEFAULT_FONT_LABEL};
 use lianli_shared::media::SensorRange;
 use lianli_shared::screen::screen_presets;
-use lianli_shared::template::{LcdTemplate, TemplateBackground, WidgetKind};
+use lianli_shared::template::{GradientStop, LcdTemplate, TemplateBackground, WidgetKind};
 use parking_lot::Mutex as PLMutex;
 use slint::{ComponentHandle, Image, ModelRc, SharedString, VecModel};
 use std::sync::atomic::AtomicU64;
@@ -331,7 +333,8 @@ pub fn install(main: &MainWindow, shared: Shared) -> EditorHandle {
                 }
             }
             if let Some(e) = editor_weak.upgrade() {
-                reflect::reflect_widget_row(&e, &editor_state, &shared, idx as usize);
+                reflect::select_widget(&e, &editor_state, &shared, idx);
+                reflect::reflect_gradient_stops(&e, &editor_state);
             }
             preview::request_preview(&editor_weak, &editor_state, &preview_version, &shared);
         });
@@ -486,6 +489,7 @@ pub fn install(main: &MainWindow, shared: Shared) -> EditorHandle {
             }
             if let Some(e) = editor_weak.upgrade() {
                 reflect::reflect_ranges(&e, &editor_state);
+                reflect::reflect_gradient_stops(&e, &editor_state);
                 reflect::reflect_widget_row(&e, &editor_state, &shared, target_idx as usize);
             }
             preview::request_preview(&editor_weak, &editor_state, &preview_version, &shared);
@@ -497,17 +501,21 @@ pub fn install(main: &MainWindow, shared: Shared) -> EditorHandle {
         let editor_weak = editor.as_weak();
         let preview_version = preview_version.clone();
         let shared = shared.clone();
+
         editor.on_range_removed(move |range_idx| {
             let target_idx = editor_state.lock().selected_widget;
             if target_idx < 0 {
                 return;
             }
+
             {
                 let mut st = editor_state.lock();
+
                 if let Some(tpl) = st.template.as_mut() {
                     if let Some(widget) = tpl.widgets.get_mut(target_idx as usize) {
                         if let Some(ranges) = apply::widget_ranges_mut(&mut widget.kind) {
                             let i = range_idx as usize;
+
                             if i < ranges.len() {
                                 ranges.remove(i);
                             }
@@ -515,10 +523,128 @@ pub fn install(main: &MainWindow, shared: Shared) -> EditorHandle {
                     }
                 }
             }
+
             if let Some(e) = editor_weak.upgrade() {
                 reflect::reflect_ranges(&e, &editor_state);
+                reflect::reflect_gradient_stops(&e, &editor_state);
                 reflect::reflect_widget_row(&e, &editor_state, &shared, target_idx as usize);
             }
+
+            preview::request_preview(&editor_weak, &editor_state, &preview_version, &shared);
+        });
+    }
+
+    {
+        let editor_state = editor_state.clone();
+        let editor_weak = editor.as_weak();
+        let preview_version = preview_version.clone();
+        let shared = shared.clone();
+
+        editor.on_gradient_stop_field(move |stop_idx, field, val| {
+            let target_idx = editor_state.lock().selected_widget;
+            if target_idx < 0 {
+                return;
+            }
+
+            {
+                let mut st = editor_state.lock();
+
+                if let Some(tpl) = st.template.as_mut() {
+                    if let Some(widget) = tpl.widgets.get_mut(target_idx as usize) {
+                        if let Some(stops) = apply::widget_gradient_stops_mut(&mut widget.kind) {
+                            let i = stop_idx as usize;
+
+                            if let Some(stop) = stops.get_mut(i) {
+                                apply::apply_gradient_stop_field(
+                                    stop,
+                                    field.as_str(),
+                                    val.as_str(),
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+            preview::request_preview(&editor_weak, &editor_state, &preview_version, &shared);
+        });
+    }
+
+    {
+        let editor_state = editor_state.clone();
+        let editor_weak = editor.as_weak();
+        let preview_version = preview_version.clone();
+        let shared = shared.clone();
+
+        editor.on_gradient_stop_added(move || {
+            let target_idx = editor_state.lock().selected_widget;
+            if target_idx < 0 {
+                return;
+            }
+
+            {
+                let mut st = editor_state.lock();
+
+                if let Some(tpl) = st.template.as_mut() {
+                    if let Some(widget) = tpl.widgets.get_mut(target_idx as usize) {
+                        if let Some(stops) = apply::widget_gradient_stops_mut(&mut widget.kind) {
+                            stops.push(GradientStop {
+                                position: 100.0,
+                                color: [255, 80, 190],
+                                alpha: 255,
+                            });
+
+                            stops.sort_by(|a, b| {
+                                a.position
+                                    .partial_cmp(&b.position)
+                                    .unwrap_or(std::cmp::Ordering::Equal)
+                            });
+                        }
+                    }
+                }
+            }
+
+            if let Some(e) = editor_weak.upgrade() {
+                reflect::reflect_gradient_stops(&e, &editor_state);
+                reflect::reflect_widget_row(&e, &editor_state, &shared, target_idx as usize);
+            }
+
+            preview::request_preview(&editor_weak, &editor_state, &preview_version, &shared);
+        });
+    }
+
+    {
+        let editor_state = editor_state.clone();
+        let editor_weak = editor.as_weak();
+        let preview_version = preview_version.clone();
+        let shared = shared.clone();
+
+        editor.on_gradient_stop_removed(move |stop_idx| {
+            let target_idx = editor_state.lock().selected_widget;
+            if target_idx < 0 {
+                return;
+            }
+
+            {
+                let mut st = editor_state.lock();
+
+                if let Some(tpl) = st.template.as_mut() {
+                    if let Some(widget) = tpl.widgets.get_mut(target_idx as usize) {
+                        if let Some(stops) = apply::widget_gradient_stops_mut(&mut widget.kind) {
+                            let i = stop_idx as usize;
+
+                            if i < stops.len() {
+                                stops.remove(i);
+                            }
+                        }
+                    }
+                }
+            }
+
+            if let Some(e) = editor_weak.upgrade() {
+                reflect::reflect_gradient_stops(&e, &editor_state);
+                reflect::reflect_widget_row(&e, &editor_state, &shared, target_idx as usize);
+            }
+
             preview::request_preview(&editor_weak, &editor_state, &preview_version, &shared);
         });
     }
@@ -543,6 +669,11 @@ pub fn open(
     handle
         .window
         .set_selected_ranges(slint::ModelRc::new(VecModel::<EditorRange>::default()));
+    handle
+        .window
+        .set_selected_gradient_stops(slint::ModelRc::new(
+            VecModel::<EditorGradientStop>::default(),
+        ));
     handle.window.set_selected_index(-1);
     handle
         .window

--- a/crates/lianli-gui/src/editor/apply.rs
+++ b/crates/lianli-gui/src/editor/apply.rs
@@ -159,6 +159,7 @@ pub(super) fn apply_kind_field(
             ranges: _,
             bg_corner_radius,
             value_corner_radius,
+            ..
         } => match field {
             "source" => {
                 if let Some(new) = super::mapping::parse_sensor_source(val, sensors) {

--- a/crates/lianli-gui/src/editor/apply.rs
+++ b/crates/lianli-gui/src/editor/apply.rs
@@ -1,7 +1,7 @@
-use crate::EditorRange;
+use crate::{EditorGradientStop, EditorRange};
 use lianli_shared::media::{SensorRange, SensorSourceConfig};
 use lianli_shared::sensors::SensorInfo;
-use lianli_shared::template::{Widget, WidgetKind};
+use lianli_shared::template::{GradientStop, Widget, WidgetKind};
 use slint::{ModelRc, VecModel};
 
 pub(super) fn apply_widget_field(
@@ -159,6 +159,7 @@ pub(super) fn apply_kind_field(
             ranges: _,
             bg_corner_radius,
             value_corner_radius,
+            gradient,
             ..
         } => match field {
             "source" => {
@@ -184,6 +185,9 @@ pub(super) fn apply_kind_field(
                 if let Ok(v) = val.parse() {
                     *value_max = v;
                 }
+            }
+            "gradient" => {
+                *gradient = val == "true" || val == "1";
             }
             "start_angle" => {
                 if let Ok(v) = val.parse() {
@@ -728,6 +732,20 @@ pub(super) fn widget_ranges(kind: &WidgetKind) -> Option<&[SensorRange]> {
     }
 }
 
+pub(super) fn widget_gradient_stops_mut(kind: &mut WidgetKind) -> Option<&mut Vec<GradientStop>> {
+    match kind {
+        WidgetKind::RadialGauge { gradient_stops, .. } => Some(gradient_stops),
+        _ => None,
+    }
+}
+
+pub(super) fn widget_gradient_stops(kind: &WidgetKind) -> Option<&[GradientStop]> {
+    match kind {
+        WidgetKind::RadialGauge { gradient_stops, .. } => Some(gradient_stops.as_slice()),
+        _ => None,
+    }
+}
+
 pub(super) fn apply_range_field(range: &mut SensorRange, field: &str, val: &str) {
     match field {
         "max" => {
@@ -747,6 +765,21 @@ pub(super) fn apply_range_field(range: &mut SensorRange, field: &str, val: &str)
     }
 }
 
+pub(super) fn apply_gradient_stop_field(stop: &mut GradientStop, field: &str, val: &str) {
+    match field {
+        "position" => {
+            if let Ok(v) = val.parse::<i32>() {
+                stop.position = v.clamp(0, 100) as f32;
+            }
+        }
+        "color_r" => stop.color[0] = super::mapping::parse_u8(val),
+        "color_g" => stop.color[1] = super::mapping::parse_u8(val),
+        "color_b" => stop.color[2] = super::mapping::parse_u8(val),
+        "color_a" => stop.alpha = super::mapping::parse_u8(val),
+        _ => {}
+    }
+}
+
 pub(super) fn ranges_to_editor(ranges: &[SensorRange]) -> ModelRc<EditorRange> {
     let items: Vec<EditorRange> = ranges
         .iter()
@@ -758,5 +791,20 @@ pub(super) fn ranges_to_editor(ranges: &[SensorRange]) -> ModelRc<EditorRange> {
             color_a: r.alpha as i32,
         })
         .collect();
+    ModelRc::new(VecModel::from(items))
+}
+
+pub(super) fn gradient_stops_to_editor(stops: &[GradientStop]) -> ModelRc<EditorGradientStop> {
+    let items: Vec<EditorGradientStop> = stops
+        .iter()
+        .map(|s| EditorGradientStop {
+            position_pct: s.position.round().clamp(0.0, 100.0) as i32,
+            color_r: s.color[0] as i32,
+            color_g: s.color[1] as i32,
+            color_b: s.color[2] as i32,
+            color_a: s.alpha as i32,
+        })
+        .collect();
+
     ModelRc::new(VecModel::from(items))
 }

--- a/crates/lianli-gui/src/editor/mapping/to_editor.rs
+++ b/crates/lianli-gui/src/editor/mapping/to_editor.rs
@@ -65,6 +65,7 @@ pub(in crate::editor) fn widget_to_editor(w: &Widget, sensors: &[SensorInfo]) ->
         corner_radius: 0,
         bg_corner_radius: 0,
         value_corner_radius: 0,
+        gauge_gradient: false,
         letter_spacing: 0,
         clock_show_seconds: true,
         clock_show_hour_ticks: true,
@@ -201,6 +202,7 @@ pub(in crate::editor) fn widget_to_editor(w: &Widget, sensors: &[SensorInfo]) ->
             background_color,
             bg_corner_radius,
             value_corner_radius,
+            gradient,
             ..
         } => {
             out.source_index = sensor_index_for_source(source, sensors);
@@ -218,6 +220,7 @@ pub(in crate::editor) fn widget_to_editor(w: &Widget, sensors: &[SensorInfo]) ->
             out.bg_a = background_color[3] as i32;
             out.bg_corner_radius = bg_corner_radius.max(0.0).round() as i32;
             out.value_corner_radius = value_corner_radius.max(0.0).round() as i32;
+            out.gauge_gradient = *gradient;
         }
         WidgetKind::VerticalBar {
             source,

--- a/crates/lianli-gui/src/editor/mapping/to_editor.rs
+++ b/crates/lianli-gui/src/editor/mapping/to_editor.rs
@@ -609,6 +609,7 @@ pub(in crate::editor) fn blank_editor_widget() -> EditorWidget {
         corner_radius: 0,
         bg_corner_radius: 0,
         value_corner_radius: 0,
+        gauge_gradient: false,
         sparkline_history: 60,
         sparkline_line_width: 2.0,
         sparkline_auto_range: false,

--- a/crates/lianli-gui/src/editor/mapping/to_template.rs
+++ b/crates/lianli-gui/src/editor/mapping/to_template.rs
@@ -1,7 +1,9 @@
 use lianli_shared::fonts::font_path_for_label;
 use lianli_shared::media::{SensorRange, SensorSourceConfig};
 use lianli_shared::sensors::{SensorInfo, SensorSource};
-use lianli_shared::template::{BarOrientation, FontRef, ImageFit, TextAlign, Widget, WidgetKind};
+use lianli_shared::template::{
+    default_gradient_stops, BarOrientation, FontRef, ImageFit, TextAlign, Widget, WidgetKind,
+};
 
 pub(in crate::editor) fn label_to_font_ref(label: &str) -> FontRef {
     FontRef {
@@ -43,6 +45,8 @@ pub(in crate::editor) fn make_default_widget(id: &str, kind_str: &str, cx: f32, 
             ranges: default_ranges(),
             bg_corner_radius: 0.0,
             value_corner_radius: 0.0,
+            gradient: false,
+            gradient_stops: default_gradient_stops(),
         },
         "vertical_bar" => WidgetKind::VerticalBar {
             source: SensorSourceConfig::CpuUsage,
@@ -178,6 +182,7 @@ pub(in crate::editor) fn make_default_widget(id: &str, kind_str: &str, cx: f32, 
             letter_spacing: 0.0,
         },
     };
+
     Widget {
         id: id.to_string(),
         kind,
@@ -232,11 +237,14 @@ pub(in crate::editor) fn parse_sensor_source(
     if label.ends_with(". Custom command") || label == "Custom command" {
         return Some(SensorSourceConfig::Command { cmd: String::new() });
     }
+
     let idx: usize = label.split('.').next()?.parse().ok()?;
     if idx == 0 {
         return None;
     }
+
     let sensor = sensors.get(idx - 1)?;
+
     Some(match &sensor.source {
         SensorSource::Hwmon {
             name,

--- a/crates/lianli-gui/src/editor/reflect.rs
+++ b/crates/lianli-gui/src/editor/reflect.rs
@@ -1,5 +1,5 @@
 use super::{EditorState, SharedEditor};
-use crate::{EditorRange, Shared, TemplateEditorWindow};
+use crate::{EditorGradientStop, EditorRange, Shared, TemplateEditorWindow};
 use lianli_shared::screen::screen_preset_label;
 use lianli_shared::template::TemplateBackground;
 use slint::{Model, ModelRc, SharedString, VecModel};
@@ -22,6 +22,29 @@ pub(super) fn reflect_ranges(editor: &TemplateEditorWindow, state: &SharedEditor
         None => ModelRc::new(VecModel::<EditorRange>::default()),
     };
     editor.set_selected_ranges(model);
+}
+
+pub(super) fn reflect_gradient_stops(editor: &TemplateEditorWindow, state: &SharedEditor) {
+    let stops = {
+        let st = state.lock();
+        let idx = st.selected_widget;
+
+        if idx < 0 {
+            None
+        } else {
+            st.template
+                .as_ref()
+                .and_then(|t| t.widgets.get(idx as usize))
+                .and_then(|w| super::apply::widget_gradient_stops(&w.kind).map(|s| s.to_vec()))
+        }
+    };
+
+    let model = match stops {
+        Some(s) => super::apply::gradient_stops_to_editor(&s),
+        None => ModelRc::new(VecModel::<EditorGradientStop>::default()),
+    };
+
+    editor.set_selected_gradient_stops(model);
 }
 
 pub(super) fn editor_color_from_state(st: &EditorState) -> [u8; 4] {
@@ -108,6 +131,7 @@ pub(super) fn select_widget(
         editor.set_selected_widget(super::mapping::blank_editor_widget());
     }
     reflect_ranges(editor, state);
+    reflect_gradient_stops(editor, state);
 }
 
 pub(super) fn reflect_widgets_model(
@@ -137,4 +161,5 @@ pub(super) fn reflect_widgets_model(
         editor.set_selected_widget(super::mapping::blank_editor_widget());
     }
     reflect_ranges(editor, state);
+    reflect_gradient_stops(editor, state);
 }

--- a/crates/lianli-gui/ui/windows/template_editor.slint
+++ b/crates/lianli-gui/ui/windows/template_editor.slint
@@ -2,13 +2,13 @@ import { Theme } from "../theme.slint";
 import {
     Button, ComboBox, LineEdit, ScrollView, Palette,
 } from "std-widgets.slint";
-import { EditorRange, EditorWidget } from "template_editor/types.slint";
+import { EditorRange, EditorGradientStop, EditorWidget } from "template_editor/types.slint";
 import { BareSpinBox, LabeledCheckBox } from "template_editor/inputs.slint";
 import { WidgetListRow } from "template_editor/list_row.slint";
 import { WidgetBox } from "template_editor/canvas_box.slint";
 import { PropertiesPanel } from "template_editor/props.slint";
 
-export { EditorRange, EditorWidget }
+export { EditorRange, EditorGradientStop, EditorWidget }
 
 export component TemplateEditorWindow inherits Window {
     title: "LCD Template Editor";
@@ -38,6 +38,7 @@ export component TemplateEditorWindow inherits Window {
     in-out property <int> selected-index: -1;
     in-out property <EditorWidget> selected-widget;
     in-out property <[EditorRange]> selected-ranges: [];
+    in-out property <[EditorGradientStop]> selected-gradient-stops: [];
 
     in property <image> preview-image;
     in property <[string]> device-presets: [];
@@ -71,6 +72,9 @@ export component TemplateEditorWindow inherits Window {
     callback range-field(int, string, string);
     callback range-added();
     callback range-removed(int);
+    callback gradient-stop-field(int, string, string);
+    callback gradient-stop-added();
+    callback gradient-stop-removed(int);
     callback pick-bg-image();
     callback pick-widget-image(int);
     callback preset-selected(string);
@@ -354,6 +358,7 @@ export component TemplateEditorWindow inherits Window {
                 selected-index: root.selected-index;
                 selected-widget: root.selected-widget;
                 selected-ranges: root.selected-ranges;
+                selected-gradient-stops: root.selected-gradient-stops;
                 sensor-options: root.sensor-options;
                 font-names: root.font-names;
                 align-options: root.align-options;
@@ -361,6 +366,9 @@ export component TemplateEditorWindow inherits Window {
                 range-field(i, f, v) => { root.range-field(i, f, v); }
                 range-added => { root.range-added(); }
                 range-removed(i) => { root.range-removed(i); }
+                gradient-stop-field(i, f, v) => { root.gradient-stop-field(i, f, v); }
+                gradient-stop-added => { root.gradient-stop-added(); }
+                gradient-stop-removed(i) => { root.gradient-stop-removed(i); }
                 widget-removed(i) => { root.widget-removed(i); }
                 pick-widget-image(i) => { root.pick-widget-image(i); }
             }

--- a/crates/lianli-gui/ui/windows/template_editor/props.slint
+++ b/crates/lianli-gui/ui/windows/template_editor/props.slint
@@ -1,6 +1,6 @@
 import { Theme } from "../../theme.slint";
 import { Button, ScrollView } from "std-widgets.slint";
-import { EditorRange, EditorWidget } from "types.slint";
+import { EditorRange, EditorGradientStop, EditorWidget } from "types.slint";
 import {
     LabeledSpinBox, LabeledLineEdit, LabeledComboValue, LabeledComboIndex,
     LabeledCheckBox, RgbaRow, BareSpinBox, BareLineEdit,
@@ -10,6 +10,7 @@ export component PropertiesPanel inherits Rectangle {
     in property <int> selected-index;
     in property <EditorWidget> selected-widget;
     in property <[EditorRange]> selected-ranges;
+    in property <[EditorGradientStop]> selected-gradient-stops;
     in property <[string]> sensor-options;
     in property <[string]> font-names;
     in property <[string]> align-options;
@@ -17,6 +18,9 @@ export component PropertiesPanel inherits Rectangle {
     callback widget-field(int, string, string);
     callback range-field(int, string, string);
     callback range-added();
+    callback gradient-stop-field(int, string, string);
+    callback gradient-stop-added();
+    callback gradient-stop-removed(int);
     callback range-removed(int);
     callback widget-removed(int);
     callback pick-widget-image(int);
@@ -170,12 +174,90 @@ export component PropertiesPanel inherits Rectangle {
                     }
                 }
 
-                if root.selected-widget.kind == "radial_gauge"
-                   || root.selected-widget.kind == "vertical_bar"
-                   || root.selected-widget.kind == "horizontal_bar"
-                   || root.selected-widget.kind == "speedometer"
-                   || root.selected-widget.kind == "value_text"
-                   || root.selected-widget.kind == "sparkline": VerticalLayout {
+                if root.selected-widget.kind == "radial_gauge": LabeledCheckBox {
+                    text: "Gradient fill";
+                    checked: root.selected-widget.gauge-gradient;
+                    toggled(c) => { root.widget-field(root.selected-index, "gradient", c ? "true" : "false"); }
+                }
+
+                if root.selected-widget.kind == "radial_gauge" && root.selected-widget.gauge-gradient: VerticalLayout {
+                    spacing: 6px;
+
+                    Text {
+                        text: "Gradient points (% / R / G / B / A)";
+                        font-size: 10px;
+                        color: Theme.text-secondary;
+                    }
+
+                    for s[si] in root.selected-gradient-stops: HorizontalLayout {
+                        spacing: 3px;
+                        height: 28px;
+
+                        BareSpinBox {
+                            width: 96px;
+                            horizontal-stretch: 0;
+                            value: s.position-pct;
+                            minimum: 0;
+                            maximum: 100;
+                            edited(v) => { root.gradient-stop-field(si, "position", v); }
+                        }
+
+                        BareSpinBox {
+                            width: 96px;
+                            horizontal-stretch: 0;
+                            value: s.color-r;
+                            edited(v) => { root.gradient-stop-field(si, "color_r", v); }
+                        }
+
+                        BareSpinBox {
+                            width: 96px;
+                            horizontal-stretch: 0;
+                            value: s.color-g;
+                            edited(v) => { root.gradient-stop-field(si, "color_g", v); }
+                        }
+
+                        BareSpinBox {
+                            width: 96px;
+                            horizontal-stretch: 0;
+                            value: s.color-b;
+                            edited(v) => { root.gradient-stop-field(si, "color_b", v); }
+                        }
+
+                        BareSpinBox {
+                            width: 96px;
+                            horizontal-stretch: 0;
+                            value: s.color-a;
+                            edited(v) => { root.gradient-stop-field(si, "color_a", v); }
+                        }
+
+                        Button {
+                            text: "✕";
+                            horizontal-stretch: 1;
+                            height: 28px;
+                            clicked => { root.gradient-stop-removed(si); }
+                        }
+                    }
+
+                    Button {
+                        text: "+ Add gradient point";
+                        clicked => { root.gradient-stop-added(); }
+                    }
+
+                    Text {
+                        text: "Color ranges are ignored while gradient fill is enabled.";
+                        font-size: 10px;
+                        color: Theme.text-secondary;
+                        wrap: word-wrap;
+                    }
+                }
+
+                if (root.selected-widget.kind == "radial_gauge"
+                    || root.selected-widget.kind == "vertical_bar"
+                    || root.selected-widget.kind == "horizontal_bar"
+                    || root.selected-widget.kind == "speedometer"
+                    || root.selected-widget.kind == "core_bars"
+                    || root.selected-widget.kind == "value_text"
+                    || root.selected-widget.kind == "sparkline"): VerticalLayout {
                     spacing: 6px;
                     LabeledComboIndex {
                         label: "Sensor";
@@ -711,13 +793,14 @@ export component PropertiesPanel inherits Rectangle {
                     }
                 }
 
-                if root.selected-widget.kind == "radial_gauge"
-                   || root.selected-widget.kind == "vertical_bar"
-                   || root.selected-widget.kind == "horizontal_bar"
-                   || root.selected-widget.kind == "speedometer"
-                   || root.selected-widget.kind == "core_bars"
-                   || root.selected-widget.kind == "value_text"
-                   || root.selected-widget.kind == "sparkline": VerticalLayout {
+                if (root.selected-widget.kind != "radial_gauge" || !root.selected-widget.gauge-gradient)
+                && (root.selected-widget.kind == "radial_gauge"
+                    || root.selected-widget.kind == "vertical_bar"
+                    || root.selected-widget.kind == "horizontal_bar"
+                    || root.selected-widget.kind == "speedometer"
+                    || root.selected-widget.kind == "core_bars"
+                    || root.selected-widget.kind == "value_text"
+                    || root.selected-widget.kind == "sparkline"): VerticalLayout {
                     spacing: 6px;
                     Text { text: "Color ranges (max value / R / G / B / A)"; font-size: 10px; color: Theme.text-secondary; }
                     for r[ri] in root.selected-ranges: HorizontalLayout {

--- a/crates/lianli-gui/ui/windows/template_editor/types.slint
+++ b/crates/lianli-gui/ui/windows/template_editor/types.slint
@@ -7,6 +7,14 @@ export struct EditorRange {
     color-a: int,
 }
 
+export struct EditorGradientStop {
+    position-pct: int,
+    color-r: int,
+    color-g: int,
+    color-b: int,
+    color-a: int,
+}
+
 export struct EditorWidget {
     id: string,
     kind: string,
@@ -49,6 +57,7 @@ export struct EditorWidget {
     corner-radius: int,
     bg-corner-radius: int,
     value-corner-radius: int,
+    gauge-gradient: bool,
     letter-spacing: int,
 
     show-gauge: bool,

--- a/crates/lianli-media/src/custom/widgets/mod.rs
+++ b/crates/lianli-media/src/custom/widgets/mod.rs
@@ -208,6 +208,8 @@ pub(super) fn draw_widget(
             ranges,
             bg_corner_radius,
             value_corner_radius,
+            gradient,
+            gradient_stops,
             ..
         } => {
             radial_gauge::draw(
@@ -220,6 +222,8 @@ pub(super) fn draw_widget(
                 *inner_radius_pct,
                 *background_color,
                 ranges,
+                *gradient,
+                gradient_stops,
                 *bg_corner_radius * ss,
                 *value_corner_radius * ss,
             );

--- a/crates/lianli-media/src/custom/widgets/radial_gauge.rs
+++ b/crates/lianli-media/src/custom/widgets/radial_gauge.rs
@@ -4,6 +4,7 @@
 use super::super::helpers::{range_color, unit_interval};
 use image::{Rgba, RgbaImage};
 use lianli_shared::media::SensorRange;
+use lianli_shared::template::GradientStop;
 use std::f32::consts::PI;
 
 #[allow(clippy::too_many_arguments)]
@@ -17,6 +18,8 @@ pub(in super::super) fn draw(
     inner_radius_pct: f32,
     background_color: [u8; 4],
     ranges: &[SensorRange],
+    gradient: bool,
+    gradient_stops: &[GradientStop],
     bg_corner_radius: f32,
     value_corner_radius: f32,
 ) {
@@ -36,7 +39,12 @@ pub(in super::super) fn draw(
     let fill_sweep = sweep * u;
 
     let bg = Rgba(background_color);
-    let value_color = range_color(ranges, u);
+    let solid_value_color = range_color(ranges, u);
+    let gradient_stops = if gradient {
+        prepare_gradient_stops(gradient_stops)
+    } else {
+        Vec::new()
+    };
 
     let bg_cr = clamp_corner(bg_corner_radius, half_thickness, sweep, r_mid);
     let value_cr = clamp_corner(value_corner_radius, half_thickness, fill_sweep, r_mid);
@@ -88,13 +96,88 @@ pub(in super::super) fn draw(
                 }
                 sub.put_pixel(x, y, bg);
             } else {
+                let value_color = if gradient {
+                    let pixel_u = (diff / sweep).clamp(0.0, 1.0);
+                    gradient_color(&gradient_stops, pixel_u)
+                } else {
+                    solid_value_color
+                };
+
                 if value_color[3] == 0 {
                     continue;
                 }
+
                 sub.put_pixel(x, y, value_color);
             }
         }
     }
+}
+
+fn prepare_gradient_stops(stops: &[GradientStop]) -> Vec<(f32, [u8; 4])> {
+    let mut out: Vec<(f32, [u8; 4])> = if stops.is_empty() {
+        vec![
+            (0.0, [45, 110, 255, 255]),
+            (0.55, [170, 80, 255, 255]),
+            (1.0, [255, 80, 190, 255]),
+        ]
+    } else {
+        stops
+            .iter()
+            .map(|s| {
+                (
+                    (s.position / 100.0).clamp(0.0, 1.0),
+                    [s.color[0], s.color[1], s.color[2], s.alpha],
+                )
+            })
+            .collect()
+    };
+
+    out.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    out
+}
+
+fn gradient_color(stops: &[(f32, [u8; 4])], t: f32) -> Rgba<u8> {
+    if stops.is_empty() {
+        return Rgba([255, 255, 255, 255]);
+    }
+
+    let t = t.clamp(0.0, 1.0);
+
+    if t <= stops[0].0 {
+        return Rgba(stops[0].1);
+    }
+
+    let last = stops.last().unwrap();
+    if t >= last.0 {
+        return Rgba(last.1);
+    }
+
+    for pair in stops.windows(2) {
+        let (p0, c0) = pair[0];
+        let (p1, c1) = pair[1];
+
+        if t >= p0 && t <= p1 {
+            let local_t = (t - p0) / (p1 - p0).max(f32::EPSILON);
+
+            return Rgba([
+                lerp_u8(c0[0], c1[0], local_t),
+                lerp_u8(c0[1], c1[1], local_t),
+                lerp_u8(c0[2], c1[2], local_t),
+                lerp_u8(c0[3], c1[3], local_t),
+            ]);
+        }
+    }
+
+    Rgba(last.1)
+}
+
+fn lerp_u8(a: u8, b: u8, t: f32) -> u8 {
+    let t = t.clamp(0.0, 1.0);
+
+    (a as f32 + (b as f32 - a as f32) * t)
+        .round()
+        .clamp(0.0, 255.0) as u8
 }
 
 fn clamp_corner(raw: f32, half_thickness: f32, arc_sweep_deg: f32, r_mid: f32) -> f32 {

--- a/crates/lianli-media/src/custom/widgets/radial_gauge.rs
+++ b/crates/lianli-media/src/custom/widgets/radial_gauge.rs
@@ -37,7 +37,6 @@ pub(in super::super) fn draw(
     }
     let u = unit_interval(value, value_min, value_max);
     let fill_sweep = sweep * u;
-
     let bg = Rgba(background_color);
     let solid_value_color = range_color(ranges, u);
     let gradient_stops = if gradient {
@@ -117,7 +116,7 @@ fn prepare_gradient_stops(stops: &[GradientStop]) -> Vec<(f32, [u8; 4])> {
     let mut out: Vec<(f32, [u8; 4])> = if stops.is_empty() {
         vec![
             (0.0, [45, 110, 255, 255]),
-            (0.55, [170, 80, 255, 255]),
+            (0.50, [170, 80, 255, 255]),
             (1.0, [255, 80, 190, 255]),
         ]
     } else {

--- a/crates/lianli-shared/src/template/mod.rs
+++ b/crates/lianli-shared/src/template/mod.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 pub mod widget_kind;
-pub use widget_kind::WidgetKind;
+pub use widget_kind::{default_gradient_stops, GradientStop, WidgetKind};
 
 /// Accepts both `[r,g,b]` (alpha defaults to 255) and `[r,g,b,a]` so older
 /// hand-written templates keep loading after the alpha channel was added.

--- a/crates/lianli-shared/src/template/widget_kind.rs
+++ b/crates/lianli-shared/src/template/widget_kind.rs
@@ -7,7 +7,7 @@ fn default_alpha() -> u8 {
     255
 }
 
-fn default_gradient_stops() -> Vec<GradientStop> {
+pub fn default_gradient_stops() -> Vec<GradientStop> {
     vec![
         GradientStop {
             position: 0.0,

--- a/crates/lianli-shared/src/template/widget_kind.rs
+++ b/crates/lianli-shared/src/template/widget_kind.rs
@@ -3,6 +3,38 @@ use crate::media::{SensorRange, SensorSourceConfig};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+fn default_alpha() -> u8 {
+    255
+}
+
+fn default_gradient_stops() -> Vec<GradientStop> {
+    vec![
+        GradientStop {
+            position: 0.0,
+            color: [45, 110, 255],
+            alpha: 255,
+        },
+        GradientStop {
+            position: 50.0,
+            color: [170, 80, 255],
+            alpha: 255,
+        },
+        GradientStop {
+            position: 100.0,
+            color: [255, 80, 190],
+            alpha: 255,
+        },
+    ]
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GradientStop {
+    pub position: f32,
+    pub color: [u8; 3],
+    #[serde(default = "default_alpha")]
+    pub alpha: u8,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum WidgetKind {
@@ -56,6 +88,10 @@ pub enum WidgetKind {
         bg_corner_radius: f32,
         #[serde(default)]
         value_corner_radius: f32,
+        #[serde(default)]
+        gradient: bool,
+        #[serde(default = "default_gradient_stops")]
+        gradient_stops: Vec<GradientStop>,
     },
     VerticalBar {
         source: SensorSourceConfig,


### PR DESCRIPTION
**Adds gradient fill support for radial gauge widgets.**

This adds `gradient` and `gradient_stops` fields to radial gauges, while keeping the existing color range behavior when gradient fill is disabled.

The LCD template editor now has a gradient stop editor for radial gauges, with editable position and RGBA values for each stop. Newly-created radial gauges and serde defaults use the same default gradient stops.

Tested with:
* `cargo build`
* Template editor preview
* Physical LCD output on a Lian Li SL Wireless LCD 120mm Reverse


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Radial gauge widgets now support customizable gradient fills on the value indicator ring
  * New gradient editor interface enables adding, removing, and adjusting color stop position and RGBA values
  * Users can toggle between gradient and solid color fill modes as needed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->