### PR TITLE
daemon: add SetRgbFrames IPC to upload onboard wireless animations

### DIFF
--- a/crates/lianli-daemon/src/ipc_server.rs
+++ b/crates/lianli-daemon/src/ipc_server.rs
@@ -361,6 +361,22 @@ fn handle_request(
             }
         }
 
+        IpcRequest::SetRgbFrames {
+            device_id,
+            frames,
+            interval_ms,
+        } => {
+            let state = state.lock();
+            if let Some(ref rgb) = state.rgb_controller {
+                match rgb.lock().set_rgb_frames(&device_id, &frames, interval_ms) {
+                    Ok(()) => IpcResponse::ok(serde_json::json!(null)),
+                    Err(e) => IpcResponse::error(format!("RGB frames error: {e}")),
+                }
+            } else {
+                IpcResponse::error("RGB controller not initialized")
+            }
+        }
+
         IpcRequest::SetMbRgbSync { device_id, enabled } => {
             let state = state.lock();
             if let Some(ref rgb) = state.rgb_controller {

--- a/crates/lianli-daemon/src/rgb_controller/mod.rs
+++ b/crates/lianli-daemon/src/rgb_controller/mod.rs
@@ -249,6 +249,45 @@ impl RgbController {
         anyhow::bail!("RGB device not found: {device_id}");
     }
 
+    /// Upload a multi-frame animation to a wireless device via
+    /// `send_rgb_frames`. Each frame must be a full-device LED buffer; the
+    /// firmware then loops the animation onboard at `interval_ms` with no
+    /// further host packets. The effect_index is hashed across all frames so
+    /// the wireless drift check treats the running animation as the desired
+    /// state; `led_state` is parked on the final frame for a consistent later
+    /// single-frame re-send.
+    ///
+    /// Note: only the final frame is cached in `led_state`, so a later
+    /// `refresh_wireless_devices()` reconstructs a static image, not the
+    /// animation. The device also doesn't persist the effect (only bindings do),
+    /// so callers are expected to re-`SetRgbFrames` on reconnect to keep an
+    /// animation running.
+    pub fn set_rgb_frames(
+        &mut self,
+        device_id: &str,
+        frames: &[Vec<[u8; 3]>],
+        interval_ms: u16,
+    ) -> anyhow::Result<()> {
+        if frames.is_empty() {
+            anyhow::bail!("no frames supplied");
+        }
+        if let (Some(ref wireless), Some(state)) =
+            (&self.wireless, self.wireless_state.get_mut(device_id))
+        {
+            let want = state.led_state.len();
+            for (i, f) in frames.iter().enumerate() {
+                if f.len() != want {
+                    anyhow::bail!("frame {i} has {} LEDs, device has {want}", f.len());
+                }
+            }
+            let idx = effect_index_from_frames(frames);
+            wireless.send_rgb_frames(&state.mac, frames, interval_ms, &idx, 4)?;
+            state.led_state.copy_from_slice(&frames[frames.len() - 1]);
+            return Ok(());
+        }
+        anyhow::bail!("wireless RGB device not found: {device_id}");
+    }
+
     pub fn capabilities(&self) -> Vec<RgbDeviceCapabilities> {
         let mut caps = Vec::new();
 
@@ -455,6 +494,25 @@ fn effect_index_from_state(led_state: &[[u8; 3]]) -> [u8; 4] {
         for &b in px {
             h ^= b as u32;
             h = h.wrapping_mul(0x0100_0193);
+        }
+    }
+    if h == 0 {
+        h = 1;
+    }
+    h.to_be_bytes()
+}
+
+/// Same FNV-1a as `effect_index_from_state`, but over a frame sequence without
+/// flattening it into one buffer first (a multi-frame animation can be large).
+/// The byte order is identical to hashing the concatenated frames.
+fn effect_index_from_frames(frames: &[Vec<[u8; 3]>]) -> [u8; 4] {
+    let mut h: u32 = 0x811c_9dc5;
+    for frame in frames {
+        for px in frame {
+            for &b in px {
+                h ^= b as u32;
+                h = h.wrapping_mul(0x0100_0193);
+            }
         }
     }
     if h == 0 {

--- a/crates/lianli-shared/src/ipc.rs
+++ b/crates/lianli-shared/src/ipc.rs
@@ -43,6 +43,15 @@ pub enum IpcRequest {
         /// RGB triplets, one per LED.
         colors: Vec<[u8; 3]>,
     },
+    /// Upload a multi-frame animation to a wireless device. The firmware stores
+    /// the frames and loops them onboard at `interval_ms`, so no further host
+    /// packets are needed (unlike streamed Direct mode). Each frame is a
+    /// full-device LED buffer (one `[r, g, b]` per LED).
+    SetRgbFrames {
+        device_id: String,
+        frames: Vec<Vec<[u8; 3]>>,
+        interval_ms: u16,
+    },
     /// Set a single LED's color by index within a zone.
     /// Convenience wrapper around SetRgbDirect that modifies one LED
     /// without requiring the caller to track the full zone state.


### PR DESCRIPTION
WirelessController::send_rgb_frames already exists but has no caller. It uploads a multi-frame RGB blob that the fan firmware stores and loops onboard at interval_ms, with no further host packets — unlike streamed Direct mode, which sends every frame and keeps the wireless link continuously busy.

This exposes it over IPC so external tools can drive onboard animations:

- SetRgbFrames { device_id, frames, interval_ms } in lianli-shared
- RgbController::set_rgb_frames() — validates each frame is a full-device LED buffer, hashes the effect_index across all frames so the wireless drift check keeps the animation as the desired state, and parks led_state on the final frame for a consistent single-frame re-send
- IPC handler wiring in the daemon

Additive only; existing Static/Direct behaviour is unchanged.

Tested on UNI FAN SL-Infinity wireless: uploading an N-frame buffer makes the fan loop the animation autonomously with the dongle idle afterwards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for uploading multi-frame RGB animations to compatible wireless devices.
  * You can now send full LED frame sequences along with a custom playback interval for on-device looping.

* **Bug Fixes**
  * Improved request handling by returning clearer errors when the lighting controller isn’t initialized or when the targeted wireless device can’t be found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->