### PR TITLE
Add HydroShift II pump/fan USB control protocol spec + hs2-fanctl service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3050,6 +3050,8 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "rusb",
+ "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "time",
  "tracing",

--- a/contrib/hs2-fanctl/README.md
+++ b/contrib/hs2-fanctl/README.md
@@ -1,0 +1,65 @@
+# hs2-fanctl — HydroShift II fan controller
+
+A small standalone service that replaces the HydroShift II's **pulsating firmware fan curve**
+with a smooth, coolant-temp-driven curve, using the protocol in
+[`docs/hydroshift2-fan-protocol.md`](../../docs/hydroshift2-fan-protocol.md).
+
+Directly-connected HydroShift II units currently expose no wired fan device (the HID path is
+HID-only), so their fans run the onboard curve — which chases the spiky CPU die temp and
+audibly hunts. `hs2-fanctl` instead follows the **coolant** temperature (naturally smooth,
+thermal mass of the loop), with an EMA low-pass and a slew-rate limit on top, so fan speed only
+ever drifts. It streams `0xFB` continuously to hold the setpoint; if the service stops, the
+firmware curve simply resumes (built-in failsafe — the cooler never sticks at a manual speed).
+
+## Build
+
+```sh
+cargo build --release -p lianli-devices --bin hs2-fanctl
+```
+
+## Install
+
+```sh
+sudo install -m755 target/release/hs2-fanctl /usr/local/bin/hs2-fanctl
+sudo install -m644 contrib/hs2-fanctl/hs2-fanctl.json /etc/hs2-fanctl.json
+sudo install -m644 contrib/hs2-fanctl/hs2-fanctl.service /etc/systemd/system/hs2-fanctl.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now hs2-fanctl
+```
+
+The device is claimed continuously, so stop `hs2-fanctl` before using the LCD.
+
+## Monitor
+
+```sh
+systemctl status hs2-fanctl
+# Live: coolant temp (smoothed), commanded duty %, per-fan RPM, pump RPM
+journalctl -u hs2-fanctl -f -o cat
+```
+
+Example line:
+
+```
+coolant 43.0C (ema 43.3) -> duty 60% | fans 1312/1316/1310 rpm  pump 2148 rpm
+```
+
+## Configure
+
+Edit `/etc/hs2-fanctl.json` and `sudo systemctl restart hs2-fanctl`.
+
+| key | meaning |
+|-----|---------|
+| `temp_source` | `"coolant"` (recommended) or `"cpu"` (k10temp `Tctl`) |
+| `curve` | `[temp_c, duty_pct]` points, linearly interpolated |
+| `min_duty_pct` / `max_duty_pct` | hard clamps |
+| `smoothing_tau_secs` | EMA time constant on the temp reading (bigger = smoother) |
+| `slew_pct_per_sec` | max duty change per second (caps audible ramps) |
+| `interval_secs` | poll/stream interval |
+
+For a dead-silent idle, drop the first curve point (e.g. `[38, 20]`). Coolant has high thermal
+inertia, so it only crosses ~44 °C under sustained all-core load — the default curve stays quiet
+in the normal band and ramps only when the loop is genuinely saturated.
+
+> Note: this is a standalone service, not daemon-integrated. It shares the WinUSB handle with
+> the LCD, so run one or the other. Pump-speed control isn't wired (that opcode isn't captured
+> yet); the pump stays on its firmware default.

--- a/contrib/hs2-fanctl/hs2-fanctl.json
+++ b/contrib/hs2-fanctl/hs2-fanctl.json
@@ -1,0 +1,15 @@
+{
+  "temp_source": "coolant",
+  "interval_secs": 2.0,
+  "curve": [
+    [38.0, 30.0],
+    [41.0, 45.0],
+    [44.0, 65.0],
+    [47.0, 85.0],
+    [50.0, 100.0]
+  ],
+  "min_duty_pct": 25.0,
+  "max_duty_pct": 100.0,
+  "smoothing_tau_secs": 8.0,
+  "slew_pct_per_sec": 5.0
+}

--- a/contrib/hs2-fanctl/hs2-fanctl.service
+++ b/contrib/hs2-fanctl/hs2-fanctl.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=HydroShift II fan controller (smooth coolant-temp curve)
+Documentation=https://github.com/sgtaziz/lian-li-linux/blob/main/docs/hydroshift2-fan-protocol.md
+After=multi-user.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/hs2-fanctl
+Restart=always
+RestartSec=3
+# Only needs USB (/dev/bus/usb) + sysfs hwmon reads.
+ProtectSystem=strict
+ProtectHome=read-only
+PrivateTmp=true
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/crates/lianli-devices/Cargo.toml
+++ b/crates/lianli-devices/Cargo.toml
@@ -21,6 +21,8 @@ image = { workspace = true }
 turbojpeg = { workspace = true }
 time = { workspace = true }
 clap = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [build-dependencies]
 cc = "1.0"
@@ -28,3 +30,7 @@ cc = "1.0"
 [[bin]]
 name = "desktop-mode-probe"
 path = "src/bin/desktop_mode_probe.rs"
+
+[[bin]]
+name = "hs2-fanctl"
+path = "src/bin/hs2_fanctl.rs"

--- a/crates/lianli-devices/src/bin/hs2_fanctl.rs
+++ b/crates/lianli-devices/src/bin/hs2_fanctl.rs
@@ -1,0 +1,375 @@
+//! HydroShift II fan controller — persistent local service.
+//!
+//! Replaces the pulsating firmware fan curve with a smooth, coolant-temp-driven
+//! curve streamed over the same WinUSB channel L-Connect uses. Protocol lives in
+//! `docs/hydroshift2-fan-protocol.md`; this is a working consumer of it.
+//!
+//! Why it doesn't pulsate: the firmware curve chases the spiky CPU die temp. This
+//! service follows the *coolant* temp (naturally smooth — thermal mass of the loop),
+//! then adds an EMA low-pass on the reading plus a slew-rate limit on the duty, so
+//! fan speed only ever drifts gently. A single 0xFB decays back to firmware in a few
+//! seconds, so we re-stream every `interval_secs` to hold the setpoint; if the service
+//! dies, the firmware curve simply resumes (built-in failsafe).
+//!
+//! Config: /etc/hs2-fanctl.json (falls back to built-in defaults). Reloaded on SIGHUP
+//! is not implemented — edit + `systemctl restart hs2-fanctl`.
+
+use anyhow::{Context, Result};
+use cbc::Encryptor;
+use des::cipher::{block_padding::Pkcs7, BlockEncryptMut, KeyIvInit};
+use des::Des;
+use lianli_transport::usb::{UsbTransport, LCD_READ_TIMEOUT, LCD_WRITE_TIMEOUT};
+use serde::Deserialize;
+use std::time::{Duration, Instant};
+
+const DES_KEY: [u8; 8] = *b"slv3tuzx";
+const VID: u16 = 0x1CBE;
+const PID: u16 = 0xA021;
+const CMD_GET_STATUS: u8 = 0xFA;
+const CMD_SET_FANS: u8 = 0xFB;
+const CONFIG_PATH: &str = "/etc/hs2-fanctl.json";
+
+// ─────────────────────────── config ───────────────────────────
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+struct Config {
+    /// "coolant" (default, recommended for an AIO) or "cpu" (k10temp Tctl).
+    temp_source: String,
+    /// Streaming/poll interval in seconds.
+    interval_secs: f32,
+    /// Curve points [temp_c, duty_pct], any order; linearly interpolated.
+    /// Below the first point → first duty; above the last → last duty.
+    curve: Vec<[f32; 2]>,
+    /// Hard clamps on duty percent.
+    min_duty_pct: f32,
+    max_duty_pct: f32,
+    /// EMA time constant (s) low-passing the temp reading. Bigger = smoother/slower.
+    smoothing_tau_secs: f32,
+    /// Max duty change per second (percent). Caps how fast fans ramp — kills audible steps.
+    slew_pct_per_sec: f32,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            temp_source: "coolant".into(),
+            interval_secs: 2.0,
+            // Coolant-driven. Real coolant idles ~36-40 °C and only crosses ~44 °C under
+            // sustained all-core load, so hold a quiet floor through the normal band and
+            // ramp only when the loop is genuinely saturated (full tilt by 50 °C).
+            curve: vec![
+                [38.0, 30.0],
+                [41.0, 45.0],
+                [44.0, 65.0],
+                [47.0, 85.0],
+                [50.0, 100.0],
+            ],
+            min_duty_pct: 25.0,
+            max_duty_pct: 100.0,
+            smoothing_tau_secs: 8.0,
+            slew_pct_per_sec: 5.0,
+        }
+    }
+}
+
+impl Config {
+    fn load() -> Self {
+        match std::fs::read_to_string(CONFIG_PATH) {
+            Ok(s) => match serde_json::from_str::<Config>(&s) {
+                Ok(mut c) => {
+                    c.curve.sort_by(|a, b| a[0].partial_cmp(&b[0]).unwrap());
+                    c
+                }
+                Err(e) => {
+                    eprintln!("config parse error ({CONFIG_PATH}): {e}; using defaults");
+                    Config::default()
+                }
+            },
+            Err(_) => {
+                eprintln!("no {CONFIG_PATH}; using built-in defaults");
+                Config::default()
+            }
+        }
+    }
+
+    fn interp(&self, temp: f32) -> f32 {
+        let c = &self.curve;
+        if c.is_empty() {
+            return self.min_duty_pct;
+        }
+        if temp <= c[0][0] {
+            return c[0][1].clamp(self.min_duty_pct, self.max_duty_pct);
+        }
+        if temp >= c[c.len() - 1][0] {
+            return c[c.len() - 1][1].clamp(self.min_duty_pct, self.max_duty_pct);
+        }
+        for w in c.windows(2) {
+            let (t0, d0) = (w[0][0], w[0][1]);
+            let (t1, d1) = (w[1][0], w[1][1]);
+            if temp >= t0 && temp <= t1 {
+                let f = (temp - t0) / (t1 - t0);
+                return (d0 + f * (d1 - d0)).clamp(self.min_duty_pct, self.max_duty_pct);
+            }
+        }
+        self.min_duty_pct
+    }
+}
+
+// ─────────────────────────── protocol ───────────────────────────
+
+fn build_set_fans(duty_255: u8, sensor_mirror: u16, ts_ms: u32) -> Vec<u8> {
+    fn crc16_xmodem(data: &[u8]) -> u16 {
+        let mut crc: u16 = 0;
+        for &b in data {
+            crc ^= (b as u16) << 8;
+            for _ in 0..8 {
+                crc = if crc & 0x8000 != 0 { (crc << 1) ^ 0x1021 } else { crc << 1 };
+            }
+        }
+        crc
+    }
+    let mut params = vec![0xff, 0x0f, 0xa2, 0x00];
+    params.extend_from_slice(&sensor_mirror.to_be_bytes());
+    params.extend_from_slice(&[duty_255, duty_255, duty_255]);
+    params.extend_from_slice(&[0, 0, 0]);
+    let crc = crc16_xmodem(&params);
+    params.extend_from_slice(&crc.to_be_bytes());
+
+    let mut buf = vec![0u8; 508];
+    buf[0] = CMD_SET_FANS;
+    buf[2] = 0x1A;
+    buf[3] = 0x6D;
+    buf[4..8].copy_from_slice(&ts_ms.to_le_bytes());
+    buf[8..8 + params.len()].copy_from_slice(&params);
+    let enc = Encryptor::<Des>::new_from_slices(&DES_KEY, &DES_KEY)
+        .unwrap()
+        .encrypt_padded_mut::<Pkcs7>(&mut buf, 500)
+        .unwrap()
+        .to_vec();
+    let mut out = vec![0u8; 512];
+    out[..504].copy_from_slice(&enc);
+    out[510] = 0xa1;
+    out[511] = 0x1a;
+    out
+}
+
+fn build_cmd(cmd: u8, ts_ms: u32) -> Vec<u8> {
+    let mut buf = vec![0u8; 508];
+    buf[0] = cmd;
+    buf[2] = 0x1A;
+    buf[3] = 0x6D;
+    buf[4..8].copy_from_slice(&ts_ms.to_le_bytes());
+    let enc = Encryptor::<Des>::new_from_slices(&DES_KEY, &DES_KEY)
+        .unwrap()
+        .encrypt_padded_mut::<Pkcs7>(&mut buf, 500)
+        .unwrap()
+        .to_vec();
+    let mut out = vec![0u8; 512];
+    out[..504].copy_from_slice(&enc);
+    out[510] = 0xa1;
+    out[511] = 0x1a;
+    out
+}
+
+struct Status {
+    coolant_c: f32,
+    fan_rpm: [u16; 3],
+    pump_rpm: u16,
+}
+
+fn parse_status(buf: &[u8; 512]) -> Option<Status> {
+    if buf[0] != CMD_GET_STATUS || buf[8] != 0x0a {
+        return None;
+    }
+    let be = |i: usize| u16::from_be_bytes([buf[i], buf[i + 1]]);
+    Some(Status {
+        fan_rpm: [be(14), be(16), be(18)],
+        pump_rpm: be(20),
+        // [13] = coolant temp, whole °C (verified vs the pump's own LCD readout).
+        // [30:32] is a constant (0x0116), NOT temperature.
+        coolant_c: buf[13] as f32,
+    })
+}
+
+// ─────────────────────────── device ───────────────────────────
+
+struct Device {
+    transport: UsbTransport,
+    start: Instant,
+}
+
+impl Device {
+    fn open() -> Result<Self> {
+        let mut transport = UsbTransport::open(VID, PID).context("opening HydroShift II")?;
+        transport
+            .detach_and_configure("hs2-fanctl")
+            .context("configuring device")?;
+        let _ = transport.clear_halt(0x01);
+        let _ = transport.clear_halt(0x81);
+        transport.read_flush();
+        let dev = Self { transport, start: Instant::now() };
+        dev.wake()?;
+        Ok(dev)
+    }
+
+    fn ts(&self) -> u32 {
+        self.start.elapsed().as_millis() as u32
+    }
+
+    fn xfer(&self, pkt: &[u8]) -> Result<Option<[u8; 512]>> {
+        self.transport.read_flush();
+        self.transport.write(pkt, LCD_WRITE_TIMEOUT)?;
+        let mut buf = [0u8; 512];
+        match self.transport.read(&mut buf, LCD_READ_TIMEOUT) {
+            Ok(n) if n > 0 => Ok(Some(buf)),
+            _ => Ok(None),
+        }
+    }
+
+    /// Re-arm the command channel (device ignores fan cmds after LCD play mode).
+    fn wake(&self) -> Result<()> {
+        for cmd in [0x7Bu8, 0x34, 0x0A] {
+            let _ = self.xfer(&build_cmd(cmd, self.ts()))?;
+            std::thread::sleep(Duration::from_millis(150));
+        }
+        Ok(())
+    }
+
+    fn status(&self) -> Result<Option<Status>> {
+        Ok(self.xfer(&build_cmd(CMD_GET_STATUS, self.ts()))?
+            .as_ref()
+            .and_then(parse_status))
+    }
+
+    fn set_fans(&self, duty_255: u8, sensor_mirror: u16) -> Result<()> {
+        self.xfer(&build_set_fans(duty_255, sensor_mirror, self.ts()))?;
+        Ok(())
+    }
+}
+
+// ─────────────────────────── sensors ───────────────────────────
+
+/// Read k10temp Tctl (°C) from sysfs.
+fn read_cpu_tctl() -> Option<f32> {
+    for hw in std::fs::read_dir("/sys/class/hwmon").ok()? {
+        let dir = hw.ok()?.path();
+        let name = std::fs::read_to_string(dir.join("name")).ok()?;
+        if name.trim() != "k10temp" {
+            continue;
+        }
+        for entry in std::fs::read_dir(&dir).ok()? {
+            let p = entry.ok()?.path();
+            let fname = p.file_name()?.to_str()?.to_string();
+            if fname.ends_with("_label") {
+                if let Ok(label) = std::fs::read_to_string(&p) {
+                    if label.trim() == "Tctl" {
+                        let input = p.to_str()?.replace("_label", "_input");
+                        let milli: f32 = std::fs::read_to_string(&input).ok()?.trim().parse().ok()?;
+                        return Some(milli / 1000.0);
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+fn pct_to_255(pct: f32) -> u8 {
+    (pct.clamp(0.0, 100.0) * 255.0 / 100.0).round() as u8
+}
+
+// ─────────────────────────── control loop ───────────────────────────
+
+fn run() -> Result<()> {
+    let cfg = Config::load();
+    let use_cpu = cfg.temp_source.eq_ignore_ascii_case("cpu");
+    let dt = cfg.interval_secs.max(0.5);
+    let alpha = 1.0 - (-dt / cfg.smoothing_tau_secs.max(0.1)).exp();
+    let max_step = cfg.slew_pct_per_sec * dt;
+
+    println!(
+        "hs2-fanctl: source={} interval={:.1}s tau={:.1}s slew={:.1}%/s curve={:?}",
+        cfg.temp_source, dt, cfg.smoothing_tau_secs, cfg.slew_pct_per_sec, cfg.curve
+    );
+
+    let mut dev = Device::open()?;
+    let mut ema_temp: Option<f32> = None;
+    let mut duty_pct = cfg.min_duty_pct;
+    let mut fails = 0u32;
+    let mut ticks = 0u64;
+
+    loop {
+        let status = match dev.status() {
+            Ok(Some(s)) => {
+                fails = 0;
+                Some(s)
+            }
+            Ok(None) | Err(_) => {
+                fails += 1;
+                if fails == 3 {
+                    eprintln!("no telemetry x3 — re-waking");
+                    let _ = dev.wake();
+                }
+                if fails >= 8 {
+                    eprintln!("device unresponsive — reopening");
+                    std::thread::sleep(Duration::from_secs(2));
+                    match Device::open() {
+                        Ok(d) => {
+                            dev = d;
+                            fails = 0;
+                        }
+                        Err(e) => eprintln!("reopen failed: {e}"),
+                    }
+                }
+                None
+            }
+        };
+
+        // Pick the driving temperature.
+        let raw_temp = if use_cpu {
+            read_cpu_tctl()
+        } else {
+            status.as_ref().map(|s| s.coolant_c)
+        };
+
+        if let Some(t) = raw_temp {
+            let e = ema_temp.map_or(t, |prev| prev + alpha * (t - prev));
+            ema_temp = Some(e);
+            let target = cfg.interp(e);
+            // slew-rate limit
+            duty_pct = if target > duty_pct {
+                (duty_pct + max_step).min(target)
+            } else {
+                (duty_pct - max_step).max(target)
+            };
+            duty_pct = duty_pct.clamp(cfg.min_duty_pct, cfg.max_duty_pct);
+
+            // sensor mirror = the temp L-Connect would display; feed it the die temp
+            // (or coolant) so the pump's on-screen readout stays plausible.
+            let mirror = (read_cpu_tctl().unwrap_or(t) * 10.0) as u16;
+            if let Err(err) = dev.set_fans(pct_to_255(duty_pct), mirror) {
+                eprintln!("set_fans failed: {err}");
+            }
+
+            // Log once every ~10 s.
+            ticks += 1;
+            if ticks % ((10.0 / dt).round() as u64).max(1) == 0 {
+                if let Some(s) = &status {
+                    println!(
+                        "coolant {:.1}C (ema {:.1}) -> duty {:.0}% | fans {}/{}/{} rpm  pump {} rpm",
+                        s.coolant_c, e, duty_pct, s.fan_rpm[0], s.fan_rpm[1], s.fan_rpm[2], s.pump_rpm
+                    );
+                } else {
+                    println!("temp {:.1}C (ema {:.1}) -> duty {:.0}% (no telemetry this tick)", t, e, duty_pct);
+                }
+            }
+        }
+
+        std::thread::sleep(Duration::from_secs_f32(dt));
+    }
+}
+
+fn main() -> Result<()> {
+    run()
+}

--- a/docs/hydroshift2-fan-protocol.md
+++ b/docs/hydroshift2-fan-protocol.md
@@ -1,0 +1,108 @@
+# HydroShift II — pump/fan USB control protocol
+
+Reverse-engineered spec for controlling the **HydroShift II** (`1CBE:A021`) pump/fans over
+its WinUSB link, contributed toward [#101](https://github.com/sgtaziz/lian-li-linux/issues/101).
+Derived from an L-Connect 3 USBPcap capture on Windows and validated live on Linux against a
+standalone probe (offered separately — see *Validation* below). Coolant/RPM readings were
+cross-checked against the pump's own onboard LCD readout.
+
+## Transport
+
+Pump/fan control shares the **same WinUSB channel and DES-CBC scheme as the LCD** — no separate
+interface, and no wireless dongle involved. Bulk `EP 0x01` OUT / `EP 0x81` IN, 512-byte frames.
+
+Host→device frames are DES-CBC encrypted exactly like the LCD commands
+(`key = IV = "slv3tuzx"`, PKCS7 over 500 plaintext bytes → 504 cipher bytes in a 512-byte frame,
+trailer `[510]=0xA1 [511]=0x1A`) — i.e. the existing `crypto.rs::build_winusb`. **Device→host
+replies are plaintext.**
+
+Plaintext command layout (before encryption):
+
+```
+[0]        command byte
+[2]=0x1A [3]=0x6D    fixed magic
+[4:8]      u32 LE timestamp (ms since a monotonic base; must not go backwards)
+[8:]       params
+```
+
+## Wake requirement (the non-obvious part)
+
+Once the device has been put into LCD "play" mode it **silently ignores fan commands and never
+answers status polls**. A cold open from Windows/L-Connect answered immediately, but coming from
+an active LCD session on Linux it did not. A short wake preamble re-arms the command/telemetry
+channel:
+
+**`StopPlay 0x7B` → `StopClock 0x34` → `GetVer 0x0A`** (~150 ms apart).
+
+The first command is swallowed; after `StopClock`/`GetVer` the channel is live. (`GetVer`'s
+plaintext reply carries the device id string at `[8:]`, e.g. `lianlih2_0004_0020`.)
+
+## Commands
+
+### `0xFA` — Get status (poll)
+
+params: none. Plaintext reply:
+
+```
+[8]=0x0A               marker
+[9]                    fan count (0x03)
+[10],[11],[12]         per-fan configured PROFILE duty %  (nominal, not live-RPM-derived)
+[13]                   COOLANT TEMP, whole °C  (verified vs the pump LCD:
+                       [13]=0x28 while the LCD read 40 °C, → 0x29 as it reached 41 °C)
+[14:16],[16:18],[18:20]  fan RPM ×3  (u16 BE)
+[20:22]                pump RPM  (u16 BE)
+[22:28]                constant (7c 35 7f 72 ab e1) — id/serial, not telemetry
+[30:32]                constant 0x0116 — NOT temperature (do not use; it never tracks)
+```
+
+### `0xFB` — Set fan speed
+
+params (12 bytes) + 2-byte CRC:
+
+```
+[8:12]   = FF 0F A2 00        fixed header
+[12:14]  = u16 BE   host sensor mirror — the temp L-Connect shows on-screen; display-only,
+                     any plausible value works
+[14],[15],[16] = fan duty ×3, raw 0–255  (all three equal in every capture)
+[17:20]  = 00 00 00
+[20:22]  = CRC-16/XMODEM (poly 0x1021, init 0x0000, no reflection, no xorout)
+           over params[8:20], big-endian
+```
+
+Pump control is presumably a sibling opcode / different fixed header — not captured yet (the
+reference capture only moved the fans; the pump stayed on its firmware curve).
+
+## Behaviour
+
+A single `0xFB` is applied, then **decays back to the firmware temp-curve within a few seconds**.
+To hold a manual speed you must re-stream `0xFB` continuously (L-Connect sends one about every
+4 s). When streaming stops, the onboard curve reasserts on its own — a convenient built-in
+failsafe: the cooler can never get stuck at a manual setpoint if the host process dies.
+
+## Validated control authority
+
+Live on Linux, streaming `0xFB` at a fixed duty:
+
+| duty (0–255) | fans (RPM) |
+|---|---|
+| 50  | ~415 |
+| firmware idle (~41 %) | ~1400–1600 |
+| 255 | ~2150 |
+
+Clean and monotonic across all three fans.
+
+## Validation
+
+Confirmed end-to-end with a small standalone probe built against this workspace's
+`lianli-devices`/`lianli-transport` crates (reusing `crypto.rs`'s `build_winusb`): it does the
+wake preamble, polls `0xFA`, streams `0xFB` at a target duty, and reads back RPM/coolant. Happy
+to contribute the probe binary and a longer-run controller as follow-ups if useful — just say
+the word.
+
+## Suggested integration point (defer to your design)
+
+The device shares the WinUSB handle with the LCD, so a fan/pump driver likely wants to live under
+the same `WinUsbLcdDevice`/transport rather than the HID `create_wired_controllers` path (which is
+HID-only — the reason a directly-connected HydroShift II currently enumerates with zero wired fan
+devices). A `FanDevice`-style impl would map `set_fan_speeds` → streamed `0xFB` and
+`read_fan_rpm`/pump RPM/coolant → `0xFA`, with the wake preamble in its init.


### PR DESCRIPTION
Following up on #101 — the reverse-engineered pump/fan control spec for the HydroShift II (`1CBE:A021`), plus a small working service that uses it.

## What's here

- **`docs/hydroshift2-fan-protocol.md`** — the protocol. It rides the **same WinUSB channel + DES-CBC scheme as the LCD** (no separate interface, no dongle). `0xFB` sets fan duty (0–255) with a **CRC-16/XMODEM** trailer; `0xFA` polls status (coolant temp is byte `[13]`, whole °C — verified against the pump's own LCD). The non-obvious bit is a **wake preamble** (`StopPlay` → `StopClock` → `GetVer`) needed after LCD play mode, without which the device silently ignores fan commands.
- **`hs2-fanctl`** (new `lianli-devices` bin) — a standalone service that replaces the pulsating firmware curve with a smooth coolant-temp-driven one (EMA + slew-limit, streams `0xFB` to hold the setpoint, firmware curve resumes as a failsafe when it stops). Sample config, systemd unit, and monitoring commands in **`contrib/hs2-fanctl/`**.

Validated live on Linux (three fans, monotonic across 50→255 duty; coolant field cross-checked against the LCD readout). Builds clean (`cargo build --release -p lianli-devices --bin hs2-fanctl`).

Marked **draft** so you can take the spec as reference for your own integration or use the service as-is — whatever fits best. Happy to restructure, drop the service to keep it doc-only, or follow up with the reverse-engineering probe.

<sub>🤖 Reverse-engineering and this PR were done with [Claude Code](https://claude.com/claude-code); findings verified on real hardware.</sub>