### PR TITLE
feat(hydroshift): expose wired coolant telemetry to fan curves

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3112,6 +3112,7 @@ version = "0.6.1"
 dependencies = [
  "anyhow",
  "hex",
+ "libc",
  "reqwest",
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -224,8 +224,29 @@ Each LCD entry specifies a target device (by serial), media type, and orientatio
 
 ### Fan Curves
 
-Fan curves map a temperature source (any shell command) to a speed percentage.
+Fan curves map a temperature source to a speed percentage.
 Points are linearly interpolated; temperatures outside the curve range clamp to the nearest point's speed.
+
+Wired HydroShift LCD and Galahad II LCD/Vision controllers can use their
+coolant sensor directly. The serialized source name remains
+`wireless_coolant` for backward compatibility:
+
+```json
+{
+  "name": "AIO coolant",
+  "temp_source": {
+    "type": "wireless_coolant",
+    "device_id": "hid:<device-id>"
+  },
+  "curve": [[28, 25], [34, 40], [38, 70], [42, 100]]
+}
+```
+
+Active HID polling is enabled only when a configured fan group references such
+a curve. Failed polls back off to avoid repeatedly disturbing the USB device.
+If telemetry is missing or older than ten seconds, curve-controlled outputs use
+full PWM until a fresh valid sample arrives; constant pump/fan settings are left
+unchanged.
 
 ### Fan Speed Modes
 

--- a/crates/lianli-daemon/src/fan_controller.rs
+++ b/crates/lianli-daemon/src/fan_controller.rs
@@ -4,13 +4,43 @@ use lianli_devices::traits::FanDevice;
 use lianli_devices::wireless::WirelessController;
 use lianli_shared::fan::{FanConfig, FanCurve, FanSpeed};
 use lianli_shared::sensors::{self, ResolvedSensor, SensorInfo, SensorSource};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::Sender;
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 use tracing::{debug, info, warn};
+
+const COOLANT_POLL_INTERVAL: Duration = Duration::from_secs(1);
+const COOLANT_POLL_MAX_BACKOFF: Duration = Duration::from_secs(60);
+
+#[derive(Debug)]
+struct CoolantPollState {
+    failures: u32,
+    next_poll: Instant,
+}
+
+impl CoolantPollState {
+    fn ready(now: Instant) -> Self {
+        Self {
+            failures: 0,
+            next_poll: now,
+        }
+    }
+
+    fn success(&mut self, now: Instant) {
+        self.failures = 0;
+        self.next_poll = now + COOLANT_POLL_INTERVAL;
+    }
+
+    fn failure(&mut self, now: Instant) {
+        self.failures = self.failures.saturating_add(1);
+        let shift = self.failures.saturating_sub(1).min(5);
+        let delay = COOLANT_POLL_INTERVAL * (1_u32 << shift);
+        self.next_poll = now + delay.min(COOLANT_POLL_MAX_BACKOFF);
+    }
+}
 
 pub struct FanController {
     config: FanConfig,
@@ -131,6 +161,11 @@ fn fan_control_thread(
     let mut temp_ema: HashMap<SensorSource, f32> = HashMap::new();
     let mut sensor_cache: HashMap<SensorSource, ResolvedSensor> = HashMap::new();
     let mut fan_states: HashMap<usize, FanState> = HashMap::new();
+    let coolant_device_ids = coolant_devices_for_config(&config, &curves);
+    let mut coolant_poll_states: HashMap<String, CoolantPollState> = coolant_device_ids
+        .iter()
+        .map(|id| (id.clone(), CoolantPollState::ready(Instant::now())))
+        .collect();
 
     let mut mb_sync_init: HashMap<String, HashMap<u8, bool>> = HashMap::new();
     for group in config.speeds.iter() {
@@ -208,6 +243,49 @@ fn fan_control_thread(
 
         let tick_start = Instant::now();
         last_update = tick_start;
+
+        // Refresh wired AIO coolant telemetry before resolving curve sensors.
+        // This also creates the runtime sensor on the first tick after boot,
+        // without depending on the separate IPC telemetry polling schedule.
+        for device_id in &coolant_device_ids {
+            let Some(dev) = wired.get(device_id) else {
+                continue;
+            };
+            let state = coolant_poll_states
+                .entry(device_id.clone())
+                .or_insert_with(|| CoolantPollState::ready(tick_start));
+            if tick_start < state.next_poll {
+                continue;
+            }
+
+            match dev.poll_coolant_temp() {
+                Ok(Some(temp)) if temp.is_finite() && (0.0..=100.0).contains(&temp) => {
+                    match sensors::write_coolant_temp(device_id, temp) {
+                        Ok(()) => state.success(tick_start),
+                        Err(err) => {
+                            state.failure(tick_start);
+                            warn!("Failed to publish coolant temperature for {device_id}: {err:#}");
+                        }
+                    }
+                }
+                Ok(Some(temp)) => {
+                    state.failure(tick_start);
+                    warn!("Ignoring invalid coolant temperature {temp:?} for {device_id}");
+                }
+                Ok(None) => {
+                    state.failure(tick_start);
+                    debug!("Device {device_id} does not expose coolant telemetry");
+                }
+                Err(err) => {
+                    state.failure(tick_start);
+                    warn!(
+                        "Failed to poll coolant temperature for {device_id}; retry {} in {:?}: {err:#}",
+                        state.failures,
+                        state.next_poll.saturating_duration_since(tick_start)
+                    );
+                }
+            }
+        }
 
         for (group_idx, group) in config.speeds.iter().enumerate() {
             let is_wireless = group
@@ -340,6 +418,25 @@ fn map_stop(speeds: &[u8; 4], stop: u8) -> [u8; 4] {
     ]
 }
 
+fn coolant_devices_for_config(
+    config: &FanConfig,
+    curves: &HashMap<String, FanCurve>,
+) -> HashSet<String> {
+    config
+        .speeds
+        .iter()
+        .flat_map(|group| group.speeds.iter())
+        .filter_map(|speed| match speed {
+            FanSpeed::Curve(name) => curves.get(name),
+            _ => None,
+        })
+        .filter_map(|curve| match curve.effective_source() {
+            SensorSource::WirelessCoolant { device_id } => Some(device_id),
+            _ => None,
+        })
+        .collect()
+}
+
 fn apply_wireless_by_id(
     wireless: &Option<Arc<WirelessController>>,
     device_id: &str,
@@ -445,8 +542,19 @@ fn calculate_fan_speeds(
                     .ok_or_else(|| anyhow::anyhow!("Curve '{curve_name}' not found"))?;
 
                 let source = curve.effective_source();
-                let temp = smoothed_temperature(&source, sensor_cache, temp_ema, all_sensors)?;
-                let speed_percent = interpolate_curve(&curve.curve, temp);
+                let temp = match smoothed_temperature(&source, sensor_cache, temp_ema, all_sensors)
+                {
+                    Ok(temp) => temp,
+                    Err(err) if matches!(source, SensorSource::WirelessCoolant { .. }) => {
+                        warn!(
+                            "Coolant sensor unavailable for fan {i}; applying full-speed fail-safe: {err:#}"
+                        );
+                        pwm_values[i] = u8::MAX;
+                        continue;
+                    }
+                    Err(err) => return Err(err),
+                };
+                let speed_percent = interpolate_curve(&curve.curve, temp).clamp(0.0, 100.0);
                 let target_pwm = (speed_percent * 2.55) as u8;
 
                 let pwm = match prev_state {
@@ -497,10 +605,16 @@ fn smoothed_temperature(
         }
         Ok(temp) => {
             debug!("Ignoring out-of-range temperature {temp:.1}°C");
+            if matches!(source, SensorSource::WirelessCoolant { .. }) {
+                ema.remove(source);
+            }
         }
         Err(err) => {
             debug!("Sensor read failed: {err}");
             cache.remove(source);
+            if matches!(source, SensorSource::WirelessCoolant { .. }) {
+                ema.remove(source);
+            }
         }
     }
 
@@ -540,4 +654,136 @@ fn interpolate_curve(curve: &[(f32, f32)], temp: f32) -> f32 {
     }
 
     50.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lianli_shared::fan::FanGroup;
+
+    fn coolant_curve(device_id: &str) -> FanCurve {
+        FanCurve {
+            name: "coolant".into(),
+            temp_source: Some(SensorSource::WirelessCoolant {
+                device_id: device_id.into(),
+            }),
+            temp_command: String::new(),
+            curve: vec![(25.0, 20.0), (45.0, 100.0)],
+        }
+    }
+
+    #[test]
+    fn only_configured_coolant_devices_are_polled() {
+        let curve = coolant_curve("hid:aio");
+        let curves = HashMap::from([(curve.name.clone(), curve)]);
+        let config = FanConfig {
+            speeds: vec![FanGroup {
+                device_id: Some("hid:aio".into()),
+                speeds: [
+                    FanSpeed::Curve("coolant".into()),
+                    FanSpeed::Constant(64),
+                    FanSpeed::Constant(64),
+                    FanSpeed::Constant(128),
+                ],
+            }],
+            ..FanConfig::default()
+        };
+
+        assert_eq!(
+            coolant_devices_for_config(&config, &curves),
+            HashSet::from(["hid:aio".to_string()])
+        );
+        assert!(coolant_devices_for_config(&FanConfig::default(), &curves).is_empty());
+    }
+
+    #[test]
+    fn coolant_poll_failures_back_off_and_recovery_resets_delay() {
+        let now = Instant::now();
+        let mut state = CoolantPollState::ready(now);
+        state.failure(now);
+        assert_eq!(state.failures, 1);
+        assert_eq!(state.next_poll.duration_since(now), Duration::from_secs(1));
+
+        let second = state.next_poll;
+        state.failure(second);
+        assert_eq!(
+            state.next_poll.duration_since(second),
+            Duration::from_secs(2)
+        );
+
+        state.success(state.next_poll);
+        assert_eq!(state.failures, 0);
+        assert_eq!(
+            state
+                .next_poll
+                .duration_since(second + Duration::from_secs(2)),
+            COOLANT_POLL_INTERVAL
+        );
+    }
+
+    #[test]
+    fn missing_coolant_sensor_uses_full_speed_fail_safe() {
+        let source = SensorSource::WirelessCoolant {
+            device_id: format!("missing-test-device-{}", std::process::id()),
+        };
+        let curve = FanCurve {
+            name: "coolant".into(),
+            temp_source: Some(source),
+            temp_command: String::new(),
+            curve: vec![(25.0, 20.0), (45.0, 100.0)],
+        };
+        let curves = HashMap::from([(curve.name.clone(), curve)]);
+        let mut cache = HashMap::new();
+        let mut ema = HashMap::new();
+        let speeds = calculate_fan_speeds(
+            &[
+                FanSpeed::Curve("coolant".into()),
+                FanSpeed::Constant(64),
+                FanSpeed::Constant(64),
+                FanSpeed::Constant(128),
+            ],
+            &curves,
+            &mut cache,
+            &mut ema,
+            &[],
+            None,
+            1.0,
+            5,
+        )
+        .unwrap();
+        assert_eq!(speeds, [u8::MAX, 64, 64, 128]);
+    }
+
+    #[test]
+    fn curve_percent_is_clamped_before_pwm_conversion() {
+        let source = SensorSource::Command {
+            cmd: "unused".into(),
+        };
+        let curve = FanCurve {
+            name: "bad-range".into(),
+            temp_source: Some(source.clone()),
+            temp_command: "unused".into(),
+            curve: vec![(20.0, -50.0), (40.0, 150.0)],
+        };
+        let curves = HashMap::from([(curve.name.clone(), curve)]);
+        let mut cache = HashMap::from([(source, ResolvedSensor::Constant(40.0))]);
+        let mut ema = HashMap::new();
+        let speeds = calculate_fan_speeds(
+            &[
+                FanSpeed::Curve("bad-range".into()),
+                FanSpeed::Constant(0),
+                FanSpeed::Constant(0),
+                FanSpeed::Constant(0),
+            ],
+            &curves,
+            &mut cache,
+            &mut ema,
+            &[],
+            None,
+            1.0,
+            5,
+        )
+        .unwrap();
+        assert_eq!(speeds[0], u8::MAX);
+    }
 }

--- a/crates/lianli-daemon/src/service/sync.rs
+++ b/crates/lianli-daemon/src/service/sync.rs
@@ -257,7 +257,11 @@ impl ServiceManager {
                     .telemetry
                     .coolant_temps
                     .insert(device_id.clone(), temp as f32);
-                lianli_shared::sensors::write_coolant_temp(&device_id, temp as f32);
+                if let Err(err) =
+                    lianli_shared::sensors::write_coolant_temp(&device_id, temp as f32)
+                {
+                    debug!("Failed to publish coolant temperature for {device_id}: {err:#}");
+                }
             }
         }
 
@@ -316,6 +320,21 @@ impl ServiceManager {
 
         // Read wired fan RPMs and split per port.
         for (base_id, dev) in self.wired_fan_devices.iter() {
+            // The fan controller publishes live wired-AIO coolant readings to
+            // the runtime sensor before calculating its curves.  Mirror that
+            // value into IPC telemetry without issuing a second USB handshake.
+            match lianli_shared::sensors::read_coolant_temp(base_id) {
+                Ok(temp) if temp > 0.0 && temp <= 100.0 => {
+                    ipc_state
+                        .telemetry
+                        .coolant_temps
+                        .insert(base_id.clone(), temp);
+                }
+                _ => {
+                    ipc_state.telemetry.coolant_temps.remove(base_id);
+                }
+            }
+
             if let Ok(all_rpms) = dev.read_fan_rpm() {
                 let ports = dev.fan_port_info();
                 let per_fan = dev.per_fan_control();

--- a/crates/lianli-devices/src/hydroshift_lcd/controller.rs
+++ b/crates/lianli-devices/src/hydroshift_lcd/controller.rs
@@ -36,13 +36,146 @@ fn find_au_split(data: &[u8]) -> Option<usize> {
     None
 }
 
+fn parse_handshake_response(resp: &[u8]) -> Result<AioHandshake> {
+    if resp.len() < A_HEADER_LEN {
+        bail!(
+            "AIO LCD: handshake response too short ({} < {A_HEADER_LEN} bytes)",
+            resp.len()
+        );
+    }
+    if resp[0] != REPORT_ID_A || resp[1] != CMD_HANDSHAKE {
+        bail!(
+            "AIO LCD: unexpected handshake response (report={:#04x}, command={:#04x})",
+            resp[0],
+            resp[1]
+        );
+    }
+
+    let data_len = resp[5] as usize;
+    let available = resp.len() - A_HEADER_LEN;
+    if data_len > available {
+        bail!("AIO LCD: truncated handshake payload ({data_len} declared, {available} available)");
+    }
+    if data_len < 4 {
+        bail!("AIO LCD: handshake payload too short ({data_len} bytes)");
+    }
+
+    let data = &resp[A_HEADER_LEN..A_HEADER_LEN + data_len];
+    let temp_valid = data_len >= 5 && data[4] != 0;
+    let coolant_temp = if data_len >= 7 {
+        let integer = data[5] as f32;
+        let fraction = (data[6] % 10) as f32 / 10.0;
+        integer + fraction
+    } else {
+        0.0
+    };
+
+    Ok(AioHandshake {
+        fan_rpm: u16::from_be_bytes([data[0], data[1]]),
+        pump_rpm: u16::from_be_bytes([data[2], data[3]]),
+        temp_valid,
+        coolant_temp,
+    })
+}
+
+fn validate_coolant_sample(hs: &AioHandshake) -> Result<f32> {
+    if !hs.temp_valid || !hs.coolant_temp.is_finite() || !(0.0..=100.0).contains(&hs.coolant_temp) {
+        bail!(
+            "Coolant telemetry invalid (temp={:.1}°C, pump={}rpm, valid={})",
+            hs.coolant_temp,
+            hs.pump_rpm,
+            hs.temp_valid
+        );
+    }
+
+    // Some controllers briefly return this placeholder while the LCD
+    // interface is starting. Reject the complete signature, but do not reject
+    // a real hot sample or a zero-RPM pump: both must reach the fail-safe path.
+    if hs.fan_rpm == 0 && hs.pump_rpm == 0 && (hs.coolant_temp - 1.0).abs() < f32::EPSILON {
+        bail!("Coolant telemetry returned the startup placeholder");
+    }
+
+    Ok(hs.coolant_temp)
+}
+
+#[cfg(test)]
+mod telemetry_tests {
+    use super::*;
+
+    fn response(fan_rpm: u16, pump_rpm: u16, valid: bool, temp: (u8, u8)) -> Vec<u8> {
+        let mut packet = vec![0; A_HEADER_LEN + 7];
+        packet[0] = REPORT_ID_A;
+        packet[1] = CMD_HANDSHAKE;
+        packet[5] = 7;
+        packet[6..8].copy_from_slice(&fan_rpm.to_be_bytes());
+        packet[8..10].copy_from_slice(&pump_rpm.to_be_bytes());
+        packet[10] = u8::from(valid);
+        packet[11] = temp.0;
+        packet[12] = temp.1;
+        packet
+    }
+
+    #[test]
+    fn parses_complete_handshake() {
+        let hs = parse_handshake_response(&response(1234, 2876, true, (35, 7))).unwrap();
+        assert_eq!(hs.fan_rpm, 1234);
+        assert_eq!(hs.pump_rpm, 2876);
+        assert!(hs.temp_valid);
+        assert!((hs.coolant_temp - 35.7).abs() < 0.01);
+    }
+
+    #[test]
+    fn rejects_every_truncated_handshake_without_panicking() {
+        let complete = response(1234, 2876, true, (35, 7));
+        for len in 0..complete.len() {
+            assert!(
+                parse_handshake_response(&complete[..len]).is_err(),
+                "length {len} unexpectedly parsed"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_mismatched_report_and_command() {
+        let mut packet = response(1234, 2876, true, (35, 7));
+        packet[0] = REPORT_ID_B;
+        assert!(parse_handshake_response(&packet).is_err());
+
+        packet[0] = REPORT_ID_A;
+        packet[1] = CMD_GET_FIRMWARE;
+        assert!(parse_handshake_response(&packet).is_err());
+    }
+
+    #[test]
+    fn rejects_declared_payload_larger_than_response() {
+        let mut packet = response(1234, 2876, true, (35, 7));
+        packet[5] = 8;
+        assert!(parse_handshake_response(&packet).is_err());
+    }
+
+    #[test]
+    fn validates_hot_and_zero_pump_samples() {
+        let hot = parse_handshake_response(&response(900, 0, true, (99, 9))).unwrap();
+        assert!((validate_coolant_sample(&hot).unwrap() - 99.9).abs() < 0.01);
+    }
+
+    #[test]
+    fn rejects_invalid_and_placeholder_samples() {
+        let invalid = parse_handshake_response(&response(900, 2800, false, (35, 0))).unwrap();
+        assert!(validate_coolant_sample(&invalid).is_err());
+
+        let placeholder = parse_handshake_response(&response(0, 0, true, (1, 0))).unwrap();
+        assert!(validate_coolant_sample(&placeholder).is_err());
+    }
+}
+
 /// HydroShift LCD / Galahad2 LCD AIO controller.
 ///
 /// Provides pump + fan speed control, coolant temperature reading, and LCD streaming.
 pub struct HydroShiftLcdController {
     device: Arc<Mutex<HidBackend>>,
     variant: AioLcdVariant,
-    last_handshake: Option<AioHandshake>,
+    last_handshake: Mutex<Option<AioHandshake>>,
     brightness: u8,
     rotation: ScreenRotation,
     initialized: bool,
@@ -60,7 +193,7 @@ impl HydroShiftLcdController {
         Ok(Self {
             device,
             variant,
-            last_handshake: None,
+            last_handshake: Mutex::new(None),
             brightness: 50,
             rotation: ScreenRotation::Rotate0,
             initialized: false,
@@ -128,41 +261,20 @@ impl HydroShiftLcdController {
         Ok(())
     }
 
-    pub fn handshake(&mut self) -> Result<AioHandshake> {
+    pub fn handshake(&self) -> Result<AioHandshake> {
         let timeout = if self.initialized {
             READ_TIMEOUT_MS
         } else {
             INIT_READ_TIMEOUT_MS
         };
         let resp = self.send_a_command(CMD_HANDSHAKE, &[], timeout)?;
-        let data = &resp[A_HEADER_LEN..];
-        let data_len = resp[5] as usize;
-
-        if data_len < 4 {
-            bail!("AIO LCD: handshake response too short ({data_len} bytes)");
-        }
-
-        let temp_valid = data_len >= 5 && data[4] != 0;
-        let coolant_temp = if data_len >= 7 {
-            let integer = data[5] as f32;
-            let fraction = (data[6] % 10) as f32 / 10.0;
-            integer + fraction
-        } else {
-            0.0
-        };
-
-        let hs = AioHandshake {
-            fan_rpm: u16::from_be_bytes([data[0], data[1]]),
-            pump_rpm: u16::from_be_bytes([data[2], data[3]]),
-            temp_valid,
-            coolant_temp,
-        };
+        let hs = parse_handshake_response(&resp)?;
 
         debug!(
             "Handshake: fan={}rpm pump={}rpm temp_valid={} temp={:.1}°C",
             hs.fan_rpm, hs.pump_rpm, hs.temp_valid, hs.coolant_temp
         );
-        self.last_handshake = Some(hs.clone());
+        *self.last_handshake.lock() = Some(hs.clone());
         Ok(hs)
     }
 
@@ -382,20 +494,35 @@ impl HydroShiftLcdController {
         self.write_a_command_internal(&mut *dev, cmd, data)?;
 
         let mut buf = [0u8; A_PACKET_SIZE];
-        let n = dev
-            .read_timeout(&mut buf, timeout_ms)
-            .context("AIO LCD: read A-response")?;
+        let timeout = std::time::Duration::from_millis(timeout_ms.max(0) as u64);
+        let deadline = Instant::now() + timeout;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                bail!(
+                    "AIO LCD: no matching response to A-command {cmd:#04x} (timeout after {timeout_ms}ms)"
+                );
+            }
+            let remaining_ms = remaining.as_millis().min(i32::MAX as u128).max(1) as i32;
+            let n = dev
+                .read_timeout(&mut buf, remaining_ms)
+                .context("AIO LCD: read A-response")?;
 
-        debug!(
-            "A-cmd {cmd:#04x}: response {n} bytes, raw={:02x?}",
-            &buf[..n.min(20)]
-        );
+            debug!(
+                "A-cmd {cmd:#04x}: response {n} bytes, raw={:02x?}",
+                &buf[..n.min(20)]
+            );
 
-        if n == 0 {
-            bail!("AIO LCD: no response to A-command {cmd:#04x} (timeout after {timeout_ms}ms)");
+            if n == 0 {
+                bail!(
+                    "AIO LCD: no response to A-command {cmd:#04x} (timeout after {timeout_ms}ms)"
+                );
+            }
+            if n >= 2 && buf[0] == REPORT_ID_A && buf[1] == cmd {
+                return Ok(buf[..n].to_vec());
+            }
+            debug!("A-cmd {cmd:#04x}: skipping stale or unrelated response");
         }
-
-        Ok(buf[..n].to_vec())
     }
 
     /// Public write_a_command. Locks `HidBackend` for the duration of the call —
@@ -533,6 +660,7 @@ impl FanDevice for HydroShiftLcdController {
     fn read_fan_rpm(&self) -> Result<Vec<u16>> {
         Ok(vec![self
             .last_handshake
+            .lock()
             .as_ref()
             .map(|hs| hs.fan_rpm)
             .unwrap_or(0)])
@@ -540,6 +668,12 @@ impl FanDevice for HydroShiftLcdController {
 
     fn fan_slot_count(&self) -> u8 {
         1
+    }
+
+    fn poll_coolant_temp(&self) -> Result<Option<f32>> {
+        self.handshake()
+            .and_then(|hs| validate_coolant_sample(&hs))
+            .map(Some)
     }
 
     fn has_pump_control(&self) -> bool {
@@ -567,6 +701,9 @@ impl FanDevice for Arc<HydroShiftLcdController> {
     fn fan_slot_count(&self) -> u8 {
         (**self).fan_slot_count()
     }
+    fn poll_coolant_temp(&self) -> Result<Option<f32>> {
+        <HydroShiftLcdController as FanDevice>::poll_coolant_temp(self)
+    }
     fn has_pump_control(&self) -> bool {
         (**self).has_pump_control()
     }
@@ -579,13 +716,14 @@ impl AioDevice for HydroShiftLcdController {
     fn read_pump_rpm(&self) -> Result<u16> {
         Ok(self
             .last_handshake
+            .lock()
             .as_ref()
             .map(|hs| hs.pump_rpm)
             .unwrap_or(0))
     }
 
     fn read_coolant_temp(&self) -> Result<f32> {
-        match &self.last_handshake {
+        match &*self.last_handshake.lock() {
             Some(hs) if hs.temp_valid => Ok(hs.coolant_temp),
             Some(_) => bail!("Coolant temperature sensor reports invalid"),
             None => bail!("No handshake data available"),

--- a/crates/lianli-devices/src/hydroshift_lcd/controller.rs
+++ b/crates/lianli-devices/src/hydroshift_lcd/controller.rs
@@ -61,7 +61,7 @@ fn parse_handshake_response(resp: &[u8]) -> Result<AioHandshake> {
     }
 
     let data = &resp[A_HEADER_LEN..A_HEADER_LEN + data_len];
-    let temp_valid = data_len >= 5 && data[4] != 0;
+    let temp_valid = data_len >= 7 && data[4] != 0;
     let coolant_temp = if data_len >= 7 {
         let integer = data[5] as f32;
         let fraction = (data[6] % 10) as f32 / 10.0;
@@ -151,6 +151,18 @@ mod telemetry_tests {
         let mut packet = response(1234, 2876, true, (35, 7));
         packet[5] = 8;
         assert!(parse_handshake_response(&packet).is_err());
+    }
+
+    #[test]
+    fn incomplete_temperature_fields_remain_invalid() {
+        for data_len in [5_usize, 6] {
+            let mut packet = response(1234, 2876, true, (35, 7));
+            packet[5] = data_len as u8;
+            packet.truncate(A_HEADER_LEN + data_len);
+            let hs = parse_handshake_response(&packet).unwrap();
+            assert!(!hs.temp_valid);
+            assert!(validate_coolant_sample(&hs).is_err());
+        }
     }
 
     #[test]
@@ -491,6 +503,26 @@ impl HydroShiftLcdController {
 
     fn send_a_command(&self, cmd: u8, data: &[u8], timeout_ms: i32) -> Result<Vec<u8>> {
         let mut dev = self.device.lock();
+
+        // A response that arrived after a previous timeout has no transaction
+        // identifier and is otherwise indistinguishable from a fresh response
+        // to the same command. Drain the bounded HID queue before issuing the
+        // new request so delayed telemetry cannot receive a fresh timestamp.
+        let mut stale = [0u8; A_PACKET_SIZE];
+        for _ in 0..16 {
+            match dev.read_timeout(&mut stale, 0) {
+                Ok(0) => break,
+                Ok(n) => debug!(
+                    "A-cmd {cmd:#04x}: drained stale response ({n} bytes, raw={:02x?})",
+                    &stale[..n.min(20)]
+                ),
+                Err(err) => {
+                    debug!("A-cmd {cmd:#04x}: stale-response drain stopped: {err}");
+                    break;
+                }
+            }
+        }
+
         self.write_a_command_internal(&mut *dev, cmd, data)?;
 
         let mut buf = [0u8; A_PACKET_SIZE];
@@ -724,8 +756,7 @@ impl AioDevice for HydroShiftLcdController {
 
     fn read_coolant_temp(&self) -> Result<f32> {
         match &*self.last_handshake.lock() {
-            Some(hs) if hs.temp_valid => Ok(hs.coolant_temp),
-            Some(_) => bail!("Coolant temperature sensor reports invalid"),
+            Some(hs) => validate_coolant_sample(hs),
             None => bail!("No handshake data available"),
         }
     }

--- a/crates/lianli-devices/src/traits.rs
+++ b/crates/lianli-devices/src/traits.rs
@@ -12,6 +12,15 @@ pub trait FanDevice: Send + Sync {
     fn read_fan_rpm(&self) -> Result<Vec<u16>>;
     fn fan_slot_count(&self) -> u8;
 
+    /// Poll a coolant temperature sensor, when the device exposes one.
+    ///
+    /// `Ok(None)` distinguishes devices without a coolant sensor from a
+    /// temporary read failure. Implementations may refresh other cached
+    /// telemetry as part of the same hardware transaction.
+    fn poll_coolant_temp(&self) -> Result<Option<f32>> {
+        Ok(None)
+    }
+
     /// Per-port fan counts: `(port_index, fan_count)`.
     /// Default: single port with `fan_slot_count()` fans.
     fn fan_port_info(&self) -> Vec<(u8, u8)> {

--- a/crates/lianli-shared/Cargo.toml
+++ b/crates/lianli-shared/Cargo.toml
@@ -11,3 +11,4 @@ tracing = { workspace = true }
 reqwest = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
+libc = { workspace = true }

--- a/crates/lianli-shared/src/media.rs
+++ b/crates/lianli-shared/src/media.rs
@@ -42,6 +42,7 @@ pub enum SensorSourceConfig {
         card_index: u32,
     },
     #[serde(rename = "wireless_coolant")]
+    // Serialized name retained for compatibility; also used by wired AIOs.
     WirelessCoolant {
         device_id: String,
     },
@@ -209,7 +210,7 @@ impl SensorDescriptor {
             SensorSourceConfig::AmdGpuUsage { .. } => {}
             SensorSourceConfig::WirelessCoolant { device_id } => {
                 if device_id.trim().is_empty() {
-                    anyhow::bail!("wireless coolant device_id must not be empty");
+                    anyhow::bail!("coolant device_id must not be empty");
                 }
             }
             SensorSourceConfig::CpuUsage

--- a/crates/lianli-shared/src/sensors/mod.rs
+++ b/crates/lianli-shared/src/sensors/mod.rs
@@ -8,7 +8,7 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 pub mod enumerate;
 pub mod picker;
@@ -23,7 +23,7 @@ pub use picker::{
     find_default_cpu_temp, find_default_gpu_temp, infer_sensor_category, pick_source_for_category,
 };
 pub use read::{get_mem_usage, read_sensor_value};
-pub use resolve::{coolant_runtime_path, resolve_sensor, write_coolant_temp};
+pub use resolve::{coolant_runtime_path, read_coolant_temp, resolve_sensor, write_coolant_temp};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -168,7 +168,10 @@ pub enum ResolvedSensor {
         metric: NvidiaMetric,
     },
     ShellCommand(String),
-    RuntimeFile(PathBuf),
+    RuntimeFile {
+        path: PathBuf,
+        max_age: Option<Duration>,
+    },
     Virtual {
         source: SensorSource,
         divider: usize,

--- a/crates/lianli-shared/src/sensors/read.rs
+++ b/crates/lianli-shared/src/sensors/read.rs
@@ -38,13 +38,30 @@ pub fn read_sensor_value(resolved: &ResolvedSensor) -> anyhow::Result<f32> {
             _ => anyhow::bail!("unexpected virtual sensor source"),
         },
         ResolvedSensor::NvidiaGpu { index, metric } => Ok(nvidia_cache_get(*index, *metric)),
-        ResolvedSensor::RuntimeFile(path) => {
+        ResolvedSensor::RuntimeFile { path, max_age } => {
+            if let Some(max_age) = max_age {
+                let modified = std::fs::metadata(path)
+                    .and_then(|metadata| metadata.modified())
+                    .map_err(|e| anyhow::anyhow!("metadata {}: {e}", path.display()))?;
+                let age = modified
+                    .elapsed()
+                    .map_err(|e| anyhow::anyhow!("timestamp {}: {e}", path.display()))?;
+                if age > *max_age {
+                    anyhow::bail!(
+                        "runtime sensor {} is stale ({age:?} > {max_age:?})",
+                        path.display()
+                    );
+                }
+            }
             let content = std::fs::read_to_string(path)
                 .map_err(|e| anyhow::anyhow!("reading {}: {e}", path.display()))?;
             let temp: f32 = content
                 .trim()
                 .parse()
                 .map_err(|e| anyhow::anyhow!("parsing {}: {e}", path.display()))?;
+            if !temp.is_finite() {
+                anyhow::bail!("runtime sensor {} is not finite", path.display());
+            }
             Ok(temp)
         }
         ResolvedSensor::ShellCommand(cmd) => {

--- a/crates/lianli-shared/src/sensors/resolve.rs
+++ b/crates/lianli-shared/src/sensors/resolve.rs
@@ -1,7 +1,16 @@
 use super::enumerate::{get_pci_id_from_path, get_unit};
 use super::{RateState, ResolvedSensor, SensorSource};
+use anyhow::{Context, Result};
+use sha2::{Digest, Sha256};
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+const COOLANT_MAX_AGE: Duration = Duration::from_secs(10);
+static TEMP_FILE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 pub fn resolve_sensor(source: &SensorSource, divider: usize) -> Option<ResolvedSensor> {
     match source {
@@ -96,11 +105,14 @@ pub fn resolve_sensor(source: &SensorSource, divider: usize) -> Option<ResolvedS
         SensorSource::Command { cmd } => Some(ResolvedSensor::ShellCommand(cmd.clone())),
         SensorSource::WirelessCoolant { device_id } => {
             let path = coolant_runtime_path(device_id);
-            if path.exists() {
-                Some(ResolvedSensor::RuntimeFile(path))
-            } else {
-                None
-            }
+            // Wired AIO telemetry creates this runtime file shortly after the
+            // daemon has initialized its media assets.  Keep the path resolved
+            // even when the first value has not been published yet so custom
+            // LCD widgets retry the read and start updating as soon as it is.
+            Some(ResolvedSensor::RuntimeFile {
+                path,
+                max_age: Some(COOLANT_MAX_AGE),
+            })
         }
         SensorSource::NetworkRate { iface, direction } => Some(ResolvedSensor::NetworkRate {
             iface: iface.clone(),
@@ -117,15 +129,164 @@ pub fn resolve_sensor(source: &SensorSource, divider: usize) -> Option<ResolvedS
     }
 }
 
-/// Runtime path for a wireless coolant temperature file.
-pub fn coolant_runtime_path(device_id: &str) -> PathBuf {
-    let runtime_dir = std::env::var("XDG_RUNTIME_DIR").unwrap_or_else(|_| "/tmp".to_string());
-    let sanitized = device_id.replace(':', "-");
-    PathBuf::from(format!("{runtime_dir}/lianli-coolant-{sanitized}"))
+fn runtime_base_dir() -> PathBuf {
+    std::env::var_os("XDG_RUNTIME_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            std::env::temp_dir().join(format!("lianli-linux-{}", std::process::id()))
+        })
+        .join("lianli-linux")
 }
 
-/// Write a coolant temperature value to the runtime file.
-pub fn write_coolant_temp(device_id: &str, temp_c: f32) {
-    let path = coolant_runtime_path(device_id);
-    let _ = std::fs::write(&path, format!("{temp_c}"));
+fn coolant_runtime_path_in(runtime_dir: &Path, device_id: &str) -> PathBuf {
+    let digest = Sha256::digest(device_id.as_bytes());
+    runtime_dir.join(format!("coolant-{}.txt", hex::encode(&digest[..12])))
+}
+
+/// Runtime path for a coolant temperature file. Device identifiers are hashed
+/// so serials cannot escape the private runtime directory or collide after
+/// lossy filename sanitization.
+pub fn coolant_runtime_path(device_id: &str) -> PathBuf {
+    coolant_runtime_path_in(&runtime_base_dir(), device_id)
+}
+
+fn write_coolant_temp_at(runtime_dir: &Path, device_id: &str, temp_c: f32) -> Result<()> {
+    if !temp_c.is_finite() || !(0.0..=100.0).contains(&temp_c) {
+        anyhow::bail!("refusing invalid coolant temperature {temp_c}");
+    }
+
+    std::fs::create_dir_all(runtime_dir)
+        .with_context(|| format!("creating runtime directory {}", runtime_dir.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(runtime_dir, std::fs::Permissions::from_mode(0o700))
+            .with_context(|| format!("securing runtime directory {}", runtime_dir.display()))?;
+    }
+
+    let path = coolant_runtime_path_in(runtime_dir, device_id);
+    let sequence = TEMP_FILE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let temp_path = runtime_dir.join(format!(".coolant-{}-{sequence}.tmp", std::process::id()));
+    let result = (|| -> Result<()> {
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = options
+            .open(&temp_path)
+            .with_context(|| format!("creating temporary sensor file {}", temp_path.display()))?;
+        write!(file, "{temp_c:.1}")
+            .with_context(|| format!("writing temporary sensor file {}", temp_path.display()))?;
+        file.flush()
+            .with_context(|| format!("flushing temporary sensor file {}", temp_path.display()))?;
+        std::fs::rename(&temp_path, &path).with_context(|| {
+            format!(
+                "publishing coolant sensor {} as {}",
+                temp_path.display(),
+                path.display()
+            )
+        })?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temp_path);
+    }
+    result
+}
+
+/// Atomically publish a coolant temperature value for LCD widgets and curves.
+pub fn write_coolant_temp(device_id: &str, temp_c: f32) -> Result<()> {
+    write_coolant_temp_at(&runtime_base_dir(), device_id, temp_c)
+}
+
+pub fn read_coolant_temp(device_id: &str) -> Result<f32> {
+    super::read::read_sensor_value(&ResolvedSensor::RuntimeFile {
+        path: coolant_runtime_path(device_id),
+        max_age: Some(COOLANT_MAX_AGE),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_dir(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "lianli-shared-{name}-{}-{}",
+            std::process::id(),
+            TEMP_FILE_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    #[test]
+    fn runtime_path_never_contains_device_path_components() {
+        let root = PathBuf::from("/run/user/1000/lianli-linux");
+        let path = coolant_runtime_path_in(&root, "../../other/\u{2603}:device");
+        assert_eq!(path.parent(), Some(root.as_path()));
+        assert!(path
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .starts_with("coolant-"));
+        assert!(!path.to_string_lossy().contains("other"));
+    }
+
+    #[test]
+    fn atomic_write_publishes_valid_temperature() {
+        let dir = test_dir("write");
+        write_coolant_temp_at(&dir, "hid:test", 35.7).unwrap();
+        let resolved = ResolvedSensor::RuntimeFile {
+            path: coolant_runtime_path_in(&dir, "hid:test"),
+            max_age: Some(COOLANT_MAX_AGE),
+        };
+        let value = super::super::read::read_sensor_value(&resolved).unwrap();
+        assert!((value - 35.7).abs() < 0.01);
+        assert!(std::fs::read_dir(&dir)
+            .unwrap()
+            .flatten()
+            .all(|entry| !entry.file_name().to_string_lossy().ends_with(".tmp")));
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn expired_runtime_sample_is_rejected() {
+        let dir = test_dir("stale");
+        write_coolant_temp_at(&dir, "hid:test", 35.7).unwrap();
+        std::thread::sleep(Duration::from_millis(2));
+        let resolved = ResolvedSensor::RuntimeFile {
+            path: coolant_runtime_path_in(&dir, "hid:test"),
+            max_age: Some(Duration::ZERO),
+        };
+        assert!(super::super::read::read_sensor_value(&resolved).is_err());
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn invalid_values_are_not_published() {
+        let dir = test_dir("invalid");
+        for value in [f32::NAN, f32::INFINITY, -1.0, 100.1] {
+            assert!(write_coolant_temp_at(&dir, "hid:test", value).is_err());
+        }
+        assert!(!dir.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_publish_replaces_symlink_without_following_it() {
+        use std::os::unix::fs::symlink;
+        let dir = test_dir("symlink");
+        std::fs::create_dir_all(&dir).unwrap();
+        let victim = dir.join("victim");
+        std::fs::write(&victim, "unchanged").unwrap();
+        let path = coolant_runtime_path_in(&dir, "hid:test");
+        symlink(&victim, &path).unwrap();
+
+        write_coolant_temp_at(&dir, "hid:test", 42.0).unwrap();
+        assert_eq!(std::fs::read_to_string(&victim).unwrap(), "unchanged");
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "42.0");
+        std::fs::remove_dir_all(dir).unwrap();
+    }
 }

--- a/crates/lianli-shared/src/sensors/resolve.rs
+++ b/crates/lianli-shared/src/sensors/resolve.rs
@@ -129,15 +129,16 @@ pub fn resolve_sensor(source: &SensorSource, divider: usize) -> Option<ResolvedS
     }
 }
 
+/// Return the per-user runtime directory without falling back to a shared,
+/// symlinkable temporary path.
 fn runtime_base_dir() -> PathBuf {
     std::env::var_os("XDG_RUNTIME_DIR")
         .map(PathBuf::from)
-        .unwrap_or_else(|| {
-            std::env::temp_dir().join(format!("lianli-linux-{}", std::process::id()))
-        })
+        .unwrap_or_else(|| PathBuf::from(format!("/run/user/{}", unsafe { libc::geteuid() })))
         .join("lianli-linux")
 }
 
+/// Derive a non-reversible, single-component filename for a device ID.
 fn coolant_runtime_path_in(runtime_dir: &Path, device_id: &str) -> PathBuf {
     let digest = Sha256::digest(device_id.as_bytes());
     runtime_dir.join(format!("coolant-{}.txt", hex::encode(&digest[..12])))
@@ -150,6 +151,7 @@ pub fn coolant_runtime_path(device_id: &str) -> PathBuf {
     coolant_runtime_path_in(&runtime_base_dir(), device_id)
 }
 
+/// Publish one validated sample below an explicitly supplied runtime directory.
 fn write_coolant_temp_at(runtime_dir: &Path, device_id: &str, temp_c: f32) -> Result<()> {
     if !temp_c.is_finite() || !(0.0..=100.0).contains(&temp_c) {
         anyhow::bail!("refusing invalid coolant temperature {temp_c}");
@@ -202,6 +204,7 @@ pub fn write_coolant_temp(device_id: &str, temp_c: f32) -> Result<()> {
     write_coolant_temp_at(&runtime_base_dir(), device_id, temp_c)
 }
 
+/// Read a fresh coolant sample, rejecting files older than the safety window.
 pub fn read_coolant_temp(device_id: &str) -> Result<f32> {
     super::read::read_sensor_value(&ResolvedSensor::RuntimeFile {
         path: coolant_runtime_path(device_id),


### PR DESCRIPTION
## Summary

- poll wired HydroShift/Galahad II LCD coolant telemetry when a configured fan curve explicitly references it
- publish fresh samples to LCD sensors and IPC telemetry
- add full-speed fail-safe behavior for missing or stale coolant samples
- harden HID handshake parsing against truncated, stale, and unrelated responses
- publish runtime samples atomically in a private directory with hashed device identifiers

## Background

The shared HydroShift/Galahad II LCD HID controller already parses coolant temperature during its handshake, but the value was not refreshed or exposed to fan curves and custom LCD widgets. This change makes that existing telemetry usable by the daemon while retaining the serialized `wireless_coolant` sensor name for config compatibility.

This is separate from #102, which targets the HydroShift II WinUSB protocol. This PR covers the existing wired `HydroShiftLcd` / `Galahad2Lcd` HID controller.

## Safety behavior

- Active HID polling is opt-in: it only runs for device IDs referenced by an active coolant-based fan curve.
- Polling is limited to once per second and uses exponential backoff up to 60 seconds after errors.
- Runtime samples expire after 10 seconds. A curve-controlled output uses full PWM until fresh telemetry returns; constant fan/pump outputs remain unchanged.
- The known startup placeholder (`1.0 C`, zero fan and pump RPM) is rejected, while real hot readings and zero-pump conditions remain visible to the fail-safe path.
- Short or mismatched HID responses return errors instead of indexing beyond the received packet.

Because #73 reports firmware-sensitive AIO initialization, the polling path is deliberately not enabled globally. It was tested successfully with HIDAPI on a Galahad II Vision (`0416:7395`, firmware 1.6), but review and additional hardware testing are welcome.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --workspace` (40 relevant unit tests passed, including new truncation, placeholder, stale-sample, atomic-write, backoff, and fail-safe cases)
- `cargo build --verbose`
- live daemon test: repeated coolant updates, fan-curve control, LCD sensor updates, no USB resets or daemon failures


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for using HydroShift LCD and Galahad II LCD/Vision coolant temperatures in fan curves.
  * Added automatic coolant telemetry polling with retry backoff.
  * Added safe handling for missing, invalid, or stale coolant readings, including full-speed fallback for curve-controlled outputs.
  * Added interpolation and output clamping for fan curves.

* **Documentation**
  * Expanded fan curve configuration guidance with coolant sensor examples and behavior details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->