### PR TITLE
daemon: restore configured wireless devices after discovery

### DIFF
--- a/crates/lianli-daemon/src/service/init.rs
+++ b/crates/lianli-daemon/src/service/init.rs
@@ -1,3 +1,4 @@
+use super::runtime::parse_mac_str;
 use super::{DaemonEvent, ServiceManager};
 use crate::aio_controller::AioController;
 use crate::fan_controller::FanController;
@@ -563,6 +564,50 @@ impl ServiceManager {
         }
     }
 
+    fn auto_rebind_configured_wireless(&mut self) {
+        let Some(cfg) = self.config.as_ref() else {
+            return;
+        };
+
+        let mut configured_ids = std::collections::HashSet::new();
+
+        if let Some(fans) = &cfg.fans {
+            for group in &fans.speeds {
+                if let Some(device_id) = &group.device_id {
+                    configured_ids.insert(device_id.clone());
+                }
+            }
+        }
+
+        if let Some(rgb) = &cfg.rgb {
+            for device in &rgb.devices {
+                configured_ids.insert(device.device_id.clone());
+            }
+        }
+
+        configured_ids.extend(cfg.aio.keys().cloned());
+
+        for dev in self.wireless.unbound_devices() {
+            let device_id = format!("wireless:{}", dev.mac_str());
+            if !configured_ids.contains(&device_id) {
+                continue;
+            }
+
+            let Some(mac_str) = device_id.strip_prefix("wireless:") else {
+                continue;
+            };
+            let Some(mac) = parse_mac_str(mac_str) else {
+                warn!("Invalid configured wireless MAC: {mac_str}");
+                continue;
+            };
+
+            info!("Auto-rebinding configured wireless device {device_id}");
+            if let Err(err) = self.wireless.bind_device(&mac) {
+                warn!("Auto-rebind failed for {device_id}: {err}");
+            }
+        }
+    }
+
     pub(super) fn try_wireless(&mut self) {
         if !lianli_devices::wireless::tx_dongle_present() {
             debug!("[wireless] no TX/RX devices found, skipping wireless");
@@ -572,6 +617,8 @@ impl ServiceManager {
             Ok(()) => match self.wireless.start_polling() {
                 Ok(()) => {
                     let _ = self.wireless.send_rx_sequence();
+                    self.auto_rebind_configured_wireless();
+                    self.device_poll();
                     info!("Wireless links active");
                 }
                 Err(err) => warn!("[wireless] polling start failed: {err}"),

--- a/crates/lianli-devices/src/wireless/bind.rs
+++ b/crates/lianli-devices/src/wireless/bind.rs
@@ -1,11 +1,11 @@
 use super::controller::WirelessController;
 use super::discovery::poll_and_discover;
 use super::{RF_CHUNKS, RF_CHUNK_SIZE, RF_DATA_SIZE, RF_PWM_CMD, RF_SELECT, USB_CMD_SEND_RF};
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use lianli_transport::usb::USB_TIMEOUT;
 use std::thread;
 use std::time::{Duration, Instant};
-use tracing::{info, warn};
+use tracing::info;
 
 impl WirelessController {
     pub fn bind_device(&self, mac: &[u8; 6]) -> Result<()> {
@@ -59,11 +59,11 @@ impl WirelessController {
                 return Ok(());
             }
             if Instant::now() >= deadline {
-                warn!(
+                bail!(
                     "bind convergence for {:02x?} timed out after {attempts} attempt(s); observed={:?}",
-                    mac, observed
+                    mac,
+                    observed
                 );
-                return Ok(());
             }
         }
     }


### PR DESCRIPTION
## Summary

Restore the saved configuration for wireless devices immediately after wireless discovery completes during daemon startup.

Previously, configured wireless devices were discovered after a cold boot, but their saved configuration was not restored until the daemon was restarted manually. As a result, LCD media and RGB settings were not applied automatically after startup.

This change restores the configured wireless devices immediately after successful wireless initialization, ensuring that the saved LCD media and RGB configuration are applied without requiring a manual daemon restart.

## Tested

Tested on SteamOS with a Lian Li HydroShift II LCD AIO.

Verified:

- Cold boot
- Multiple consecutive cold boots
- LCD image restore
- LCD GIF restore
- Switching between saved LCD templates
- Configuration changes saved from the GUI
- Desktop Mode
- Game Mode

The saved wireless configuration is now restored automatically after startup without requiring any manual intervention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically rebinds wireless devices that were previously configured when wireless polling starts.
  * Refreshes wireless device status after initialization to improve device availability.
  * Ensures bind convergence failures are surfaced as errors (with clearer timeout details) while allowing wireless polling to continue as appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->