### PR TITLE
Add support for O11 Vision-M 9.2" LCD kit (1cbe:a092)

### DIFF
--- a/crates/lianli-daemon/src/service/media.rs
+++ b/crates/lianli-daemon/src/service/media.rs
@@ -120,6 +120,7 @@ impl ServiceManager {
             DeviceFamily::HydroShift2Lcd,
             DeviceFamily::Lancool207,
             DeviceFamily::UniversalScreen,
+            DeviceFamily::Vision92,
             DeviceFamily::HydroShiftLcd,
             DeviceFamily::Galahad2Lcd,
             DeviceFamily::TlLcd,
@@ -243,6 +244,11 @@ impl ServiceManager {
                     DeviceFamily::UniversalScreen => {
                         let device = Device::clone(candidate.usb_device.as_ref().unwrap());
                         lianli_devices::universal_screen::open(device)
+                            .map(|d| LcdBackend::WinUsb(ThreadedWinUsbSender::new(d, cfg_idx)))
+                    }
+                    DeviceFamily::Vision92 => {
+                        let device = Device::clone(candidate.usb_device.as_ref().unwrap());
+                        lianli_devices::vision92::open(device)
                             .map(|d| LcdBackend::WinUsb(ThreadedWinUsbSender::new(d, cfg_idx)))
                     }
                     DeviceFamily::HydroShiftLcd

--- a/crates/lianli-devices/src/lib.rs
+++ b/crates/lianli-devices/src/lib.rs
@@ -15,6 +15,7 @@ pub mod traits;
 pub mod turzx;
 pub mod universal_screen;
 pub mod universal_screen_lighting;
+pub mod vision92;
 pub mod winusb_lcd;
 pub mod winusb_led;
 pub mod wireless;

--- a/crates/lianli-devices/src/vision92.rs
+++ b/crates/lianli-devices/src/vision92.rs
@@ -1,0 +1,19 @@
+//! O11 Vision-M 9.2" LCD kit driver.
+//!
+//! VID=0x1CBE, PID=0xA092 — 1920x462 LCD via WinUSB.
+//!
+//! Uses the generic WinUSB LCD protocol (DES-CBC encrypted headers),
+//! identical to the Universal Screen 8.8" apart from panel geometry.
+
+use crate::winusb_lcd::WinUsbLcdDevice;
+use anyhow::Result;
+use lianli_shared::screen::vision92_screen;
+use rusb::{Device, GlobalContext};
+
+pub const VID: u16 = 0x1CBE;
+pub const PID: u16 = 0xA092;
+
+/// Open an O11 Vision-M 9.2" LCD device.
+pub fn open(device: Device<GlobalContext>) -> Result<WinUsbLcdDevice> {
+    WinUsbLcdDevice::new(device, vision92_screen(), "O11 Vision-M 9.2\" LCD")
+}

--- a/crates/lianli-gui/src/conversions/device.rs
+++ b/crates/lianli-gui/src/conversions/device.rs
@@ -21,6 +21,7 @@ pub(super) fn family_display_name(f: DeviceFamily) -> &'static str {
         DeviceFamily::HydroShift2Lcd => "HydroShift II LCD Circle",
         DeviceFamily::Lancool207 => "Lancool 207 Digital",
         DeviceFamily::UniversalScreen => "Universal Screen 8.8\"",
+        DeviceFamily::Vision92 => "O11 Vision-M 9.2\" LCD",
         DeviceFamily::HydroShift2LcdDesktop => "HydroShift II LCD (Desktop Mode)",
         DeviceFamily::Lancool207Desktop => "Lancool 207 Digital (Desktop Mode)",
         DeviceFamily::UniversalScreenDesktop => "Universal Screen 8.8\" (Desktop Mode)",

--- a/crates/lianli-shared/src/device_id.rs
+++ b/crates/lianli-shared/src/device_id.rs
@@ -37,6 +37,8 @@ pub enum DeviceFamily {
     Lancool207,
     /// Universal Screen 8.8" — WinUSB 1920x480
     UniversalScreen,
+    /// O11 Vision-M 9.2" LCD kit — WinUSB 1920x462
+    Vision92,
     /// HydroShift II LCD in desktop mode (CH340, 0x1A86:0xAD20)
     HydroShift2LcdDesktop,
     /// Lancool 207 in desktop mode (CH340, 0x1A86:0xACD1 / 0xAD11)
@@ -264,6 +266,12 @@ pub static KNOWN_DEVICES: &[DeviceEntry] = &[
         name: "Universal Screen 8.8\"",
         hid_usage_page: None,
     },
+    DeviceEntry {
+        id: UsbId::new(0x1CBE, 0xA092),
+        family: DeviceFamily::Vision92,
+        name: "O11 Vision-M 9.2\" LCD",
+        hid_usage_page: None,
+    },
     // Desktop-mode variants (CH340, VID=0x1A86) — same physical device as 0x1CBE LCD
     DeviceEntry {
         id: UsbId::new(0x1A86, 0xAD20),
@@ -321,6 +329,7 @@ impl DeviceFamily {
                 | Self::HydroShift2Lcd
                 | Self::Lancool207
                 | Self::UniversalScreen
+                | Self::Vision92
         )
     }
 
@@ -414,6 +423,7 @@ pub fn uses_usb_bulk(family: DeviceFamily) -> bool {
             | DeviceFamily::HydroShift2Lcd
             | DeviceFamily::Lancool207
             | DeviceFamily::UniversalScreen
+            | DeviceFamily::Vision92
             | DeviceFamily::UniversalScreenLighting
     )
 }

--- a/crates/lianli-shared/src/screen.rs
+++ b/crates/lianli-shared/src/screen.rs
@@ -83,6 +83,34 @@ impl ScreenInfo {
         h264: true,
         needs_keepalive: false,
     };
+
+    /// O11 Vision-M 9.2" LCD kit. Panel is native portrait 462x1920,
+    /// mounted landscape (marketing spec is 1920x462).
+    pub const VISION_92: Self = Self {
+        width: 462,
+        height: 1920,
+        max_fps: 30,
+        jpeg_quality: 95,
+        max_payload: 512_000,
+        h264: false,
+        needs_keepalive: false,
+    };
+}
+
+/// Resolve the 9.2" Vision-M screen config.
+///
+/// The panel accepts and ACKs H.264 chunks but never renders them, so JPEG is
+/// the default. `LIANLI_VISION92_H264=1` opts back in, mirroring
+/// `LIANLI_LANCOOL207_H264`, for anyone wanting to investigate further.
+pub fn vision92_screen() -> ScreenInfo {
+    let mut s = ScreenInfo::VISION_92;
+    if std::env::var("LIANLI_VISION92_H264")
+        .map(|v| v != "0" && !v.is_empty())
+        .unwrap_or(false)
+    {
+        s.h264 = true;
+    }
+    s
 }
 
 fn lancool207_h264_enabled() -> bool {
@@ -105,6 +133,7 @@ pub fn screen_info_for(family: DeviceFamily) -> Option<ScreenInfo> {
             ScreenInfo::LANCOOL_207
         }),
         DeviceFamily::UniversalScreen => Some(ScreenInfo::UNIVERSAL_SCREEN),
+        DeviceFamily::Vision92 => Some(vision92_screen()),
         _ => None,
     }
 }
@@ -136,6 +165,11 @@ pub fn screen_presets() -> &'static [ScreenPreset] {
         ScreenPreset {
             label: "Universal Screen 8.8\" (480×1920)",
             width: 480,
+            height: 1920,
+        },
+        ScreenPreset {
+            label: "O11 Vision-M 9.2\" (462×1920)",
+            width: 462,
             height: 1920,
         },
     ]

--- a/packaging/udev/99-lianli.rules
+++ b/packaging/udev/99-lianli.rules
@@ -56,6 +56,8 @@ SUBSYSTEM=="usb", ATTR{idVendor}=="1cbe", ATTR{idProduct}=="a034", MODE="0666"
 SUBSYSTEM=="usb", ATTR{idVendor}=="1cbe", ATTR{idProduct}=="a065", MODE="0666"
 # Universal Screen 8.8"
 SUBSYSTEM=="usb", ATTR{idVendor}=="1cbe", ATTR{idProduct}=="a088", MODE="0666"
+# O11 Vision-M 9.2" LCD kit
+SUBSYSTEM=="usb", ATTR{idVendor}=="1cbe", ATTR{idProduct}=="a092", MODE="0666"
 
 # Desktop-mode LCD devices (CH340, VID=0x1A86)
 SUBSYSTEM=="usb", ATTR{idVendor}=="1a86", ATTR{idProduct}=="acd1", MODE="0666"


### PR DESCRIPTION
Adds support for the O11 Vision-M 9.2" LCD kit (the divider panel with the built-in screen). It's another 0x1CBE WinUSB bulk LCD, so winusb_lcd.rs drives it as-is, this is just a device table entry, a ScreenInfo, a small module wrapper, and a udev rule.

Device:
  ID 1cbe:a092  lianli  9.2"LCD-2026041401 
  Vendor-specific class, bulk EP 0x81 IN / 0x01 OUT, 512-byte packets 
  (same shape as the Universal Screen 8.8")
  GetVer returns: lianli92_0001_2026041401

2 flags:

1. Size is 462x1920, not 1920x462. The panel is native portrait and gets
   mounted sideways in the divider; Lian Li advertise the landscape number.
   Same convention as UNIVERSAL_SCREEN and LANCOOL_207. Renders correctly
   with orientation: 90 in the LCD config.

2. H.264 doesn't work on this panel, JPEG does. With h264: true the screen
   goes black but every StartPlay chunk is ACKed and nothing errors, so
   it's not a transport problem. Switching to JPEG fixed it. I don't know
   if that's a firmware limitation or something about 462 not being
   16-aligned. Defaulted to JPEG and put H.264 behind
   LIANLI_VISION92_H264=1, same as the existing LANCOOL207 flag.

Left supports_display_mode_switch() off the 8.8" has known CH340 desktop-mode PIDs but I don't know the 9.2"'s, and sending SwitchToDesktop blind could strand the panel in a mode nothing here handles.

Tested on Arch, kernel 7.1.3: detection, static images, a live multi-gauge template, and across a reboot. Haven't tested desktop/evdi mode or video/GIF playback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Lian Li O11 Vision-M 9.2" LCD.
  * The device is now automatically detected and displayed by name.
  * Added 462×1920 screen configuration with JPEG support and optional H.264 mode.
  * Enabled USB access on supported Linux systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->