### PR TITLE
fix: curve name/command inputs get wiped mid-typing by polling re-renders

### DIFF
--- a/crates/lianli-gui/src/views/FansPage.vue
+++ b/crates/lianli-gui/src/views/FansPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 import { useDialog } from "naive-ui";
 import { Plus, X } from "lucide-vue-next";
 import { useConfigStore } from "@/stores/config";
@@ -17,6 +17,20 @@ const selectedCurve = ref(0);
 
 const curves = computed(() => config.config.fan_curves);
 const current = computed(() => curves.value[selectedCurve.value] ?? null);
+
+// Local edit buffers for the name/command text inputs. Binding these fields
+// directly to `current.name`/`current.temp_command` via a plain `:value`
+// (rather than `v-model`) means Vue force-writes the DOM `value` on every
+// re-render of this page — which happens every ~2s from the telemetry
+// polling loop — silently discarding any keystrokes typed since the last
+// tick. Buffering locally and only resyncing when the *selected curve*
+// changes (not on every render) avoids that.
+const nameBuffer = ref(current.value?.name ?? "");
+const commandBuffer = ref(current.value?.temp_command ?? "");
+watch(current, (c) => {
+  nameBuffer.value = c?.name ?? "";
+  commandBuffer.value = c?.temp_command ?? "";
+});
 
 const fanCfg = computed(() => config.ensureFans());
 
@@ -198,8 +212,8 @@ function onHysteresisPwm(v: number | null) {
             <label class="muted">Name</label>
             <n-input
               size="small"
-              :value="current.name"
-              @blur="renameCurve(($event.target as HTMLInputElement).value)"
+              v-model:value="nameBuffer"
+              @blur="renameCurve(nameBuffer)"
               placeholder="Curve name"
             />
           </div>
@@ -217,8 +231,8 @@ function onHysteresisPwm(v: number | null) {
             <label class="muted">Custom command</label>
             <n-input
               size="small"
-              :value="current.temp_command ?? ''"
-              @blur="onTempCommand(($event.target as HTMLInputElement).value)"
+              v-model:value="commandBuffer"
+              @blur="onTempCommand(commandBuffer)"
               placeholder="e.g. cat /sys/class/thermal/thermal_zone0/temp"
             />
           </div>


### PR DESCRIPTION
## Summary
On the Fans page, the fan curve "Name" and "Custom command" inputs are unusable — typing into either field appears to do nothing, and the curve keeps its default name ("New Curve").

## Root cause
Both `n-input`s are bound as `:value="current.name"` / `:value="current.temp_command ?? ''"` with a `@blur` handler, but no `v-model`. Vue force-writes an `<input>`'s DOM `value` property on every re-render of the owning component instance, regardless of whether the bound value actually changed (this is intentional Vue core behavior for form elements). The Fans page re-renders roughly every 2 seconds because of the daemon polling loop (RPM/telemetry updates touch reactive state rendered on this page), so any keystrokes typed between ticks get silently overwritten back to the last-committed value before `@blur` ever fires.

## Fix
Buffer both fields in local `ref`s that only resync from the selected curve via a `watch(current, ...)` — i.e. when the *curve selection* changes, not on every render — and bind the inputs to those buffers with `v-model` instead of a plain `:value`. `@blur` still commits the buffered value into the store, preserving the original intent of not marking the config dirty on every keystroke.

## Testing
- `cargo build --release -p lianli-gui` succeeds.
- Manually verified: typed a multi-word curve name slowly (pausing several seconds mid-word, well past the ~2s poll interval) and it now sticks correctly instead of resetting to "New Curve".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented curve names and custom temperature commands from being cleared while typing.
  * Ensured edits are saved when leaving the input field.
  * Kept input values synchronized when switching between curves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->