### PR TITLE
fix: stop registering HydroShift2Lcd as a wired fan device

### DIFF
--- a/crates/lianli-daemon/src/service/init.rs
+++ b/crates/lianli-daemon/src/service/init.rs
@@ -189,6 +189,16 @@ impl ServiceManager {
         for det in &usb_devs {
             if det.family == lianli_shared::device_id::DeviceFamily::TlLcd
                 || det.family == lianli_shared::device_id::DeviceFamily::HydroShift2OledCurveLcd
+                // WinUsbLcdDriver::open() bundles a fan/aio handle onto the
+                // same shared USB transport as the LCD (see winusb/lcd.rs).
+                // Registering that fan handle here keeps an interface-0 claim
+                // alive for the lifetime of the daemon, which races against
+                // service::media's independent open_for_pid() claim on the
+                // same device and permanently starves LCD image attach
+                // ("interface 0 busy, retrying" in a loop). This device's fan
+                // capability is not otherwise exposed/needed, so skip it and
+                // let service::media own the interface exclusively.
+                || det.family == lianli_shared::device_id::DeviceFamily::HydroShift2Lcd
             {
                 continue;
             }


### PR DESCRIPTION
## What

`init_wired_devices()` opens `HydroShift2Lcd` devices (HydroShift II LCD Circle/Square, pid `0xA021`/`0xA034`) via `WinUsbLcdDriver::open()`, which bundles a `fan`/`aio` handle onto the same shared USB transport as the `lcd` handle. Only the `fan` handle gets registered (into `fan_devices`) and kept alive — the `lcd` handle from this open is discarded. That kept-alive fan registration holds an interface-0 claim on the physical device for the daemon's entire lifetime.

Separately, `service::media` independently opens the *same* physical device via `open_for_pid()` whenever there's actual LCD content to stream. These two opens race for the same USB interface, which surfaces as a permanent `interface 0 busy, retrying...` loop — LCD image/template attach never succeeds while the stale init-time claim holds the interface.

## Fix

Skip `HydroShift2Lcd` in the `init_wired_devices()` family skip-list, matching the existing precedent for `TlLcd` and `HydroShift2OledCurveLcd` just above it. This device's fan capability isn't exposed/used anywhere else (AIO fan/pump control for these units runs through the wireless group, not this wired connection), so there's nothing lost by not registering it here — it just lets `service::media` own the interface exclusively.

## Testing

Reproduced and verified on a HydroShift II LCD Square (`1cbe:a034`) on Linux:
- Before: daemon logs a continuous `HydroShift II LCD Square interface 0 busy, retrying...` / `[devices] LCD[...] unavailable during attach` loop; LCD stays off/blank indefinitely.
- After: LCD attaches on the first attempt and stays attached, including custom templates with live widgets (digital clock overlay tested). Confirmed no regression to fan/pump/RGB control (this device's AIO runs wireless in my setup).
- Related to #120 — this is the concrete mechanism behind the `has_lcd`/dropped-`opened.lcd` gap discussed there, and interacts with the 0.7.3 reset-loop fix (b4e3f0d): after that change the init-time claim reliably wins the race, so LCD attach now fails deterministically instead of intermittently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initialization for Hydro Shift 2 LCD devices.
  * Prevented bundled fan controls from blocking access to the shared USB interface used by media LCD features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->