### PR TITLE
fix: "New" template button opens an existing template instead of blank

### DIFF
--- a/crates/lianli-gui/src/views/EditorWindow.vue
+++ b/crates/lianli-gui/src/views/EditorWindow.vue
@@ -34,15 +34,17 @@ const sensorOptions = computed(() =>
 
 const presetOptions = screenPresets.map((p) => ({ label: p.label, value: `${p.width}x${p.height}` }));
 
-/** Load the template identified by `?template=<id>` (falls back to first). */
+/**
+ * Load the template identified by `?template=<id>`. The "New" button opens
+ * the editor with no id at all (the "Edit" button is disabled unless an
+ * entry already has a template_id, so it always passes one) — treat a
+ * missing/unmatched id as "start a blank template", not "open whatever
+ * happens to be first in the list".
+ */
 function loadRequestedTemplate(id: string | (string | null)[] | null) {
   const tid = Array.isArray(id) ? id[0] : id;
   const match = tid ? config.templates.find((t) => t.id === tid) : undefined;
-  template.value = match
-    ? (JSON.parse(JSON.stringify(match)) as LcdTemplate)
-    : config.templates.length
-      ? (JSON.parse(JSON.stringify(config.templates[0])) as LcdTemplate)
-      : blankTemplate();
+  template.value = match ? (JSON.parse(JSON.stringify(match)) as LcdTemplate) : blankTemplate();
   selectedId.value = null;
   triggerPreview();
 }


### PR DESCRIPTION
## What

`loadRequestedTemplate()` in `EditorWindow.vue` is shared by both the "New" and "Edit" buttons in `LcdConfigCard.vue`. "Edit" always passes a real template id — it's disabled (`:disabled="!entry.template_id"`) whenever there isn't one. "New" always calls `openEditor()` with no id.

When no id is passed (or no match is found), the fallback logic was:

```ts
template.value = match
  ? ...
  : config.templates.length
    ? (JSON.parse(JSON.stringify(config.templates[0])) as LcdTemplate)  // wrong
    : blankTemplate();
```

Since the only caller that omits the id is "New", this made `blankTemplate()` dead code as soon as any user template existed — clicking "New" silently reopened the first saved template for editing instead of starting fresh.

## Fix

A missing/unmatched id can only mean "start a blank template" given how the two buttons are wired, so drop the `templates.length` branch and always fall back to `blankTemplate()`.

## Testing

Reproduced and verified locally: with one existing template saved, clicking "New" reliably opened a blank 480x480 template instead of a copy of the existing one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Opening the editor without a valid template request now starts with a blank template instead of automatically selecting the first configured template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->