### PR TITLE
fix: LCD template list not refreshed across windows after save

### DIFF
--- a/crates/lianli-gui/src/App.vue
+++ b/crates/lianli-gui/src/App.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
-import { computed, onMounted } from "vue";
+import { computed, onMounted, onUnmounted } from "vue";
 import { useRoute } from "vue-router";
 import { darkTheme, type GlobalTheme, type GlobalThemeOverrides } from "naive-ui";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { useDaemonStore } from "@/stores/daemon";
 import { useConfigStore } from "@/stores/config";
 import { useThemeStore } from "@/stores/theme";
+import { LCD_TEMPLATES_CHANGED_EVENT } from "@/stores/lcd";
 import AppSidebar from "@/components/layout/AppSidebar.vue";
 import AppHeader from "@/components/layout/AppHeader.vue";
 
@@ -77,10 +79,23 @@ const themeOverrides = computed(() =>
   theme.isDark ? darkOverrides : lightOverrides,
 );
 
+let unlistenTemplatesChanged: UnlistenFn | undefined;
+
 onMounted(async () => {
   // Kick off the initial config load + polling loop.
   await config.load().catch(() => undefined);
   daemon.start();
+
+  // Each window (main/editor/browser) has its own store instance, so a
+  // template saved in one (e.g. the editor) doesn't update the others on its
+  // own — resync on this window's copy of the template list when notified.
+  unlistenTemplatesChanged = await listen(LCD_TEMPLATES_CHANGED_EVENT, () => {
+    config.load().catch(() => undefined);
+  });
+});
+
+onUnmounted(() => {
+  unlistenTemplatesChanged?.();
 });
 </script>
 

--- a/crates/lianli-gui/src/stores/lcd.ts
+++ b/crates/lianli-gui/src/stores/lcd.ts
@@ -1,8 +1,13 @@
 import { defineStore } from "pinia";
 import { ref } from "vue";
+import { emit } from "@tauri-apps/api/event";
 import { useIpc } from "@/composables/useIpc";
 import { useDebounce } from "@/composables/useDebounce";
 import type { LcdConfig, LcdTemplate } from "@/types";
+
+/** Broadcast when SetLcdTemplates changes the template list, so other open
+ *  windows (each with their own config store instance) know to reload it. */
+export const LCD_TEMPLATES_CHANGED_EVENT = "lcd-templates-changed";
 
 /**
  * LCD-side effects: display-mode switch, media apply, and the template editor
@@ -26,6 +31,7 @@ export const useLcdStore = defineStore("lcd", () => {
 
   async function setTemplates(templates: LcdTemplate[]) {
     await ipc.request("SetLcdTemplates", { templates });
+    await emit(LCD_TEMPLATES_CHANGED_EVENT);
   }
 
   async function setBrightness(deviceId: string, brightness: number) {


### PR DESCRIPTION
## What

Each Tauri window (main/editor/browser) has its own independent Pinia store instance. Saving templates from the editor window (via `SetLcdTemplates`) correctly persists to the daemon and to disk, but nothing tells the *main* window's copy of `config.templates` to reload — it only refetches the full config on daemon reconnect or when the visible device count changes, neither of which happens when you just save a template. The main window's template dropdown is left showing a stale list until the app is restarted. The existing "Refresh now" button doesn't help either, since it just re-runs that same conditional reload (`daemon.refresh()` → `polling.tick()`), which does nothing new in the steady-state case.

## Fix

`core:event:default` is already granted to all three windows in `capabilities/default.json`, so this uses Tauri's built-in cross-window event bus rather than adding new plumbing:

- `lcd.ts`'s `setTemplates()` — the single place templates actually get persisted (used by the editor's Save, and by duplicate/delete in `LcdConfigCard.vue`) — now emits a `lcd-templates-changed` event after the IPC call succeeds.
- `App.vue` (mounted once per window) listens for it and reloads that window's config.

## Testing

Verified locally: with the main window and an editor window both open, saving a new template in the editor immediately updates the main window's template dropdown with no restart and no manual refresh click required.