### PR TITLE
fix: RGB config resync uses stale self.config, silently reverting IPC-driven changes

### DIFF
--- a/crates/lianli-daemon/src/service/init.rs
+++ b/crates/lianli-daemon/src/service/init.rs
@@ -80,18 +80,6 @@ impl ServiceManager {
     /// For each discovered AIO, ensure an AioConfig exists in the user's config.
     /// Migrates any legacy FanGroup targeting that device, then inserts defaults.
     pub(super) fn ensure_aio_defaults(&mut self) {
-        // Refresh from the IPC-side config before touching it. self.config
-        // can lag behind concurrent IPC-driven writes (RGB presets, device
-        // profiles, etc. all mutate state.config directly), and this
-        // function ends by persisting a full-struct snapshot back over
-        // state.config — without this refresh that snapshot would silently
-        // discard any such concurrent change.
-        if let Some(latest) = self.ipc.state.lock().config.clone() {
-            self.config = Some(latest);
-        }
-        let Some(cfg) = self.config.as_mut() else {
-            return;
-        };
         let aio_device_ids: Vec<String> = self
             .wireless
             .devices()
@@ -102,6 +90,13 @@ impl ServiceManager {
         if aio_device_ids.is_empty() {
             return;
         }
+
+        // Keep the lock held across the write, IPC handlers update
+        // state.config concurrently.
+        let mut ipc_state = self.ipc.state.lock();
+        let Some(mut cfg) = ipc_state.config.clone().or_else(|| self.config.clone()) else {
+            return;
+        };
 
         let mut changed = false;
         for device_id in aio_device_ids {
@@ -119,12 +114,12 @@ impl ServiceManager {
             }
         }
 
+        self.config = Some(cfg.clone());
         if changed {
-            let snapshot = cfg.clone();
-            if let Err(e) = persistence::write_config(&self.config_path, &snapshot) {
+            if let Err(e) = persistence::write_config(&self.config_path, &cfg) {
                 warn!("Failed to persist AIO config additions: {e}");
             } else {
-                self.ipc.state.lock().config = Some(snapshot);
+                ipc_state.config = Some(cfg);
             }
         }
     }
@@ -521,23 +516,18 @@ impl ServiceManager {
         }
 
         if let Some(serial) = serial {
-            // Refresh from the IPC-side config first — see the comment in
-            // ensure_aio_defaults() for why this matters before a snapshot
-            // gets persisted back over state.config.
-            if let Some(latest) = self.ipc.state.lock().config.clone() {
-                self.config = Some(latest);
-            }
-            if let Some(cfg) = self.config.as_mut() {
+            let mut ipc_state = self.ipc.state.lock();
+            if let Some(mut cfg) = ipc_state.config.clone().or_else(|| self.config.clone()) {
                 cfg.ene6k77
                     .entry(serial)
                     .or_default()
                     .fan_quantities
                     .insert(port, quantity);
-                let snapshot = cfg.clone();
-                if let Err(e) = persistence::write_config(&self.config_path, &snapshot) {
+                self.config = Some(cfg.clone());
+                if let Err(e) = persistence::write_config(&self.config_path, &cfg) {
                     warn!("Failed to persist ENE 6K77 fan quantity: {e}");
                 } else {
-                    self.ipc.state.lock().config = Some(snapshot);
+                    ipc_state.config = Some(cfg);
                 }
             }
         }
@@ -605,15 +595,14 @@ impl ServiceManager {
             None
         };
         if let Some(ref rgb) = self.controllers.rgb {
+            // The state lock must be taken before the controller lock, the
+            // IPC handlers use that order and the reverse can deadlock.
+            let ipc_state = self.ipc.state.lock();
             let mut ctrl = rgb.lock();
             ctrl.set_wireless(wireless);
             ctrl.refresh_wireless_devices();
-            // See apply_rgb_config() for why this reads state.config instead
-            // of self.config.
-            let ipc_state = self.ipc.state.lock();
             if let Some(rgb_cfg) = ipc_state.config.as_ref().and_then(|c| c.rgb.clone()) {
                 let presets = ipc_state.rgb_presets.clone();
-                drop(ipc_state);
                 ctrl.apply_config(&rgb_cfg, &presets);
             }
         }
@@ -626,18 +615,12 @@ impl ServiceManager {
 
     /// Apply RGB config from the current AppConfig to the RGB controller.
     pub(super) fn apply_rgb_config(&self) {
-        // Read the RGB section straight from the IPC-side config rather than
-        // self.config: self.config only refreshes on load_config() (driven
-        // by IpcUpdate events), so it can lag behind a just-applied RGB
-        // preset. This runs on the ~1s wireless drift-resync tick, so a
-        // stale self.config here means periodically re-pushing old desired
-        // state (e.g. active_preset=None) onto the hardware, undoing a
-        // preset you just applied.
+        // Read from the IPC-side config, self.config only catches up on
+        // load_config and can lag behind a just-applied preset.
         if let Some(ref rgb) = self.controllers.rgb {
             let ipc_state = self.ipc.state.lock();
             if let Some(rgb_cfg) = ipc_state.config.as_ref().and_then(|c| c.rgb.clone()) {
                 let presets = ipc_state.rgb_presets.clone();
-                drop(ipc_state);
                 rgb.lock().apply_config(&rgb_cfg, &presets);
             }
         }

--- a/crates/lianli-daemon/src/service/init.rs
+++ b/crates/lianli-daemon/src/service/init.rs
@@ -114,13 +114,15 @@ impl ServiceManager {
             }
         }
 
-        self.config = Some(cfg.clone());
         if changed {
             if let Err(e) = persistence::write_config(&self.config_path, &cfg) {
                 warn!("Failed to persist AIO config additions: {e}");
             } else {
+                self.config = Some(cfg.clone());
                 ipc_state.config = Some(cfg);
             }
+        } else {
+            self.config = Some(cfg);
         }
     }
 
@@ -523,10 +525,10 @@ impl ServiceManager {
                     .or_default()
                     .fan_quantities
                     .insert(port, quantity);
-                self.config = Some(cfg.clone());
                 if let Err(e) = persistence::write_config(&self.config_path, &cfg) {
                     warn!("Failed to persist ENE 6K77 fan quantity: {e}");
                 } else {
+                    self.config = Some(cfg.clone());
                     ipc_state.config = Some(cfg);
                 }
             }

--- a/crates/lianli-daemon/src/service/init.rs
+++ b/crates/lianli-daemon/src/service/init.rs
@@ -80,6 +80,15 @@ impl ServiceManager {
     /// For each discovered AIO, ensure an AioConfig exists in the user's config.
     /// Migrates any legacy FanGroup targeting that device, then inserts defaults.
     pub(super) fn ensure_aio_defaults(&mut self) {
+        // Refresh from the IPC-side config before touching it. self.config
+        // can lag behind concurrent IPC-driven writes (RGB presets, device
+        // profiles, etc. all mutate state.config directly), and this
+        // function ends by persisting a full-struct snapshot back over
+        // state.config — without this refresh that snapshot would silently
+        // discard any such concurrent change.
+        if let Some(latest) = self.ipc.state.lock().config.clone() {
+            self.config = Some(latest);
+        }
         let Some(cfg) = self.config.as_mut() else {
             return;
         };
@@ -512,6 +521,12 @@ impl ServiceManager {
         }
 
         if let Some(serial) = serial {
+            // Refresh from the IPC-side config first — see the comment in
+            // ensure_aio_defaults() for why this matters before a snapshot
+            // gets persisted back over state.config.
+            if let Some(latest) = self.ipc.state.lock().config.clone() {
+                self.config = Some(latest);
+            }
             if let Some(cfg) = self.config.as_mut() {
                 cfg.ene6k77
                     .entry(serial)
@@ -593,11 +608,13 @@ impl ServiceManager {
             let mut ctrl = rgb.lock();
             ctrl.set_wireless(wireless);
             ctrl.refresh_wireless_devices();
-            if let Some(ref cfg) = self.config {
-                if let Some(ref rgb_cfg) = cfg.rgb {
-                    let presets = self.ipc.state.lock().rgb_presets.clone();
-                    ctrl.apply_config(rgb_cfg, &presets);
-                }
+            // See apply_rgb_config() for why this reads state.config instead
+            // of self.config.
+            let ipc_state = self.ipc.state.lock();
+            if let Some(rgb_cfg) = ipc_state.config.as_ref().and_then(|c| c.rgb.clone()) {
+                let presets = ipc_state.rgb_presets.clone();
+                drop(ipc_state);
+                ctrl.apply_config(&rgb_cfg, &presets);
             }
         }
     }
@@ -609,10 +626,19 @@ impl ServiceManager {
 
     /// Apply RGB config from the current AppConfig to the RGB controller.
     pub(super) fn apply_rgb_config(&self) {
-        if let (Some(ref rgb), Some(ref cfg)) = (&self.controllers.rgb, &self.config) {
-            if let Some(ref rgb_cfg) = cfg.rgb {
-                let presets = self.ipc.state.lock().rgb_presets.clone();
-                rgb.lock().apply_config(rgb_cfg, &presets);
+        // Read the RGB section straight from the IPC-side config rather than
+        // self.config: self.config only refreshes on load_config() (driven
+        // by IpcUpdate events), so it can lag behind a just-applied RGB
+        // preset. This runs on the ~1s wireless drift-resync tick, so a
+        // stale self.config here means periodically re-pushing old desired
+        // state (e.g. active_preset=None) onto the hardware, undoing a
+        // preset you just applied.
+        if let Some(ref rgb) = self.controllers.rgb {
+            let ipc_state = self.ipc.state.lock();
+            if let Some(rgb_cfg) = ipc_state.config.as_ref().and_then(|c| c.rgb.clone()) {
+                let presets = ipc_state.rgb_presets.clone();
+                drop(ipc_state);
+                rgb.lock().apply_config(&rgb_cfg, &presets);
             }
         }
     }


### PR DESCRIPTION
## Summary

`ensure_aio_defaults()`, `handle_set_ene6k77_fan_quantity()`, `rebuild_rgb_controller()`, and `apply_rgb_config()` in `crates/lianli-daemon/src/service/init.rs` all read RGB/AIO config from `self.config` — the `Service`'s local copy — instead of the IPC-side `state.config` that presets, device profiles, and other IPC handlers actually mutate and persist. `self.config` only catches up via `load_config()`, triggered by `IpcUpdate` events, so it can lag behind a concurrent IPC-driven change.

Two concrete failure modes I hit and traced live:

- `ensure_aio_defaults()` and `handle_set_ene6k77_fan_quantity()` end by cloning `self.config` and writing that snapshot back over `state.config` wholesale — silently discarding any IPC-driven change (e.g. an applied RGB preset's `active_preset`) that `self.config` hadn't caught up with yet.
- `apply_rgb_config()` runs on the ~1s wireless drift-resync tick (`controllers/fan.rs`) and pushes `self.config.rgb` onto the hardware. A stale copy there means periodically re-asserting old desired state, undoing an RGB preset moments after applying it — reproducible on every wireless RGB device, not fan-specific.

## Fix

All four now read the RGB/AIO section straight from `state.config` (via `self.ipc.state.lock()`) instead of `self.config`.

## Test plan

- [x] `cargo check --release --bin lianli-daemon`
- [x] Manually built and ran the patched daemon; confirmed via targeted trace logging (removed before commit) that `active_preset` no longer reverts to `None` after `ensure_aio_defaults`/`apply_rgb_config` runs on a live system with multiple wireless RGB fans and an AIO

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration synchronization when applying or saving device settings.
  * Ensured AIO defaults and fan-quantity changes use the latest configuration.
  * Improved RGB controller rebuilding and synchronization using current RGB settings and presets.
  * Prevented configuration changes from being overwritten during concurrent updates.
  * Ensured RGB settings remain consistent after device configuration changes.
  * Improved reliability when multiple device settings are updated at the same time.
  * Ensured saved settings are accurately reflected after successful changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->