### PR TITLE
fix: direct LED selection not cleared after Apply, overwriting earlier colors

### DIFF
--- a/crates/lianli-gui/src/components/rgb/RgbZoneEditor.vue
+++ b/crates/lianli-gui/src/components/rgb/RgbZoneEditor.vue
@@ -170,6 +170,7 @@ function applyDirect() {
   for (const i of selectedLeds.value) {
     ledColors.value[i] = directColor.value;
   }
+  selectedLeds.value = [];
   config.rgbDeviceConfig(props.deviceId).active_preset = null;
   config.markDirty();
   void rgb.sendDirect(props.deviceId, props.zoneIndex, ledColors.value);


### PR DESCRIPTION
## Summary

`applyDirect()` in `crates/lianli-gui/src/components/rgb/RgbZoneEditor.vue` never clears `selectedLeds` after painting. Each LED you click gets *added* to the selection (`onSelectLed` only toggles membership), and it's never reset after Apply — so the next Apply repaints every previously-selected LED, not just the newly-picked one, with the newest color.

## Repro

1. Select LED 0, pick orange, click Apply → LED 0 is orange.
2. Select LED 5 (LED 0 is still selected from step 1), pick blue, click Apply → LEDs 0 **and** 5 both turn blue.

By the time you've painted a few regions trying to build a multi-color pattern, the accumulated selection keeps getting stomped by whatever color you picked most recently — every saved preset I checked came out as one uniform color across all LEDs, regardless of the intended split.

## Fix

Clear `selectedLeds.value` at the end of `applyDirect()` so each Apply only affects the LEDs you just selected.

## Test plan

- [x] `npm run typecheck`
- [x] Manually built and ran the patched GUI; selected LED(s) → color A → Apply, then different LED(s) → color B → Apply — confirmed the resulting preset/live state now has both colors instead of collapsing to one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Selected LEDs are now cleared after applying a direct color, preventing previously selected LEDs from remaining active in the editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->