### PR TITLE
fix: saved RGB preset can be tagged with a stale (non-Direct) effect

### DIFF
--- a/crates/lianli-daemon/src/ipc/presets.rs
+++ b/crates/lianli-daemon/src/ipc/presets.rs
@@ -5,7 +5,7 @@ use std::sync::mpsc::Sender;
 
 use lianli_shared::config::AppConfig;
 use lianli_shared::ipc::IpcResponse;
-use lianli_shared::rgb::{RgbDeviceConfig, RgbPreset, RgbPresetZone, RgbZoneConfig};
+use lianli_shared::rgb::{RgbDeviceConfig, RgbMode, RgbPreset, RgbPresetZone, RgbZoneConfig};
 use tracing::info;
 
 use crate::ipc::{DaemonState, SharedState};
@@ -34,13 +34,21 @@ pub fn save(
             .unwrap_or_default();
 
         if let Some(led_zones) = led_colors {
+            // A zone with captured live LED colors is, by definition, in
+            // direct/per-LED mode right now — tag it Direct rather than
+            // carrying over whatever effect was configured before, or a
+            // later reconciliation will re-engage that stale effect (e.g.
+            // Static) ahead of restoring these colors.
             let zones: Vec<RgbPresetZone> = led_zones
                 .into_iter()
                 .map(|mut z| {
-                    z.effect = zone_configs
+                    let mut effect = zone_configs
                         .iter()
                         .find(|zc| zc.zone_index == z.zone)
-                        .map(|zc| zc.effect.clone());
+                        .map(|zc| zc.effect.clone())
+                        .unwrap_or_default();
+                    effect.mode = RgbMode::Direct;
+                    z.effect = Some(effect);
                     z
                 })
                 .collect();


### PR DESCRIPTION
## Summary

Builds on #145 and #146, but is an independent bug.

`save()` in `crates/lianli-daemon/src/ipc/presets.rs` captures a zone's `effect` from whatever is currently configured for it in `state.config`, even when the zone has live per-LED colors captured (the `led_colors` branch — wireless devices only, since that's the only case where a live per-LED buffer exists to read back). If that zone had never been switched to Direct mode before, the new preset ends up storing the new direct colors *and* a stale effect (e.g. `Static`).

On reconciliation (`RgbController::apply_config`), the zone's `effect` gets applied to the device *before* the preset's direct colors are restored. A stale `Static` effect there means every reconciliation cycle briefly re-asserts the old static color ahead of the correct direct colors — visible as flicker or, depending on wireless timing, the direct colors losing the race entirely.

Confirmed live: for a device whose zones had never been in Direct mode, every preset I saved — regardless of the actual per-LED colors painted — came back with `effect.mode: "Static"`. After this fix, freshly-saved presets on the same device correctly show `effect.mode: "Direct"`.

## Fix

When live colors are captured, force the captured effect's `mode` to `Direct` (keeping its other fields — brightness, speed, etc. — intact) instead of carrying over whatever was previously configured. The other branch (saving the currently-active *effect* as a preset, no live colors) is untouched — that's a distinct, intentional feature.

## Test plan

- [x] `cargo check --release --bin lianli-daemon`
- [x] Manually verified: saved a preset on a zone that had never been in Direct mode; confirmed the resulting preset's `effect.mode` is now `Direct` instead of `Static`, and the direct colors stop flickering/losing the race on reconciliation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed saved presets so live LED zones retain their captured effects correctly.
  * Prevented stale effect settings from being reapplied when loading saved presets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->