### PR TITLE
fix: OpenRGB direct colors revert to onboard rainbow after fan PWM updates

### DIFF
--- a/crates/lianli-daemon/src/controllers/rgb/mod.rs
+++ b/crates/lianli-daemon/src/controllers/rgb/mod.rs
@@ -399,6 +399,30 @@ impl RgbController {
         Ok(())
     }
 
+    /// Re-send the last known OpenRGB direct-color frame for every wireless
+    /// device. Wireless fan-speed (PWM) packets share the same RF link as
+    /// the RGB stream and interrupt it, causing the fan to fall back to its
+    /// onboard default effect. When OpenRGB has control, the normal drift
+    /// resync (which reapplies the configured native effect) is skipped, so
+    /// this re-pushes `last_direct` instead to recover the same way.
+    pub fn resync_wireless_direct_colors(&mut self) {
+        let mut by_device: HashMap<String, HashMap<u8, Vec<[u8; 3]>>> = HashMap::new();
+        for ((device_id, zone), colors) in &self.last_direct {
+            if device_id.starts_with("wireless:") {
+                by_device
+                    .entry(device_id.clone())
+                    .or_default()
+                    .insert(*zone, colors.clone());
+            }
+        }
+
+        for (device_id, zones) in by_device {
+            if let Err(e) = self.apply_wireless_batch(&device_id, &zones) {
+                debug!("Direct-color resync failed for {device_id}: {e}");
+            }
+        }
+    }
+
     /// Upload a multi-frame animation to a wireless device via
     /// `send_rgb_frames`. Each frame must be a full-device LED buffer; the
     /// firmware then loops the animation onboard at `interval_ms` with no

--- a/crates/lianli-daemon/src/service/mod.rs
+++ b/crates/lianli-daemon/src/service/mod.rs
@@ -446,9 +446,12 @@ impl ServiceManager {
                 }
                 DaemonEvent::ResyncWirelessRgb => {
                     if let Some(ref rgb) = self.controllers.rgb {
-                        let rgb = rgb.lock();
+                        let mut rgb = rgb.lock();
                         if rgb.is_openrgb_controlled() {
-                            debug!("OpenRGB server active, skipping wireless drift resync");
+                            debug!(
+                                "OpenRGB server active — resyncing last direct-color frame instead of native effect"
+                            );
+                            rgb.resync_wireless_direct_colors();
                         } else {
                             drop(rgb);
                             self.apply_rgb_config();


### PR DESCRIPTION
## Summary

Found this while setting up per-fan segment control in OpenRGB against `lianli-daemon`'s SDK server. Independent issue: RGB set via OpenRGB's Direct mode reverts to the fan's onboard rainbow effect a few seconds after being set, as long as fan curve control is active.

Wireless fan hubs share one RF link for fan-speed control and RGB. A PWM (fan speed) packet interrupts the ongoing RGB stream, and the fan falls back to its onboard default effect. The daemon already has a workaround for this for its own native effects: every PWM change fires a `ResyncWirelessRgb` event that reapplies the configured effect (see the comment at `controllers/fan.rs:396-401`, "to prevent the ~1s rainbow flicker caused by RF fan packets interrupting the device's RGB stream").

That handler, however, bails out entirely when OpenRGB has control:

```rust
DaemonEvent::ResyncWirelessRgb => {
    if let Some(ref rgb) = self.controllers.rgb {
        let rgb = rgb.lock();
        if rgb.is_openrgb_controlled() {
            debug!("OpenRGB server active, skipping wireless drift resync");
        } else {
            drop(rgb);
            self.apply_rgb_config();
        }
    }
}
```

So when OpenRGB is driving Direct colors, the recovery step is skipped and nothing is ever reasserted — the fan reverts to rainbow on the next fan-speed update and stays there.

`RgbController` already caches the last OpenRGB direct-color frame per `(device_id, zone)` in `last_direct`, and its own doc comment says it exists for exactly this purpose ("Used to re-push state after fan PWM disrupts the device's RGB") — but nothing ever read it back.

## Fix

Added `RgbController::resync_wireless_direct_colors()`, which groups the cached `last_direct` entries by wireless device and re-sends each via the existing `apply_wireless_batch` path (the same one the OpenRGB direct-color writer uses). The `ResyncWirelessRgb` handler now calls this when OpenRGB has control instead of just logging and skipping.

## Test plan

- [x] `cargo check -p lianli-daemon`
- [x] `cargo fmt -p lianli-daemon -- --check` / `cargo clippy -p lianli-daemon --no-deps` — clean on the changed files
- [ ] Manual verification: set Direct colors via OpenRGB on a wireless fan zone with active fan curve control, confirm colors no longer revert to rainbow after a PWM update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wireless RGB recovery by restoring the most recently applied direct-color settings when OpenRGB control is active.
  * Preserved native RGB configuration as a fallback when OpenRGB control is unavailable.
  * Reduced visible color drift after wireless devices reconnect or lose synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->