### PR TITLE
Fix LCD stream deadlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2643,6 +2643,7 @@ version = "0.8.6"
 dependencies = [
  "anyhow",
  "hidapi",
+ "libc",
  "rusb",
  "thiserror 2.0.20",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ libc = "0.2"
 signal-hook = "0.3"
 
 # Video encoding
-ffmpeg-next = { version = "9.0", default-features = false, features = ["codec", "software-scaling", "format"] }
+ffmpeg-next = { version = "9.0", default-features = false, features = ["codec", "software-scaling", "format", "non-exhaustive-enums"] }
 
 # Template catalog
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls", "json"] }

--- a/crates/lianli-daemon/src/service/init.rs
+++ b/crates/lianli-daemon/src/service/init.rs
@@ -143,39 +143,35 @@ impl ServiceManager {
         }
     }
 
-    pub(super) fn enumerate_wired_controller_ids(&self) -> std::collections::HashSet<String> {
+    /// One enumeration snapshot with the derived id and topology sets.
+    /// Callers must treat `Err` as "poll skipped", never as "no devices".
+    fn snapshot_wired(&self) -> Result<(HashSet<String>, HashSet<String>), anyhow::Error> {
         use lianli_shared::device_id::DeviceFamily;
         fn is_wired_controller(family: DeviceFamily) -> bool {
             lianli_shared::device_id::uses_hid(family)
                 || matches!(family, DeviceFamily::UniversalScreenLighting)
         }
-        enumerate_devices()
-            .ok()
-            .into_iter()
-            .flatten()
+        let usb_devs = enumerate_devices()?;
+        let mut ids = HashSet::new();
+        let mut topos = HashSet::new();
+        for det in usb_devs
+            .iter()
             .filter(|det| is_wired_controller(det.family))
-            .map(|det| Self::rusb_device_id(&det))
-            .collect()
-    }
-
-    fn wired_topology_set(&self) -> std::collections::HashSet<String> {
-        use lianli_shared::device_id::DeviceFamily;
-        fn is_wired_controller(family: DeviceFamily) -> bool {
-            lianli_shared::device_id::uses_hid(family)
-                || matches!(family, DeviceFamily::UniversalScreenLighting)
+        {
+            ids.insert(Self::rusb_device_id(det));
+            topos.insert(format!("{}:{}", det.bus, det.topology_key()));
         }
-        enumerate_devices()
-            .ok()
-            .into_iter()
-            .flatten()
-            .filter(|det| is_wired_controller(det.family))
-            .map(|det| format!("{}:{}", det.bus, det.topology_key()))
-            .collect()
+        Ok((ids, topos))
     }
 
     pub(super) fn check_wired_hotplug(&mut self) {
-        let current_ids = self.enumerate_wired_controller_ids();
-        let current_topos = self.wired_topology_set();
+        let (current_ids, current_topos) = match self.snapshot_wired() {
+            Ok(sets) => sets,
+            Err(e) => {
+                warn!("Wired enumeration failed, skipping hotplug poll: {e}");
+                return;
+            }
+        };
         if current_topos != self.registry.last_wired_topos {
             let added = current_topos
                 .difference(&self.registry.last_wired_topos)
@@ -207,14 +203,15 @@ impl ServiceManager {
                 .hid_backends
                 .retain(|k, _| current_ids.contains(k));
             self.registry
+                .usb_backends
+                .retain(|k, _| current_ids.contains(k));
+            self.registry
                 .aio_lcd_devices
                 .retain(|k, _| current_ids.contains(k));
             self.registry.v2_hid_entries.clear();
             self.init_wired_devices();
             self.start_fan_control();
             self.start_aio_control();
-            self.registry.last_wired_ids = current_ids;
-            self.registry.last_wired_topos = current_topos;
             return;
         }
 
@@ -272,7 +269,11 @@ impl ServiceManager {
     /// with a timeout so that one unresponsive controller cannot block the
     /// rest of the daemon. Devices that time out are skipped and will be
     /// retried by the hotplug poller.
-    pub(super) fn init_wired_devices(&mut self) {
+    ///
+    /// Returns `false` when the rebuild was deferred or enumeration failed,
+    /// in which case the topology baseline is left untouched so a later
+    /// poll retries.
+    pub(super) fn init_wired_devices(&mut self) -> bool {
         let already_opened: HashSet<String> = self
             .registry
             .hid_backends
@@ -287,7 +288,7 @@ impl ServiceManager {
                 Err(arc) => {
                     warn!("fan_devices map still shared — deferring wired re-init");
                     self.registry.fan_devices = arc;
-                    return;
+                    return false;
                 }
             };
         let mut wired_rgb: HashMap<String, std::sync::Arc<dyn lianli_devices::traits::RgbDevice>> =
@@ -299,7 +300,7 @@ impl ServiceManager {
                 warn!("Failed to enumerate USB devices: {err}");
                 self.registry.fan_devices = Arc::new(fan_devices);
                 self.init_rgb_controller_from(wired_rgb);
-                return;
+                return false;
             }
         };
 
@@ -430,8 +431,13 @@ impl ServiceManager {
         let arc = Arc::new(fan_devices);
         self.registry.fan_devices = Arc::clone(&arc);
         self.init_rgb_controller_from(wired_rgb);
-        self.registry.last_wired_ids = self.enumerate_wired_controller_ids();
-        self.registry.last_wired_topos = self.wired_topology_set();
+        match self.snapshot_wired() {
+            Ok((ids, topos)) => {
+                self.registry.last_wired_ids = ids;
+                self.registry.last_wired_topos = topos;
+            }
+            Err(e) => warn!("Post-init enumeration failed, keeping previous baseline: {e}"),
+        }
 
         if failed_ids.is_empty() {
             if self.registry.init_retry_count > 0 {
@@ -448,6 +454,7 @@ impl ServiceManager {
             );
         }
         self.registry.failed_open_ids = failed_ids;
+        true
     }
 
     /// Dispatch an [`registry::OpenedDevice`] into the fan / RGB / AIO

--- a/crates/lianli-daemon/src/service/init.rs
+++ b/crates/lianli-daemon/src/service/init.rs
@@ -158,36 +158,70 @@ impl ServiceManager {
             .collect()
     }
 
+    fn wired_topology_set(&self) -> std::collections::HashSet<String> {
+        use lianli_shared::device_id::DeviceFamily;
+        fn is_wired_controller(family: DeviceFamily) -> bool {
+            lianli_shared::device_id::uses_hid(family)
+                || matches!(family, DeviceFamily::UniversalScreenLighting)
+        }
+        enumerate_devices()
+            .ok()
+            .into_iter()
+            .flatten()
+            .filter(|det| is_wired_controller(det.family))
+            .map(|det| format!("{}:{}", det.bus, det.topology_key()))
+            .collect()
+    }
+
     pub(super) fn check_wired_hotplug(&mut self) {
-        let current = self.enumerate_wired_controller_ids();
-        if current != self.registry.last_wired_ids {
-            let added = current.difference(&self.registry.last_wired_ids).count();
-            let removed = self.registry.last_wired_ids.difference(&current).count();
+        let current_ids = self.enumerate_wired_controller_ids();
+        let current_topos = self.wired_topology_set();
+        if current_topos != self.registry.last_wired_topos {
+            let added = current_topos
+                .difference(&self.registry.last_wired_topos)
+                .count();
+            let removed = self
+                .registry
+                .last_wired_topos
+                .difference(&current_topos)
+                .count();
+            let now = std::time::Instant::now();
+            const MIN_REINIT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
+            if let Some(last) = self.registry.last_reinit {
+                if now.duration_since(last) < MIN_REINIT_INTERVAL {
+                    debug!("Wired topology changed (+{added} -{removed}) but re-init rate-limited");
+                    return;
+                }
+            }
+            self.registry.last_reinit = Some(now);
             info!("Wired device topology changed (+{added} -{removed}): re-initializing");
 
+            // stop controllers first, they hold Arcs into fan_devices
             if let Some(controller) = self.controllers.fan.take() {
+                controller.stop();
+            }
+            if let Some(controller) = self.controllers.aio.take() {
                 controller.stop();
             }
             self.registry
                 .hid_backends
-                .retain(|k, _| current.contains(k));
+                .retain(|k, _| current_ids.contains(k));
             self.registry
                 .aio_lcd_devices
-                .retain(|k, _| current.contains(k));
+                .retain(|k, _| current_ids.contains(k));
             self.registry.v2_hid_entries.clear();
             self.init_wired_devices();
             self.start_fan_control();
-            // AioController snapshots the wired device map at start; restart
-            // it so hotplug re-init is picked up.
             self.start_aio_control();
-            self.registry.last_wired_ids = current;
+            self.registry.last_wired_ids = current_ids;
+            self.registry.last_wired_topos = current_topos;
             return;
         }
 
         let pending: HashSet<String> = self
             .registry
             .failed_open_ids
-            .intersection(&current)
+            .intersection(&current_ids)
             .cloned()
             .collect();
         if pending.is_empty() || self.registry.init_retry_count >= MAX_INIT_RETRIES {
@@ -201,6 +235,9 @@ impl ServiceManager {
             MAX_INIT_RETRIES
         );
         if let Some(controller) = self.controllers.fan.take() {
+            controller.stop();
+        }
+        if let Some(controller) = self.controllers.aio.take() {
             controller.stop();
         }
         self.init_wired_devices();
@@ -248,8 +285,9 @@ impl ServiceManager {
             match Arc::try_unwrap(std::mem::take(&mut self.registry.fan_devices)) {
                 Ok(map) => map,
                 Err(arc) => {
+                    warn!("fan_devices map still shared — deferring wired re-init");
                     self.registry.fan_devices = arc;
-                    HashMap::new()
+                    return;
                 }
             };
         let mut wired_rgb: HashMap<String, std::sync::Arc<dyn lianli_devices::traits::RgbDevice>> =
@@ -393,6 +431,7 @@ impl ServiceManager {
         self.registry.fan_devices = Arc::clone(&arc);
         self.init_rgb_controller_from(wired_rgb);
         self.registry.last_wired_ids = self.enumerate_wired_controller_ids();
+        self.registry.last_wired_topos = self.wired_topology_set();
 
         if failed_ids.is_empty() {
             if self.registry.init_retry_count > 0 {

--- a/crates/lianli-daemon/src/service/media.rs
+++ b/crates/lianli-daemon/src/service/media.rs
@@ -383,6 +383,7 @@ impl ServiceManager {
                                 let hid_init = std::sync::Arc::clone(hid);
                                 let enable_512 = device_cfg.aio_512_frame_for(candidate.family);
                                 let device_id = candidate.device_id.clone();
+                                let init_tx = self.tx.clone();
                                 std::thread::Builder::new()
                                     .name(format!("lcd-init-{device_id}"))
                                     .spawn(move || {
@@ -391,6 +392,11 @@ impl ServiceManager {
                                             warn!("AIO LCD init failed for {device_id}: {e:#}");
                                         }
                                         guard.set_use_c_command(enable_512);
+                                        drop(guard);
+                                        if let Some(tx) = init_tx {
+                                            tx.send(DaemonEvent::LcdInitComplete { device_id })
+                                                .ok();
+                                        }
                                     })
                                     .ok();
                                 self.aio_lcd_firmware

--- a/crates/lianli-daemon/src/service/media.rs
+++ b/crates/lianli-daemon/src/service/media.rs
@@ -378,17 +378,21 @@ impl ServiceManager {
                             device_cfg.orientation
                         );
                         if let LcdBackend::HidLcd(ref hid) = lcd {
-                            let mut guard = hid.lock();
-                            if let Err(e) = guard.initialize() {
-                                warn!(
-                                    "AIO LCD basic init failed for {}: {e:#}",
-                                    candidate.device_id
-                                );
-                            }
+                            // hydroshift init sleeps 10s, keep it off the main loop
                             if is_wired_aio_lcd(candidate.family) {
-                                guard.set_use_c_command(
-                                    device_cfg.aio_512_frame_for(candidate.family),
-                                );
+                                let hid_init = std::sync::Arc::clone(hid);
+                                let enable_512 = device_cfg.aio_512_frame_for(candidate.family);
+                                let device_id = candidate.device_id.clone();
+                                std::thread::Builder::new()
+                                    .name(format!("lcd-init-{device_id}"))
+                                    .spawn(move || {
+                                        let mut guard = hid_init.lock();
+                                        if let Err(e) = guard.initialize() {
+                                            warn!("AIO LCD init failed for {device_id}: {e:#}");
+                                        }
+                                        guard.set_use_c_command(enable_512);
+                                    })
+                                    .ok();
                                 self.aio_lcd_firmware
                                     .record(&candidate.device_id, None, false);
                                 if !self.aio_lcd_firmware.should_skip(&candidate.device_id) {
@@ -396,6 +400,14 @@ impl ServiceManager {
                                         &candidate.device_id,
                                         std::time::Duration::from_secs(10),
                                         device_cfg.aio_512_frame_for(candidate.family),
+                                    );
+                                }
+                            } else {
+                                let mut guard = hid.lock();
+                                if let Err(e) = guard.initialize() {
+                                    warn!(
+                                        "AIO LCD basic init failed for {}: {e:#}",
+                                        candidate.device_id
                                     );
                                 }
                             }

--- a/crates/lianli-daemon/src/service/mod.rs
+++ b/crates/lianli-daemon/src/service/mod.rs
@@ -12,7 +12,7 @@ use std::sync::mpsc::Sender;
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use runtime::LcdBackend;
 
@@ -32,6 +32,38 @@ use aio_lcd_firmware::AioLcdFirmwareTracker;
 use subsystems::{Controllers, DeviceRegistry, IpcSubsystem, OpenRgbSubsystem};
 
 use runtime::ActiveTarget;
+
+fn event_label(event: &DaemonEvent) -> &'static str {
+    match event {
+        DaemonEvent::IpcUpdate => "IpcUpdate",
+        DaemonEvent::USBCheck => "USBCheck",
+        DaemonEvent::DevicePoll => "DevicePoll",
+        DaemonEvent::DisplaySwitch { .. } => "DisplaySwitch",
+        DaemonEvent::DisplaySwitchToLcd { .. } => "DisplaySwitchToLcd",
+        DaemonEvent::Bind { .. } => "Bind",
+        DaemonEvent::Unbind { .. } => "Unbind",
+        DaemonEvent::SetEne6k77FanQuantity { .. } => "SetEne6k77FanQuantity",
+        DaemonEvent::FrameFinished => "FrameFinished",
+        DaemonEvent::RecreateMedia { .. } => "RecreateMedia",
+        DaemonEvent::ResyncWirelessRgb => "ResyncWirelessRgb",
+        DaemonEvent::SystemResumed => "SystemResumed",
+        DaemonEvent::RebootWirelessLcd { .. } => "RebootWirelessLcd",
+        DaemonEvent::DisableLc217Wifi { .. } => "DisableLc217Wifi",
+        DaemonEvent::SetLcdBrightness { .. } => "SetLcdBrightness",
+        DaemonEvent::BindAll => "BindAll",
+        DaemonEvent::UnbindAll => "UnbindAll",
+        DaemonEvent::Shutdown => "Shutdown",
+    }
+}
+
+struct WatchdogClearGuard(Arc<Mutex<(&'static str, Instant)>>);
+impl Drop for WatchdogClearGuard {
+    fn drop(&mut self) {
+        let mut op = self.0.lock();
+        op.0 = "idle";
+        op.1 = Instant::now();
+    }
+}
 
 /// Parse a colon-separated MAC address string (e.g. `"01:23:45:67:89:AB"`)
 /// into a 6-byte array. Returns `None` on malformed input.
@@ -149,42 +181,41 @@ impl ServiceManager {
         let ready = self.aio_lcd_firmware.drain_due();
 
         for (device_id, enable_512) in ready {
-            let mut firmware_result: Option<Result<(Option<String>, bool), anyhow::Error>> = None;
-            {
-                let mut targets = self.targets.lock();
-                if let Some(target) = targets
-                    .values_mut()
+            let lcd: Option<runtime::SharedHidLcd> = {
+                let targets = self.targets.lock();
+                targets
+                    .values()
                     .find(|t| t.device_identity == device_id)
-                {
-                    if let LcdBackend::HidLcd(ref hid) = target.lcd {
-                        let mut guard = hid.lock();
-                        match guard.try_read_firmware() {
-                            Ok(()) => {
-                                let fw = guard.firmware_version_str().map(|s| s.to_string());
-                                let supports = guard.supports_c_command();
-                                guard.set_use_c_command(enable_512);
-                                firmware_result = Some(Ok((fw, supports)));
-                            }
-                            Err(e) => {
-                                firmware_result = Some(Err(e));
-                            }
-                        }
-                    }
-                }
-            }
-            match firmware_result {
-                Some(Ok((fw, supports))) => {
+                    .and_then(|t| match &t.lcd {
+                        LcdBackend::HidLcd(hid) => Some(Arc::clone(hid)),
+                        _ => None,
+                    })
+            };
+
+            let Some(lcd) = lcd else {
+                continue;
+            };
+            let Some(mut guard) = lcd.try_lock_for(Duration::from_millis(500)) else {
+                debug!("AIO LCD {device_id}: busy, deferring firmware read by 10s");
+                self.aio_lcd_firmware
+                    .schedule(&device_id, Duration::from_secs(10), enable_512);
+                continue;
+            };
+            match guard.try_read_firmware() {
+                Ok(()) => {
+                    let fw = guard.firmware_version_str().map(|s| s.to_string());
+                    let supports = guard.supports_c_command();
+                    guard.set_use_c_command(enable_512);
                     self.aio_lcd_firmware.record(&device_id, fw, supports);
                     info!("AIO LCD firmware read succeeded for {device_id}");
                 }
-                Some(Err(e)) => {
+                Err(e) => {
                     warn!(
                         "AIO LCD firmware read failed for {device_id}: {e:#}. \
                          Skipping firmware reads for 30 minutes."
                     );
                     self.aio_lcd_firmware.mark_failed(&device_id);
                 }
-                None => {}
             }
         }
     }
@@ -414,7 +445,49 @@ impl ServiceManager {
             }
         });
 
+        let watchdog_op: Arc<Mutex<(&'static str, Instant)>> =
+            Arc::new(Mutex::new(("idle", Instant::now())));
+        {
+            let wd = Arc::clone(&watchdog_op);
+            thread::spawn(move || {
+                let mut warned_5 = false;
+                let mut warned_30 = false;
+                let mut warned_120 = false;
+                loop {
+                    thread::sleep(Duration::from_secs(1));
+                    let (label, since) = *wd.lock();
+                    let elapsed = since.elapsed();
+                    if elapsed >= Duration::from_secs(120) {
+                        if !warned_120 {
+                            error!("WATCHDOG: main loop stuck on '{label}' for 2min+");
+                            warned_120 = true;
+                        }
+                    } else if elapsed >= Duration::from_secs(30) {
+                        if !warned_30 {
+                            warn!("WATCHDOG: main loop stuck on '{label}' for 30s+");
+                            warned_30 = true;
+                        }
+                    } else if elapsed >= Duration::from_secs(5) {
+                        if !warned_5 {
+                            warn!("WATCHDOG: main loop slow: '{label}' taking 5s+");
+                            warned_5 = true;
+                        }
+                    } else {
+                        warned_5 = false;
+                        warned_30 = false;
+                        warned_120 = false;
+                    }
+                }
+            });
+        }
+
         for event in rx {
+            {
+                let mut op = watchdog_op.lock();
+                op.0 = event_label(&event);
+                op.1 = Instant::now();
+            }
+            let _watchdog_guard = WatchdogClearGuard(Arc::clone(&watchdog_op));
             match event {
                 DaemonEvent::Shutdown => {
                     break;

--- a/crates/lianli-daemon/src/service/mod.rs
+++ b/crates/lianli-daemon/src/service/mod.rs
@@ -46,6 +46,7 @@ fn event_label(event: &DaemonEvent) -> &'static str {
         DaemonEvent::FrameFinished => "FrameFinished",
         DaemonEvent::RecreateMedia { .. } => "RecreateMedia",
         DaemonEvent::ResyncWirelessRgb => "ResyncWirelessRgb",
+        DaemonEvent::LcdInitComplete { .. } => "LcdInitComplete",
         DaemonEvent::SystemResumed => "SystemResumed",
         DaemonEvent::RebootWirelessLcd { .. } => "RebootWirelessLcd",
         DaemonEvent::DisableLc217Wifi { .. } => "DisableLc217Wifi",
@@ -89,18 +90,46 @@ pub enum DaemonEvent {
     IpcUpdate, // Somebody changed the DaemonState in the mutex
     USBCheck,
     DevicePoll,
-    DisplaySwitch { device_id: String }, // LCD→Desktop. Handled by main event loop.
-    DisplaySwitchToLcd { device_id: String, pid: u16 }, // Desktop→LCD. Handled by main event loop.
-    Bind { mac_address: String }, // MAC address pending wireless device bind. Handled by main event loop.
-    Unbind { mac_address: String }, // MAC address pending wireless device unbind. Handled by main event loop.
-    SetEne6k77FanQuantity { device_id: String, quantity: u8 },
+    DisplaySwitch {
+        device_id: String,
+    }, // LCD→Desktop. Handled by main event loop.
+    DisplaySwitchToLcd {
+        device_id: String,
+        pid: u16,
+    }, // Desktop→LCD. Handled by main event loop.
+    Bind {
+        mac_address: String,
+    }, // MAC address pending wireless device bind. Handled by main event loop.
+    Unbind {
+        mac_address: String,
+    }, // MAC address pending wireless device unbind. Handled by main event loop.
+    SetEne6k77FanQuantity {
+        device_id: String,
+        quantity: u8,
+    },
     FrameFinished,
-    RecreateMedia { target_index: usize },
+    RecreateMedia {
+        target_index: usize,
+        device_id: String,
+    },
     ResyncWirelessRgb,
+    /// Background LCD init finished; the target is rebuilt so the recovery
+    /// thread starts with firmware state now known.
+    LcdInitComplete {
+        device_id: String,
+    },
     SystemResumed,
-    RebootWirelessLcd { mac: [u8; 6] },
-    DisableLc217Wifi { mac: [u8; 6], disable: bool },
-    SetLcdBrightness { device_id: String, brightness: u8 },
+    RebootWirelessLcd {
+        mac: [u8; 6],
+    },
+    DisableLc217Wifi {
+        mac: [u8; 6],
+        disable: bool,
+    },
+    SetLcdBrightness {
+        device_id: String,
+        brightness: u8,
+    },
     BindAll,
     UnbindAll,
     Shutdown, // SIGINT/SIGTERM received, exit the event loop cleanly
@@ -405,22 +434,25 @@ impl ServiceManager {
                                 target.consecutive_errors += 1;
                                 if target.consecutive_errors >= 3 {
                                     warn!("LCD[{id}] USB error (3/3): {err}");
-                                    to_recreate.push(id);
+                                    to_recreate.push((id, target.device_identity.clone()));
                                 }
                             }
                             Err(runtime::SendError::Other(err)) => {
                                 warn!("LCD[{id}] media error: {err}");
-                                to_recreate.push(id);
+                                to_recreate.push((id, target.device_identity.clone()));
                             }
                         }
                     }
-                    for id in &to_recreate {
-                        targets.remove(id);
+                    for &(id, _) in &to_recreate {
+                        targets.remove(&id);
                     }
                 }
-                for id in to_recreate {
+                for (id, device_id) in to_recreate {
                     stream_main_tx
-                        .send(DaemonEvent::RecreateMedia { target_index: id })
+                        .send(DaemonEvent::RecreateMedia {
+                            target_index: id,
+                            device_id,
+                        })
                         .ok();
                 }
                 thread::sleep(Duration::from_millis(1));
@@ -589,8 +621,20 @@ impl ServiceManager {
                         }
                     }
                 }
-                DaemonEvent::RecreateMedia { target_index } => {
-                    if let Some(asset) = self.media_assets.get(&target_index).cloned() {
+                DaemonEvent::RecreateMedia {
+                    target_index,
+                    device_id,
+                } => {
+                    // ignore stale events from a detached recovery thread
+                    // whose target slot has since been reused
+                    let matches_current = self
+                        .targets
+                        .lock()
+                        .get(&target_index)
+                        .is_some_and(|t| t.device_identity == device_id);
+                    if !matches_current {
+                        debug!("Ignoring stale RecreateMedia for LCD[{device_id}]");
+                    } else if let Some(asset) = self.media_assets.get(&target_index).cloned() {
                         if let Some(target) = self.targets.lock().get_mut(&target_index) {
                             info!(
                                 "[devices] LCD[{}] recreating media after recovery",
@@ -598,6 +642,21 @@ impl ServiceManager {
                             );
                             target.swap_media(asset, target.custom_h264, self.tx.clone());
                         }
+                    }
+                }
+                DaemonEvent::LcdInitComplete { device_id } => {
+                    // rebuild the target so the recovery thread is created
+                    // with firmware state now recorded
+                    let mut targets = self.targets.lock();
+                    if let Some((idx, _)) = targets
+                        .iter()
+                        .find(|(_, t)| t.device_identity == device_id)
+                        .map(|(i, t)| (*i, t.device_identity.clone()))
+                    {
+                        let (_, mut target) = targets.remove_entry(&idx).unwrap();
+                        target.stop();
+                        drop(targets);
+                        info!("[devices] LCD[{device_id}] init complete, rebuilding target");
                     }
                 }
                 DaemonEvent::RebootWirelessLcd { mac } => {

--- a/crates/lianli-daemon/src/service/mod.rs
+++ b/crates/lianli-daemon/src/service/mod.rs
@@ -645,18 +645,16 @@ impl ServiceManager {
                     }
                 }
                 DaemonEvent::LcdInitComplete { device_id } => {
-                    // rebuild the target so the recovery thread is created
-                    // with firmware state now recorded
+                    // firmware state is now recorded by the init worker;
+                    // start the recovery thread if the target was created
+                    // before init finished. Idempotent, no teardown.
+                    let tx = self.tx.clone();
                     let mut targets = self.targets.lock();
-                    if let Some((idx, _)) = targets
-                        .iter()
+                    if let Some((_, target)) = targets
+                        .iter_mut()
                         .find(|(_, t)| t.device_identity == device_id)
-                        .map(|(i, t)| (*i, t.device_identity.clone()))
                     {
-                        let (_, mut target) = targets.remove_entry(&idx).unwrap();
-                        target.stop();
-                        drop(targets);
-                        info!("[devices] LCD[{device_id}] init complete, rebuilding target");
+                        target.maybe_start_recovery(tx);
                     }
                 }
                 DaemonEvent::RebootWirelessLcd { mac } => {

--- a/crates/lianli-daemon/src/service/renderers.rs
+++ b/crates/lianli-daemon/src/service/renderers.rs
@@ -1,4 +1,4 @@
-use super::runtime::{LcdBackend, StreamRestarter};
+use super::runtime::{HidStreamWorker, LcdBackend, StreamRestarter};
 use super::DaemonEvent;
 use lianli_media::sensor::FrameInfo;
 use lianli_media::video::LiveH264Encoder;
@@ -335,7 +335,7 @@ pub(super) struct AsyncCustomH264Renderer {
     stop_flag: Arc<AtomicBool>,
     _encoder: Arc<Mutex<LiveH264Encoder>>,
     _thread: Option<JoinHandle<()>>,
-    _stream_thread: Option<(JoinHandle<()>, Arc<AtomicBool>)>,
+    _stream_thread: Option<HidStreamWorker>,
 }
 
 impl AsyncCustomH264Renderer {
@@ -355,8 +355,7 @@ impl AsyncCustomH264Renderer {
             .ok_or_else(|| anyhow::anyhow!("h264 encoder stdout missing"))?;
 
         let stop_flag = Arc::new(AtomicBool::new(false));
-        let stream_thread = lcd.start_h264_stream(stdout, Arc::clone(&stop_flag), fps)?;
-        let stream_halt = stream_thread.as_ref().map(|(_, halt)| Arc::clone(halt));
+        let mut stream_thread = lcd.start_h264_stream(stdout, Arc::clone(&stop_flag), fps)?;
         let stop_clone = Arc::clone(&stop_flag);
         let encoder = Arc::new(Mutex::new(encoder));
         let encoder_clone = Arc::clone(&encoder);
@@ -364,7 +363,7 @@ impl AsyncCustomH264Renderer {
             Duration::from_secs_f32(1.0 / fps.max(1.0)).max(Duration::from_millis(16));
 
         let restarter = lcd
-            .stream_restarter(stream_halt)
+            .stream_restarter(stream_thread.take())
             .ok_or_else(|| anyhow::anyhow!("h264 streaming not supported on this backend"))?;
         let screen_clone = *screen;
 
@@ -439,7 +438,7 @@ pub(super) struct AsyncSensorH264Renderer {
     stop_flag: Arc<AtomicBool>,
     _encoder: Arc<Mutex<LiveH264Encoder>>,
     _thread: Option<JoinHandle<()>>,
-    _stream_thread: Option<(JoinHandle<()>, Arc<AtomicBool>)>,
+    _stream_thread: Option<HidStreamWorker>,
 }
 
 impl AsyncSensorH264Renderer {
@@ -464,8 +463,7 @@ impl AsyncSensorH264Renderer {
             .ok_or_else(|| anyhow::anyhow!("h264 encoder stdout missing"))?;
 
         let stop_flag = Arc::new(AtomicBool::new(false));
-        let stream_thread = lcd.start_h264_stream(stdout, Arc::clone(&stop_flag), fps)?;
-        let stream_halt = stream_thread.as_ref().map(|(_, halt)| Arc::clone(halt));
+        let mut stream_thread = lcd.start_h264_stream(stdout, Arc::clone(&stop_flag), fps)?;
         let stop_clone = Arc::clone(&stop_flag);
         let encoder = Arc::new(Mutex::new(encoder));
         let encoder_clone = Arc::clone(&encoder);
@@ -477,7 +475,7 @@ impl AsyncSensorH264Renderer {
         }
 
         let restarter = lcd
-            .stream_restarter(stream_halt)
+            .stream_restarter(stream_thread.take())
             .ok_or_else(|| anyhow::anyhow!("h264 streaming not supported on this backend"))?;
         let screen_clone = *screen;
 

--- a/crates/lianli-daemon/src/service/renderers.rs
+++ b/crates/lianli-daemon/src/service/renderers.rs
@@ -335,7 +335,7 @@ pub(super) struct AsyncCustomH264Renderer {
     stop_flag: Arc<AtomicBool>,
     _encoder: Arc<Mutex<LiveH264Encoder>>,
     _thread: Option<JoinHandle<()>>,
-    _stream_thread: Option<JoinHandle<()>>,
+    _stream_thread: Option<(JoinHandle<()>, Arc<AtomicBool>)>,
 }
 
 impl AsyncCustomH264Renderer {
@@ -356,6 +356,7 @@ impl AsyncCustomH264Renderer {
 
         let stop_flag = Arc::new(AtomicBool::new(false));
         let stream_thread = lcd.start_h264_stream(stdout, Arc::clone(&stop_flag), fps)?;
+        let stream_halt = stream_thread.as_ref().map(|(_, halt)| Arc::clone(halt));
         let stop_clone = Arc::clone(&stop_flag);
         let encoder = Arc::new(Mutex::new(encoder));
         let encoder_clone = Arc::clone(&encoder);
@@ -363,7 +364,7 @@ impl AsyncCustomH264Renderer {
             Duration::from_secs_f32(1.0 / fps.max(1.0)).max(Duration::from_millis(16));
 
         let restarter = lcd
-            .stream_restarter()
+            .stream_restarter(stream_halt)
             .ok_or_else(|| anyhow::anyhow!("h264 streaming not supported on this backend"))?;
         let screen_clone = *screen;
 
@@ -438,7 +439,7 @@ pub(super) struct AsyncSensorH264Renderer {
     stop_flag: Arc<AtomicBool>,
     _encoder: Arc<Mutex<LiveH264Encoder>>,
     _thread: Option<JoinHandle<()>>,
-    _stream_thread: Option<JoinHandle<()>>,
+    _stream_thread: Option<(JoinHandle<()>, Arc<AtomicBool>)>,
 }
 
 impl AsyncSensorH264Renderer {
@@ -464,6 +465,7 @@ impl AsyncSensorH264Renderer {
 
         let stop_flag = Arc::new(AtomicBool::new(false));
         let stream_thread = lcd.start_h264_stream(stdout, Arc::clone(&stop_flag), fps)?;
+        let stream_halt = stream_thread.as_ref().map(|(_, halt)| Arc::clone(halt));
         let stop_clone = Arc::clone(&stop_flag);
         let encoder = Arc::new(Mutex::new(encoder));
         let encoder_clone = Arc::clone(&encoder);
@@ -475,7 +477,7 @@ impl AsyncSensorH264Renderer {
         }
 
         let restarter = lcd
-            .stream_restarter()
+            .stream_restarter(stream_halt)
             .ok_or_else(|| anyhow::anyhow!("h264 streaming not supported on this backend"))?;
         let screen_clone = *screen;
 

--- a/crates/lianli-daemon/src/service/runtime.rs
+++ b/crates/lianli-daemon/src/service/runtime.rs
@@ -24,6 +24,10 @@ use tracing::{debug, info, warn};
 pub(super) type SharedHidLcd = Arc<Mutex<Box<dyn LcdDevice>>>;
 
 // lock per access unit only, never for the whole stream
+// no sane access unit comes close; malformed streams without a second
+// boundary would otherwise grow `accum` without limit
+const MAX_AU_BYTES: usize = 4 * 1024 * 1024;
+
 fn spawn_hid_h264_stream(
     lcd: SharedHidLcd,
     mut reader: Box<dyn std::io::Read + Send>,
@@ -58,6 +62,13 @@ fn spawn_hid_h264_stream(
                 break;
             }
             accum.extend_from_slice(&read_buf[..n]);
+            if accum.len() > MAX_AU_BYTES {
+                warn!(
+                    "HID h264 stream: no AU boundary within {} bytes, aborting",
+                    MAX_AU_BYTES
+                );
+                return;
+            }
             while let Some(split) = find_au_split(&accum) {
                 let au: Vec<u8> = accum.drain(..split).collect();
                 if au.is_empty() {
@@ -398,12 +409,18 @@ impl ActiveTarget {
         let recovery_stop = Arc::new(AtomicBool::new(false));
         let recovery_thread = match &lcd {
             LcdBackend::HidLcd(d) => {
-                if !d.lock().supports_c_command() {
+                // bounded: the init worker holds this mutex across the 10s
+                // settle on some paths
+                let supports = d
+                    .try_lock_for(Duration::from_millis(200))
+                    .is_some_and(|guard| guard.supports_c_command());
+                if !supports {
                     None
                 } else {
                     let lcd = Arc::clone(d);
                     let stop = Arc::clone(&recovery_stop);
                     let recovery_tx = tx.clone();
+                    let device_id = device_identity.clone();
                     Some(thread::spawn(move || {
                         use lianli_devices::traits::RecoveryAction;
                         while !stop.load(Ordering::Relaxed) {
@@ -417,10 +434,13 @@ impl ActiveTarget {
                             match guard.check_and_recover_lcd() {
                                 Ok(RecoveryAction::Recovered) => {
                                     if let Some(tx) = &recovery_tx {
-                                        tx.send(DaemonEvent::RecreateMedia {
-                                            target_index: index,
-                                        })
-                                        .ok();
+                                        if !stop.load(Ordering::Relaxed) {
+                                            tx.send(DaemonEvent::RecreateMedia {
+                                                target_index: index,
+                                                device_id: device_id.clone(),
+                                            })
+                                            .ok();
+                                        }
                                     }
                                 }
                                 Ok(RecoveryAction::NoChange) => {}
@@ -876,6 +896,13 @@ fn stream_h264_file_to_hid(
                 break;
             }
             accum.extend_from_slice(&read_buf[..n]);
+            if accum.len() > MAX_AU_BYTES {
+                warn!(
+                    "HID h264 file: no AU boundary within {} bytes, aborting",
+                    MAX_AU_BYTES
+                );
+                break 'outer;
+            }
             while let Some(split) = find_au_split(&accum) {
                 let au: Vec<u8> = accum.drain(..split).collect();
                 if au.is_empty() {

--- a/crates/lianli-daemon/src/service/runtime.rs
+++ b/crates/lianli-daemon/src/service/runtime.rs
@@ -962,8 +962,7 @@ fn stream_h264_file_to_hid(
             break;
         }
         let mut accum: Vec<u8> = Vec::with_capacity(256 * 1024);
-        let mut aus_sent = 0usize;
-        let mut clean_eof = false;
+        let mut sent_any = false;
         loop {
             if stop.load(Ordering::Relaxed) {
                 break 'outer;
@@ -976,7 +975,6 @@ fn stream_h264_file_to_hid(
                 }
             };
             if n == 0 {
-                clean_eof = true;
                 break;
             }
             accum.extend_from_slice(&read_buf[..n]);
@@ -1003,22 +1001,24 @@ fn stream_h264_file_to_hid(
                     warn!("HID h264 stream send error: {e:#}");
                     break 'outer;
                 }
-                aus_sent += 1;
+                sent_any = true;
                 pace_frame(&mut next_deadline, frame_interval);
             }
         }
-        // residual flush only on clean EOF, paced like a regular AU
-        if clean_eof && !stop.load(Ordering::Relaxed) && !accum.is_empty() {
+        // reached only via the EOF break (every other exit is break 'outer),
+        // residual flush is paced like a regular AU
+        if !stop.load(Ordering::Relaxed) && !accum.is_empty() {
             pace_frame(&mut next_deadline, frame_interval);
-            if let Err(e) = lcd.lock().send_h264_frame(&accum) {
-                debug!("HID h264 flush: {e:#}");
+            match lcd.lock().send_h264_frame(&accum) {
+                Ok(()) => sent_any = true,
+                Err(e) => debug!("HID h264 flush: {e:#}"),
             }
         }
         if !looping || stop.load(Ordering::Relaxed) {
             break;
         }
         // an empty or boundary-less file would otherwise loop forever
-        if aus_sent == 0 {
+        if !sent_any {
             warn!("HID h264 file produced no complete access units, stopping");
             break;
         }

--- a/crates/lianli-daemon/src/service/runtime.rs
+++ b/crates/lianli-daemon/src/service/runtime.rs
@@ -28,17 +28,23 @@ pub(super) type SharedHidLcd = Arc<Mutex<Box<dyn LcdDevice>>>;
 // boundary would otherwise grow `accum` without limit
 const MAX_AU_BYTES: usize = 4 * 1024 * 1024;
 
+/// Returns the join handle plus the worker's private halt flag so a
+/// replacement stream can stop this one promptly.
 fn spawn_hid_h264_stream(
     lcd: SharedHidLcd,
     mut reader: Box<dyn std::io::Read + Send>,
     stop: Arc<AtomicBool>,
     fps: f32,
-) -> JoinHandle<()> {
+) -> (JoinHandle<()>, Arc<AtomicBool>) {
     use lianli_devices::hydroshift_lcd::{find_au_split, pace_frame};
     use std::io::Read;
     use std::time::Instant;
 
-    thread::spawn(move || {
+    let halt = Arc::new(AtomicBool::new(false));
+    let worker_halt = Arc::clone(&halt);
+    let worker_stop = Arc::clone(&stop);
+    let handle = thread::spawn(move || {
+        let halted = || worker_stop.load(Ordering::Relaxed) || worker_halt.load(Ordering::Relaxed);
         let fps = {
             let mut guard = lcd.lock();
             guard.set_stream_fps(fps)
@@ -47,8 +53,11 @@ fn spawn_hid_h264_stream(
         let mut read_buf = vec![0u8; 64 * 1024];
         let mut accum: Vec<u8> = Vec::with_capacity(256 * 1024);
         let mut next_deadline = Instant::now() + frame_interval;
+        // residual data is only flushed on a clean EOF, never after a stop
+        // or error exit where it may be a partial access unit
+        let mut clean_eof = false;
         loop {
-            if stop.load(Ordering::Relaxed) {
+            if halted() {
                 break;
             }
             let n = match reader.read(&mut read_buf) {
@@ -59,6 +68,7 @@ fn spawn_hid_h264_stream(
                 }
             };
             if n == 0 {
+                clean_eof = true;
                 break;
             }
             accum.extend_from_slice(&read_buf[..n]);
@@ -83,17 +93,18 @@ fn spawn_hid_h264_stream(
                     return;
                 }
                 pace_frame(&mut next_deadline, frame_interval);
-                if stop.load(Ordering::Relaxed) {
+                if halted() {
                     return;
                 }
             }
         }
-        if !accum.is_empty() {
+        if clean_eof && !halted() && !accum.is_empty() {
             if let Err(e) = lcd.lock().send_h264_frame(&accum) {
                 debug!("HID h264 flush: {e:#}");
             }
         }
-    })
+    });
+    (handle, halt)
 }
 
 pub(super) enum LcdBackend {
@@ -157,11 +168,11 @@ impl LcdBackend {
         stdout: ChildStdout,
         stop: Arc<AtomicBool>,
         fps: f32,
-    ) -> anyhow::Result<Option<JoinHandle<()>>> {
+    ) -> anyhow::Result<Option<(JoinHandle<()>, Arc<AtomicBool>)>> {
         match self {
             Self::HidLcd(lcd) => {
-                let handle = spawn_hid_h264_stream(Arc::clone(lcd), Box::new(stdout), stop, fps);
-                Ok(Some(handle))
+                let spawned = spawn_hid_h264_stream(Arc::clone(lcd), Box::new(stdout), stop, fps);
+                Ok(Some(spawned))
             }
             Self::WinUsb(sender) => {
                 sender.stream_h264_reader(stdout, fps)?;
@@ -172,10 +183,18 @@ impl LcdBackend {
     }
 
     /// Create a restart-capable handle that can be moved into a render thread
-    /// to start a new h264 stream after encoder failure.
-    pub(super) fn stream_restarter(&self) -> Option<StreamRestarter> {
+    /// to start a new h264 stream after encoder failure. `initial_halt` is
+    /// the halt flag of the worker started by `start_h264_stream`, so the
+    /// first restart can stop it.
+    pub(super) fn stream_restarter(
+        &self,
+        initial_halt: Option<Arc<AtomicBool>>,
+    ) -> Option<StreamRestarter> {
         match self {
-            Self::HidLcd(lcd) => Some(StreamRestarter::HidLcd(Arc::clone(lcd))),
+            Self::HidLcd(lcd) => Some(StreamRestarter::HidLcd(
+                Arc::clone(lcd),
+                Mutex::new(initial_halt),
+            )),
             Self::WinUsb(sender) => Some(StreamRestarter::WinUsb(
                 sender.tx.clone(),
                 Arc::clone(&sender.h264_stop),
@@ -187,7 +206,7 @@ impl LcdBackend {
 
 /// Cloneable handle for restarting an h264 stream from inside a render thread.
 pub(super) enum StreamRestarter {
-    HidLcd(SharedHidLcd),
+    HidLcd(SharedHidLcd, Mutex<Option<Arc<AtomicBool>>>),
     WinUsb(std::sync::mpsc::SyncSender<LcdThreadMsg>, Arc<AtomicBool>),
 }
 
@@ -201,8 +220,14 @@ impl StreamRestarter {
         fps: f32,
     ) -> anyhow::Result<Option<JoinHandle<()>>> {
         match self {
-            Self::HidLcd(lcd) => {
-                let handle = spawn_hid_h264_stream(Arc::clone(lcd), Box::new(stdout), stop, fps);
+            Self::HidLcd(lcd, current) => {
+                let mut current = current.lock();
+                if let Some(old) = current.take() {
+                    old.store(true, Ordering::Relaxed);
+                }
+                let (handle, halt) =
+                    spawn_hid_h264_stream(Arc::clone(lcd), Box::new(stdout), stop, fps);
+                *current = Some(halt);
                 Ok(Some(handle))
             }
             Self::WinUsb(tx, h264_stop) => {
@@ -726,7 +751,12 @@ struct H264FileSource {
     started: bool,
     hid_thread: Option<JoinHandle<()>>,
     hid_stop: Arc<AtomicBool>,
+    /// start() runs every streaming tick; back off after an open failure
+    /// so a missing file retries periodically instead of once or per-tick.
+    retry_after: Option<std::time::Instant>,
 }
+
+const FILE_OPEN_RETRY: Duration = Duration::from_secs(5);
 
 impl H264FileSource {
     fn new(path: PathBuf, looping: bool, fps: f32) -> Self {
@@ -737,6 +767,7 @@ impl H264FileSource {
             started: false,
             hid_thread: None,
             hid_stop: Arc::new(AtomicBool::new(false)),
+            retry_after: None,
         }
     }
 }
@@ -746,16 +777,31 @@ impl FrameSource for H264FileSource {
         if self.started {
             return Ok(());
         }
+        if let Some(t) = self.retry_after {
+            if std::time::Instant::now() < t {
+                return Ok(());
+            }
+        }
         match lcd {
             LcdBackend::WinUsb(sender) => {
                 sender.stream_h264(self.path.clone(), self.looping, self.fps)?;
             }
             LcdBackend::HidLcd(hid) => {
+                // open before marking started so a missing file can retry
+                let file = match std::fs::File::open(&self.path) {
+                    Ok(f) => f,
+                    Err(e) => {
+                        warn!("HID h264 file open failed for {:?}: {e:#}", self.path);
+                        self.retry_after = Some(std::time::Instant::now() + FILE_OPEN_RETRY);
+                        return Ok(());
+                    }
+                };
+                self.retry_after = None;
                 let lcd = Arc::clone(hid);
-                let (path, looping, fps) = (self.path.clone(), self.looping, self.fps);
+                let (looping, fps) = (self.looping, self.fps);
                 let stop = Arc::clone(&self.hid_stop);
                 self.hid_thread = Some(thread::spawn(move || {
-                    stream_h264_file_to_hid(lcd, path, looping, fps, stop);
+                    stream_h264_file_to_hid(lcd, file, looping, fps, stop);
                 }));
             }
             _ => {}
@@ -896,7 +942,7 @@ fn make_frame_source(
 
 fn stream_h264_file_to_hid(
     lcd: SharedHidLcd,
-    path: PathBuf,
+    mut file: std::fs::File,
     looping: bool,
     fps: f32,
     stop: Arc<AtomicBool>,
@@ -905,13 +951,6 @@ fn stream_h264_file_to_hid(
     use std::io::{Read, Seek, SeekFrom};
     use std::time::Instant;
 
-    let mut file = match std::fs::File::open(&path) {
-        Ok(f) => f,
-        Err(e) => {
-            warn!("HID h264 file open failed: {e:#}");
-            return;
-        }
-    };
     let frame_interval = {
         let mut guard = lcd.lock();
         Duration::from_secs_f32(1.0 / guard.set_stream_fps(fps))
@@ -923,6 +962,8 @@ fn stream_h264_file_to_hid(
             break;
         }
         let mut accum: Vec<u8> = Vec::with_capacity(256 * 1024);
+        let mut aus_sent = 0usize;
+        let mut clean_eof = false;
         loop {
             if stop.load(Ordering::Relaxed) {
                 break 'outer;
@@ -935,6 +976,7 @@ fn stream_h264_file_to_hid(
                 }
             };
             if n == 0 {
+                clean_eof = true;
                 break;
             }
             accum.extend_from_slice(&read_buf[..n]);
@@ -961,15 +1003,23 @@ fn stream_h264_file_to_hid(
                     warn!("HID h264 stream send error: {e:#}");
                     break 'outer;
                 }
+                aus_sent += 1;
                 pace_frame(&mut next_deadline, frame_interval);
             }
         }
-        if !accum.is_empty() {
+        // residual flush only on clean EOF, paced like a regular AU
+        if clean_eof && !stop.load(Ordering::Relaxed) && !accum.is_empty() {
+            pace_frame(&mut next_deadline, frame_interval);
             if let Err(e) = lcd.lock().send_h264_frame(&accum) {
                 debug!("HID h264 flush: {e:#}");
             }
         }
         if !looping || stop.load(Ordering::Relaxed) {
+            break;
+        }
+        // an empty or boundary-less file would otherwise loop forever
+        if aus_sent == 0 {
+            warn!("HID h264 file produced no complete access units, stopping");
             break;
         }
         if let Err(e) = file.seek(SeekFrom::Start(0)) {

--- a/crates/lianli-daemon/src/service/runtime.rs
+++ b/crates/lianli-daemon/src/service/runtime.rs
@@ -946,6 +946,9 @@ fn stream_h264_file_to_hid(
                 break 'outer;
             }
             while let Some(split) = find_au_split(&accum) {
+                if stop.load(Ordering::Relaxed) {
+                    break 'outer;
+                }
                 let au: Vec<u8> = accum.drain(..split).collect();
                 if au.is_empty() {
                     continue;

--- a/crates/lianli-daemon/src/service/runtime.rs
+++ b/crates/lianli-daemon/src/service/runtime.rs
@@ -23,6 +23,68 @@ use tracing::{debug, info, warn};
 
 pub(super) type SharedHidLcd = Arc<Mutex<Box<dyn LcdDevice>>>;
 
+// lock per access unit only, never for the whole stream
+fn spawn_hid_h264_stream(
+    lcd: SharedHidLcd,
+    mut reader: Box<dyn std::io::Read + Send>,
+    stop: Arc<AtomicBool>,
+    fps: f32,
+) -> JoinHandle<()> {
+    use lianli_devices::hydroshift_lcd::{find_au_split, pace_frame};
+    use std::io::Read;
+    use std::time::Instant;
+
+    thread::spawn(move || {
+        let fps = {
+            let mut guard = lcd.lock();
+            guard.set_stream_fps(fps)
+        };
+        let frame_interval = Duration::from_secs_f32(1.0 / fps);
+        let mut read_buf = vec![0u8; 64 * 1024];
+        let mut accum: Vec<u8> = Vec::with_capacity(256 * 1024);
+        let mut next_deadline = Instant::now() + frame_interval;
+        loop {
+            if stop.load(Ordering::Relaxed) {
+                break;
+            }
+            let n = match reader.read(&mut read_buf) {
+                Ok(n) => n,
+                Err(e) => {
+                    warn!("HID h264 stream read error: {e:#}");
+                    break;
+                }
+            };
+            if n == 0 {
+                break;
+            }
+            accum.extend_from_slice(&read_buf[..n]);
+            while let Some(split) = find_au_split(&accum) {
+                let au: Vec<u8> = accum.drain(..split).collect();
+                if au.is_empty() {
+                    continue;
+                }
+                let result = {
+                    let mut guard = lcd.lock();
+                    guard.send_h264_frame(&au)
+                };
+                if let Err(e) = result {
+                    warn!("HID h264 stream send error: {e:#}");
+                    return;
+                }
+                pace_frame(&mut next_deadline, frame_interval);
+                if stop.load(Ordering::Relaxed) {
+                    return;
+                }
+            }
+        }
+        if !accum.is_empty() {
+            if let Err(e) = lcd.lock().send_h264_frame(&accum) {
+                debug!("HID h264 flush: {e:#}");
+            }
+        }
+    })
+}
+
 pub(super) enum LcdBackend {
     Slv3(Slv3LcdDevice),
     WinUsb(ThreadedWinUsbSender),
@@ -87,14 +149,7 @@ impl LcdBackend {
     ) -> anyhow::Result<Option<JoinHandle<()>>> {
         match self {
             Self::HidLcd(lcd) => {
-                let lcd = Arc::clone(lcd);
-                let mut stdout = stdout;
-                let handle = thread::spawn(move || {
-                    let mut guard = lcd.lock();
-                    if let Err(e) = guard.stream_h264_reader(&mut stdout, &stop, fps) {
-                        warn!("HID h264 stream error: {e:#}");
-                    }
-                });
+                let handle = spawn_hid_h264_stream(Arc::clone(lcd), Box::new(stdout), stop, fps);
                 Ok(Some(handle))
             }
             Self::WinUsb(sender) => {
@@ -136,14 +191,7 @@ impl StreamRestarter {
     ) -> anyhow::Result<Option<JoinHandle<()>>> {
         match self {
             Self::HidLcd(lcd) => {
-                let lcd = Arc::clone(lcd);
-                let mut stdout = stdout;
-                let handle = thread::spawn(move || {
-                    let mut guard = lcd.lock();
-                    if let Err(e) = guard.stream_h264_reader(&mut stdout, &stop, fps) {
-                        warn!("HID h264 stream restart error: {e:#}");
-                    }
-                });
+                let handle = spawn_hid_h264_stream(Arc::clone(lcd), Box::new(stdout), stop, fps);
                 Ok(Some(handle))
             }
             Self::WinUsb(tx, h264_stop) => {
@@ -363,7 +411,10 @@ impl ActiveTarget {
                             if stop.load(Ordering::Relaxed) {
                                 break;
                             }
-                            match lcd.lock().check_and_recover_lcd() {
+                            let Some(mut guard) = lcd.try_lock_for(Duration::from_secs(2)) else {
+                                continue;
+                            };
+                            match guard.check_and_recover_lcd() {
                                 Ok(RecoveryAction::Recovered) => {
                                     if let Some(tx) = &recovery_tx {
                                         tx.send(DaemonEvent::RecreateMedia {
@@ -482,8 +533,19 @@ impl ActiveTarget {
 
     pub(super) fn stop(&mut self) {
         self.recovery_stop.store(true, Ordering::Relaxed);
+        // dropping media sets the renderer stop flags, which unblock stop()
+        self.media = Box::new(NoopFrameSource);
         if let Some(t) = self.recovery_thread.take() {
-            let _ = t.join();
+            let deadline = std::time::Instant::now() + Duration::from_secs(5);
+            while !t.is_finished() && std::time::Instant::now() < deadline {
+                thread::sleep(Duration::from_millis(50));
+            }
+            if !t.is_finished() {
+                warn!(
+                    "LCD[{}] recovery thread did not stop in 5s — detaching it",
+                    self.index
+                );
+            }
         }
     }
 }
@@ -524,6 +586,9 @@ trait FrameSource: Send {
         false
     }
 }
+
+struct NoopFrameSource;
+impl FrameSource for NoopFrameSource {}
 
 // ─── JPEG sources ──────────────────────────────────────────────────────
 
@@ -774,7 +839,10 @@ fn stream_h264_file_to_hid(
     fps: f32,
     stop: Arc<AtomicBool>,
 ) {
-    use std::io::{Seek, SeekFrom};
+    use lianli_devices::hydroshift_lcd::{find_au_split, pace_frame};
+    use std::io::{Read, Seek, SeekFrom};
+    use std::time::Instant;
+
     let mut file = match std::fs::File::open(&path) {
         Ok(f) => f,
         Err(e) => {
@@ -782,16 +850,53 @@ fn stream_h264_file_to_hid(
             return;
         }
     };
-    loop {
+    let frame_interval = {
+        let mut guard = lcd.lock();
+        Duration::from_secs_f32(1.0 / guard.set_stream_fps(fps))
+    };
+    let mut read_buf = vec![0u8; 64 * 1024];
+    let mut next_deadline = Instant::now() + frame_interval;
+    'outer: loop {
         if stop.load(Ordering::Relaxed) {
             break;
         }
-        let mut guard = lcd.lock();
-        if let Err(e) = guard.stream_h264_reader(&mut file, &stop, fps) {
-            warn!("HID h264 stream error: {e:#}");
-            break;
+        let mut accum: Vec<u8> = Vec::with_capacity(256 * 1024);
+        loop {
+            if stop.load(Ordering::Relaxed) {
+                break 'outer;
+            }
+            let n = match file.read(&mut read_buf) {
+                Ok(n) => n,
+                Err(e) => {
+                    warn!("HID h264 file read error: {e:#}");
+                    break 'outer;
+                }
+            };
+            if n == 0 {
+                break;
+            }
+            accum.extend_from_slice(&read_buf[..n]);
+            while let Some(split) = find_au_split(&accum) {
+                let au: Vec<u8> = accum.drain(..split).collect();
+                if au.is_empty() {
+                    continue;
+                }
+                let result = {
+                    let mut guard = lcd.lock();
+                    guard.send_h264_frame(&au)
+                };
+                if let Err(e) = result {
+                    warn!("HID h264 stream send error: {e:#}");
+                    break 'outer;
+                }
+                pace_frame(&mut next_deadline, frame_interval);
+            }
         }
-        drop(guard);
+        if !accum.is_empty() {
+            if let Err(e) = lcd.lock().send_h264_frame(&accum) {
+                debug!("HID h264 flush: {e:#}");
+            }
+        }
         if !looping || stop.load(Ordering::Relaxed) {
             break;
         }

--- a/crates/lianli-daemon/src/service/runtime.rs
+++ b/crates/lianli-daemon/src/service/runtime.rs
@@ -394,6 +394,44 @@ pub(crate) struct ActiveTarget {
     recovery_thread: Option<JoinHandle<()>>,
 }
 
+fn spawn_recovery_thread(
+    lcd: SharedHidLcd,
+    stop: Arc<AtomicBool>,
+    index: usize,
+    device_id: String,
+    tx: Option<Sender<DaemonEvent>>,
+) -> JoinHandle<()> {
+    thread::spawn(move || {
+        use lianli_devices::traits::RecoveryAction;
+        while !stop.load(Ordering::Relaxed) {
+            thread::sleep(Duration::from_secs(2));
+            if stop.load(Ordering::Relaxed) {
+                break;
+            }
+            let Some(mut guard) = lcd.try_lock_for(Duration::from_secs(2)) else {
+                continue;
+            };
+            match guard.check_and_recover_lcd() {
+                Ok(RecoveryAction::Recovered) => {
+                    if let Some(tx) = &tx {
+                        if !stop.load(Ordering::Relaxed) {
+                            tx.send(DaemonEvent::RecreateMedia {
+                                target_index: index,
+                                device_id: device_id.clone(),
+                            })
+                            .ok();
+                        }
+                    }
+                }
+                Ok(RecoveryAction::NoChange) => {}
+                Err(e) => {
+                    debug!("LCD[{index}] health check error: {e:#}");
+                }
+            }
+        }
+    })
+}
+
 impl ActiveTarget {
     pub(super) fn new(
         index: usize,
@@ -414,42 +452,16 @@ impl ActiveTarget {
                 let supports = d
                     .try_lock_for(Duration::from_millis(200))
                     .is_some_and(|guard| guard.supports_c_command());
-                if !supports {
-                    None
+                if supports {
+                    Some(spawn_recovery_thread(
+                        Arc::clone(d),
+                        Arc::clone(&recovery_stop),
+                        index,
+                        device_identity.clone(),
+                        tx.clone(),
+                    ))
                 } else {
-                    let lcd = Arc::clone(d);
-                    let stop = Arc::clone(&recovery_stop);
-                    let recovery_tx = tx.clone();
-                    let device_id = device_identity.clone();
-                    Some(thread::spawn(move || {
-                        use lianli_devices::traits::RecoveryAction;
-                        while !stop.load(Ordering::Relaxed) {
-                            thread::sleep(Duration::from_secs(2));
-                            if stop.load(Ordering::Relaxed) {
-                                break;
-                            }
-                            let Some(mut guard) = lcd.try_lock_for(Duration::from_secs(2)) else {
-                                continue;
-                            };
-                            match guard.check_and_recover_lcd() {
-                                Ok(RecoveryAction::Recovered) => {
-                                    if let Some(tx) = &recovery_tx {
-                                        if !stop.load(Ordering::Relaxed) {
-                                            tx.send(DaemonEvent::RecreateMedia {
-                                                target_index: index,
-                                                device_id: device_id.clone(),
-                                            })
-                                            .ok();
-                                        }
-                                    }
-                                }
-                                Ok(RecoveryAction::NoChange) => {}
-                                Err(e) => {
-                                    debug!("LCD[{index}] health check error: {e:#}");
-                                }
-                            }
-                        }
-                    }))
+                    None
                 }
             }
             _ => None,
@@ -468,6 +480,36 @@ impl ActiveTarget {
             recovery_stop,
             recovery_thread,
         }
+    }
+
+    /// Start the recovery thread if it is missing and the device now
+    /// reports c-command support. Called from `new` (firmware may already
+    /// be known) and after `LcdInitComplete` (firmware recorded by the
+    /// init worker after the target was created).
+    pub(super) fn maybe_start_recovery(&mut self, tx: Option<Sender<DaemonEvent>>) {
+        if self.recovery_thread.is_some() {
+            return;
+        }
+        let LcdBackend::HidLcd(d) = &self.lcd else {
+            return;
+        };
+        let supports = d
+            .try_lock_for(Duration::from_millis(200))
+            .is_some_and(|guard| guard.supports_c_command());
+        if !supports {
+            return;
+        }
+        info!(
+            "[devices] LCD[{}] starting recovery thread after init",
+            self.device_identity
+        );
+        self.recovery_thread = Some(spawn_recovery_thread(
+            Arc::clone(d),
+            Arc::clone(&self.recovery_stop),
+            self.index,
+            self.device_identity.clone(),
+            tx,
+        ));
     }
 
     pub(super) fn matches(&self, identity: &str, key: &ConfigKey) -> bool {

--- a/crates/lianli-daemon/src/service/runtime.rs
+++ b/crates/lianli-daemon/src/service/runtime.rs
@@ -99,6 +99,7 @@ fn spawn_hid_h264_stream(
             }
         }
         if clean_eof && !halted() && !accum.is_empty() {
+            pace_frame(&mut next_deadline, frame_interval);
             if let Err(e) = lcd.lock().send_h264_frame(&accum) {
                 debug!("HID h264 flush: {e:#}");
             }
@@ -168,11 +169,12 @@ impl LcdBackend {
         stdout: ChildStdout,
         stop: Arc<AtomicBool>,
         fps: f32,
-    ) -> anyhow::Result<Option<(JoinHandle<()>, Arc<AtomicBool>)>> {
+    ) -> anyhow::Result<Option<HidStreamWorker>> {
         match self {
             Self::HidLcd(lcd) => {
-                let spawned = spawn_hid_h264_stream(Arc::clone(lcd), Box::new(stdout), stop, fps);
-                Ok(Some(spawned))
+                let (handle, halt) =
+                    spawn_hid_h264_stream(Arc::clone(lcd), Box::new(stdout), stop, fps);
+                Ok(Some(HidStreamWorker { handle, halt }))
             }
             Self::WinUsb(sender) => {
                 sender.stream_h264_reader(stdout, fps)?;
@@ -182,18 +184,16 @@ impl LcdBackend {
         }
     }
 
-    /// Create a restart-capable handle that can be moved into a render thread
-    /// to start a new h264 stream after encoder failure. `initial_halt` is
-    /// the halt flag of the worker started by `start_h264_stream`, so the
-    /// first restart can stop it.
+    /// Restart-capable handle for render threads; takes the initial worker
+    /// so the first restart can stop it.
     pub(super) fn stream_restarter(
         &self,
-        initial_halt: Option<Arc<AtomicBool>>,
+        initial: Option<HidStreamWorker>,
     ) -> Option<StreamRestarter> {
         match self {
             Self::HidLcd(lcd) => Some(StreamRestarter::HidLcd(
                 Arc::clone(lcd),
-                Mutex::new(initial_halt),
+                Mutex::new(initial),
             )),
             Self::WinUsb(sender) => Some(StreamRestarter::WinUsb(
                 sender.tx.clone(),
@@ -204,37 +204,56 @@ impl LcdBackend {
     }
 }
 
+pub(super) struct HidStreamWorker {
+    handle: JoinHandle<()>,
+    halt: Arc<AtomicBool>,
+}
+
+impl HidStreamWorker {
+    /// The worker may be parked reading an encoder stdout that only EOFs
+    /// once the caller replaces the encoder, so join is bounded.
+    fn stop(&self, timeout: Duration) {
+        self.halt.store(true, Ordering::Relaxed);
+        let deadline = std::time::Instant::now() + timeout;
+        while !self.handle.is_finished() && std::time::Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(25));
+        }
+        if !self.handle.is_finished() {
+            debug!("h264 stream worker did not stop within {timeout:?}, detaching");
+        }
+    }
+}
+
 /// Cloneable handle for restarting an h264 stream from inside a render thread.
 pub(super) enum StreamRestarter {
-    HidLcd(SharedHidLcd, Mutex<Option<Arc<AtomicBool>>>),
+    HidLcd(SharedHidLcd, Mutex<Option<HidStreamWorker>>),
     WinUsb(std::sync::mpsc::SyncSender<LcdThreadMsg>, Arc<AtomicBool>),
 }
 
 impl StreamRestarter {
-    /// Start a new h264 stream reading from the given stdout. The old stream
-    /// (if any) is signalled to stop first.
+    /// Start a new h264 stream reading from the given stdout. The old
+    /// stream is halted and joined (bounded) first.
     pub(super) fn start_stream(
         &self,
         stdout: ChildStdout,
         stop: Arc<AtomicBool>,
         fps: f32,
-    ) -> anyhow::Result<Option<JoinHandle<()>>> {
+    ) -> anyhow::Result<()> {
         match self {
             Self::HidLcd(lcd, current) => {
                 let mut current = current.lock();
                 if let Some(old) = current.take() {
-                    old.store(true, Ordering::Relaxed);
+                    old.stop(Duration::from_secs(1));
                 }
                 let (handle, halt) =
                     spawn_hid_h264_stream(Arc::clone(lcd), Box::new(stdout), stop, fps);
-                *current = Some(halt);
-                Ok(Some(handle))
+                *current = Some(HidStreamWorker { handle, halt });
+                Ok(())
             }
             Self::WinUsb(tx, h264_stop) => {
                 h264_stop.store(true, Ordering::Relaxed);
                 tx.send(LcdThreadMsg::StreamH264Reader(stdout, fps))
-                    .map_err(|_| anyhow::anyhow!("LCD sender thread exited"))?;
-                Ok(None)
+                    .map_err(|_| anyhow::anyhow!("LCD sender thread exited"))
             }
         }
     }
@@ -957,6 +976,10 @@ fn stream_h264_file_to_hid(
     };
     let mut read_buf = vec![0u8; 64 * 1024];
     let mut next_deadline = Instant::now() + frame_interval;
+    // a single-AU file never yields a split boundary, its only frame rides
+    // the EOF flush, allow it exactly one looping pass
+    let mut first_pass = true;
+    let mut saw_boundary = false;
     'outer: loop {
         if stop.load(Ordering::Relaxed) {
             break;
@@ -1001,6 +1024,7 @@ fn stream_h264_file_to_hid(
                     warn!("HID h264 stream send error: {e:#}");
                     break 'outer;
                 }
+                saw_boundary = true;
                 sent_any = true;
                 pace_frame(&mut next_deadline, frame_interval);
             }
@@ -1017,11 +1041,13 @@ fn stream_h264_file_to_hid(
         if !looping || stop.load(Ordering::Relaxed) {
             break;
         }
-        // an empty or boundary-less file would otherwise loop forever
-        if !sent_any {
+        // only loop when real AU boundaries were found: a boundary-less
+        // file's flush would otherwise re-send identical data forever
+        if !sent_any || (first_pass && !saw_boundary) {
             warn!("HID h264 file produced no complete access units, stopping");
             break;
         }
+        first_pass = false;
         if let Err(e) = file.seek(SeekFrom::Start(0)) {
             warn!("HID h264 file seek failed: {e:#}");
             break;

--- a/crates/lianli-daemon/src/service/subsystems.rs
+++ b/crates/lianli-daemon/src/service/subsystems.rs
@@ -165,6 +165,8 @@ pub struct DeviceRegistry {
     pub usb_backends: HashMap<String, lianli_devices::registry::SharedUsb>,
     /// Hot-plug detection: device IDs seen at the last topology scan.
     pub last_wired_ids: HashSet<String>,
+    pub last_wired_topos: HashSet<String>,
+    pub last_reinit: Option<std::time::Instant>,
     pub failed_open_ids: HashSet<String>,
     pub init_retry_count: u32,
     /// Cached USB device list from `enumerate_devices()` — refreshed every
@@ -184,6 +186,8 @@ impl DeviceRegistry {
             hid_backends: HashMap::new(),
             usb_backends: HashMap::new(),
             last_wired_ids: HashSet::new(),
+            last_wired_topos: HashSet::new(),
+            last_reinit: None,
             failed_open_ids: HashSet::new(),
             init_retry_count: 0,
             cached_usb_devices: Vec::new(),

--- a/crates/lianli-daemon/src/service/sync.rs
+++ b/crates/lianli-daemon/src/service/sync.rs
@@ -189,8 +189,7 @@ impl ServiceManager {
 
     /// Update IPC telemetry and device list.
     pub(super) fn sync_ipc_telemetry(&self) {
-        let mut ipc_state = self.ipc.state.lock();
-        ipc_state.telemetry.streaming_active = !self.targets.lock().is_empty();
+        let streaming_active = !self.targets.lock().is_empty();
 
         // OpenRGB server status
         let (enabled, _) = self
@@ -199,16 +198,24 @@ impl ServiceManager {
             .and_then(|c| c.rgb.as_ref())
             .map(|rgb| (rgb.openrgb_server, rgb.openrgb_port))
             .unwrap_or((false, 6743));
-        let orgb_state = self.openrgb.state.lock();
-        ipc_state.telemetry.openrgb_status = lianli_shared::ipc::OpenRgbServerStatus {
-            enabled,
-            running: orgb_state.running,
-            port: orgb_state.port,
-            error: orgb_state.error.clone(),
+        let openrgb_status = {
+            let orgb_state = self.openrgb.state.lock();
+            lianli_shared::ipc::OpenRgbServerStatus {
+                enabled,
+                running: orgb_state.running,
+                port: orgb_state.port,
+                error: orgb_state.error.clone(),
+            }
         };
 
         // Build device list from wireless discovery
         let mut devices = Vec::new();
+
+        let mut fan_rpms: std::collections::HashMap<String, Vec<u16>> =
+            std::collections::HashMap::new();
+        let mut coolant_temps: std::collections::HashMap<String, f32> =
+            std::collections::HashMap::new();
+
         for dev in self.wireless.devices() {
             use lianli_devices::wireless::WirelessFanType;
             use lianli_shared::device_id::DeviceFamily;
@@ -283,13 +290,10 @@ impl ServiceManager {
             if is_aio {
                 rpms.push(dev.fan_rpms[3]); // pump RPM
             }
-            ipc_state.telemetry.fan_rpms.insert(device_id.clone(), rpms);
+            fan_rpms.insert(device_id.clone(), rpms);
 
             if let Some(temp) = dev.coolant_temp_c {
-                ipc_state
-                    .telemetry
-                    .coolant_temps
-                    .insert(device_id.clone(), temp as f32);
+                coolant_temps.insert(device_id.clone(), temp as f32);
                 lianli_shared::sensors::write_coolant_temp(&device_id, temp as f32);
             }
         }
@@ -378,10 +382,7 @@ impl ServiceManager {
             // mirroring the wireless path: publish via IPC and register as a
             // fan-curve sensor source.
             if let Some(temp) = dev.poll_coolant_temp() {
-                ipc_state
-                    .telemetry
-                    .coolant_temps
-                    .insert(base_id.clone(), temp);
+                coolant_temps.insert(base_id.clone(), temp);
                 lianli_shared::sensors::write_coolant_temp(base_id, temp);
             }
             if let Ok(all_rpms) = dev.read_fan_rpm() {
@@ -412,7 +413,7 @@ impl ServiceManager {
                     } else {
                         base_id.clone()
                     };
-                    ipc_state.telemetry.fan_rpms.insert(device_id, port_rpms);
+                    fan_rpms.insert(device_id, port_rpms);
                 }
             }
         }
@@ -437,7 +438,14 @@ impl ServiceManager {
                 .cloned(),
         );
 
-        ipc_state.devices = devices;
+        {
+            let mut ipc_state = self.ipc.state.lock();
+            ipc_state.telemetry.streaming_active = streaming_active;
+            ipc_state.telemetry.openrgb_status = openrgb_status;
+            ipc_state.telemetry.fan_rpms = fan_rpms;
+            ipc_state.telemetry.coolant_temps = coolant_temps;
+            ipc_state.devices = devices;
+        }
     }
 }
 

--- a/crates/lianli-devices/src/detect/backends.rs
+++ b/crates/lianli-devices/src/detect/backends.rs
@@ -135,7 +135,7 @@ fn open_hidraw_device(
     bus: u8,
     port_numbers: &[u8],
     usage_page: Option<u16>,
-) -> Result<hidapi::HidDevice> {
+) -> Result<(hidapi::HidDevice, Option<std::ffi::OsString>)> {
     let api = hidapi::HidApi::new().map_err(|e| anyhow::anyhow!("HidApi init: {e}"))?;
 
     let candidates: Vec<_> = api
@@ -155,8 +155,13 @@ fn open_hidraw_device(
             .device_list()
             .find(|info| info.vendor_id() == vid && info.product_id() == pid)
             .ok_or_else(|| anyhow::anyhow!("hidraw device {vid:04x}:{pid:04x} not found"))?;
+        let path: std::ffi::OsString = {
+            use std::os::unix::ffi::OsStrExt;
+            std::ffi::OsStr::from_bytes(info.path().to_bytes()).to_os_string()
+        };
         return info
             .open_device(&api)
+            .map(|d| (d, Some(path)))
             .map_err(|e| anyhow::anyhow!("hidraw open {vid:04x}:{pid:04x}: {e}"));
     }
 
@@ -167,8 +172,13 @@ fn open_hidraw_device(
                 .find(|info| info.path() == expected.as_c_str())
             {
                 debug!("Opening hidraw by topology match for {vid:04x}:{pid:04x}");
+                let path: std::ffi::OsString = {
+                    use std::os::unix::ffi::OsStrExt;
+                    std::ffi::OsStr::from_bytes(info.path().to_bytes()).to_os_string()
+                };
                 return info
                     .open_device(&api)
+                    .map(|d| (d, Some(path)))
                     .map_err(|e| anyhow::anyhow!("hidraw open by topology: {e}"));
             }
         }
@@ -178,8 +188,13 @@ fn open_hidraw_device(
         "Opening first hidraw candidate for {vid:04x}:{pid:04x} ({} match(es))",
         candidates.len()
     );
+    let path: std::ffi::OsString = {
+        use std::os::unix::ffi::OsStrExt;
+        std::ffi::OsStr::from_bytes(candidates[0].path().to_bytes()).to_os_string()
+    };
     candidates[0]
         .open_device(&api)
+        .map(|d| (d, Some(path)))
         .map_err(|e| anyhow::anyhow!("hidraw open: {e}"))
 }
 
@@ -194,8 +209,10 @@ pub fn open_shared_hid(
 ) -> Result<SharedHid> {
     match backend {
         HidBackend::Hidraw => {
-            let dev = open_hidraw_device(vid, pid, bus, port_numbers, usage_page)?;
-            Ok(Arc::new(Mutex::new(Box::new(HidrawTransport::new(dev)))))
+            let (dev, path) = open_hidraw_device(vid, pid, bus, port_numbers, usage_page)?;
+            Ok(Arc::new(Mutex::new(Box::new(HidrawTransport::new(
+                dev, path,
+            )))))
         }
         HidBackend::Rusb => {
             let pn = port_numbers.to_vec();
@@ -223,8 +240,8 @@ pub fn open_hid_transient(
 ) -> Result<Box<dyn HidTransport>> {
     match backend {
         HidBackend::Hidraw => {
-            let dev = open_hidraw_device(vid, pid, bus, port_numbers, usage_page)?;
-            Ok(Box::new(HidrawTransport::new(dev)))
+            let (dev, path) = open_hidraw_device(vid, pid, bus, port_numbers, usage_page)?;
+            Ok(Box::new(HidrawTransport::new(dev, path)))
         }
         HidBackend::Rusb => {
             let transport = RusbHid::open_by_usage(device.clone(), usage_page)?;

--- a/crates/lianli-devices/src/detect/enumerate.rs
+++ b/crates/lianli-devices/src/detect/enumerate.rs
@@ -13,7 +13,14 @@ pub fn enumerate_devices() -> Result<Vec<DetectedDevice>> {
     for device in usb_devices.iter() {
         let desc = match device.device_descriptor() {
             Ok(d) => d,
-            Err(_) => continue,
+            Err(e) => {
+                warn!(
+                    "USB device at bus {} addr {}: descriptor read failed ({e}), skipping",
+                    device.bus_number(),
+                    device.address()
+                );
+                continue;
+            }
         };
 
         let vid = desc.vendor_id();

--- a/crates/lianli-devices/src/hydroshift_lcd/controller.rs
+++ b/crates/lianli-devices/src/hydroshift_lcd/controller.rs
@@ -765,10 +765,6 @@ impl FanDevice for HydroShiftLcdController {
             .lock()
             .as_ref()
             .filter(|hs| {
-                // Vendor parity: L-Connect 3 reads TemperatureInteger while
-                // ignoring TemperatureIsValid entirely — some firmwares report
-                // a plausible coolant value with the flag clear. Trust the
-                // integer whenever it is populated.
                 hs.coolant_temp > 0.0
                     // Reject startup placeholder (1.0°C, 0 RPM fan + pump)
                     && !(hs.coolant_temp == 1.0 && hs.fan_rpm == 0 && hs.pump_rpm == 0)

--- a/crates/lianli-devices/src/hydroshift_lcd/controller.rs
+++ b/crates/lianli-devices/src/hydroshift_lcd/controller.rs
@@ -28,17 +28,10 @@ fn remap_fan_pwm_rgb(pwm: u8) -> u8 {
     (12 + scaled as u8).min(95)
 }
 
-/// Used by `stream_h264_reader` to split the pipe byte stream into complete
-/// access units (AUs).
-///
-/// Since Rust reads from a continuous pipe, we must detect AU boundaries
-/// ourselves.
-///
-/// Boundary policy: if AUD NALs (type 9) are present, they
-/// alone delimit AUs. Otherwise, primary coded picture NALs (types 1 and 5)
-/// are the boundary markers. This is determined lazily from the first
-/// boundary-eligible NAL encountered.
-pub(crate) fn find_au_split(data: &[u8]) -> Option<usize> {
+/// Split an H.264 byte stream into complete access units.
+/// AUD NALs (type 9) delimit AUs when present, otherwise slice NALs
+/// (types 1 and 5) do.
+pub fn find_au_split(data: &[u8]) -> Option<usize> {
     let mut split_on_aud: Option<bool> = None;
     let mut found_first = false;
     let mut i = 0;
@@ -77,7 +70,7 @@ pub(crate) fn find_au_split(data: &[u8]) -> Option<usize> {
     None
 }
 
-fn pace_frame(next_deadline: &mut Instant, interval: Duration) {
+pub fn pace_frame(next_deadline: &mut Instant, interval: Duration) {
     let now = Instant::now();
     if now < *next_deadline {
         thread::sleep(*next_deadline - now);
@@ -932,6 +925,18 @@ impl LcdDevice for Arc<HydroShiftLcdController> {
 
     fn try_read_firmware(&mut self) -> Result<()> {
         HydroShiftLcdController::try_read_firmware(self)
+    }
+
+    fn set_stream_fps(&mut self, fps: f32) -> f32 {
+        let fps = fps
+            .round()
+            .clamp(1.0, ScreenInfo::AIO_LCD_480.max_fps as f32);
+        self.video_fps.store(fps as u8, Ordering::Relaxed);
+        fps
+    }
+
+    fn send_h264_frame(&mut self, frame: &[u8]) -> Result<()> {
+        HydroShiftLcdController::send_h264_frame(self, frame)
     }
 
     fn stream_h264_reader(

--- a/crates/lianli-devices/src/hydroshift_lcd/mod.rs
+++ b/crates/lianli-devices/src/hydroshift_lcd/mod.rs
@@ -18,7 +18,7 @@ mod controller;
 mod protocol;
 mod rgb;
 
-pub use controller::HydroShiftLcdController;
+pub use controller::{find_au_split, pace_frame, HydroShiftLcdController};
 pub use rgb::AioLcdRgbController;
 
 /// AIO LCD device variant.

--- a/crates/lianli-devices/src/traits.rs
+++ b/crates/lianli-devices/src/traits.rs
@@ -213,6 +213,16 @@ pub trait LcdDevice: Send + Sync {
     fn try_read_firmware(&mut self) -> Result<()> {
         Ok(())
     }
+    /// fps hint for stream mode, returns the effective fps after the
+    /// device cap so callers pace at the same rate
+    fn set_stream_fps(&mut self, fps: f32) -> f32 {
+        fps.round().clamp(1.0, 30.0)
+    }
+    /// Send one H.264 access unit. Lock only for the call, never across a
+    /// whole stream.
+    fn send_h264_frame(&mut self, _frame: &[u8]) -> Result<()> {
+        anyhow::bail!("h264 streaming not supported by this device")
+    }
     fn stream_h264_reader(
         &mut self,
         _reader: &mut dyn std::io::Read,

--- a/crates/lianli-transport/Cargo.toml
+++ b/crates/lianli-transport/Cargo.toml
@@ -9,3 +9,4 @@ hidapi = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+libc = { workspace = true }

--- a/crates/lianli-transport/src/hidraw.rs
+++ b/crates/lianli-transport/src/hidraw.rs
@@ -3,7 +3,7 @@ use crate::hid_trait::HidTransport;
 use hidapi::HidDevice;
 use std::ffi::OsString;
 use std::os::unix::io::AsRawFd;
-use tracing::{debug, warn};
+use tracing::warn;
 
 const WRITE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
@@ -35,8 +35,8 @@ impl HidrawTransport {
                         }
                     }
                     Err(e) => {
-                        debug!(
-                            "hidraw: no parallel write fd for {:?}: {e}, using hidapi write",
+                        warn!(
+                            "hidraw: no parallel write fd for {:?} ({e}), writes fall back to hidapi blocking write",
                             p
                         );
                         None
@@ -75,46 +75,39 @@ fn write_fd_timed(
             if written == data.len() {
                 return Ok(written);
             }
-            continue;
-        }
-        let err = std::io::Error::last_os_error();
-        match err.raw_os_error() {
-            Some(libc::EAGAIN) => {
-                let Some(remain) = deadline.checked_duration_since(std::time::Instant::now())
-                else {
-                    return Err(TransportError::Write(format!(
-                        "hidraw write timed out after {written}/{} bytes",
-                        data.len()
-                    )));
-                };
-                let mut pfd = libc::pollfd {
-                    fd,
-                    events: libc::POLLOUT,
-                    revents: 0,
-                };
-                let r = unsafe {
-                    libc::poll(
-                        &mut pfd,
-                        1,
-                        remain.as_millis().clamp(1, i32::MAX as u128) as i32,
-                    )
-                };
-                if r < 0 {
-                    let e = std::io::Error::last_os_error();
-                    if e.raw_os_error() == Some(libc::EINTR) {
-                        continue;
-                    }
-                    return Err(TransportError::Write(e.to_string()));
-                }
-                if r == 0 {
-                    return Err(TransportError::Write(format!(
-                        "hidraw write timed out after {written}/{} bytes",
-                        data.len()
-                    )));
-                }
+        } else {
+            let err = std::io::Error::last_os_error();
+            match err.raw_os_error() {
+                Some(libc::EINTR) => continue,
+                Some(libc::EAGAIN) => {}
+                _ => return Err(TransportError::Write(err.to_string())),
             }
-            Some(libc::EINTR) => continue,
-            _ => return Err(TransportError::Write(err.to_string())),
+        }
+        // deadline checked every iteration, slow draining counts too
+        let Some(remain) = deadline.checked_duration_since(std::time::Instant::now()) else {
+            return Err(TransportError::Timeout);
+        };
+        let mut pfd = libc::pollfd {
+            fd,
+            events: libc::POLLOUT,
+            revents: 0,
+        };
+        let r = unsafe {
+            libc::poll(
+                &mut pfd,
+                1,
+                remain.as_millis().clamp(1, i32::MAX as u128) as i32,
+            )
+        };
+        if r < 0 {
+            let e = std::io::Error::last_os_error();
+            if e.raw_os_error() == Some(libc::EINTR) {
+                continue;
+            }
+            return Err(TransportError::Write(e.to_string()));
+        }
+        if r == 0 {
+            return Err(TransportError::Timeout);
         }
     }
 }
@@ -160,7 +153,7 @@ mod tests {
 
     #[test]
     fn write_fd_timed_writes_when_draining() {
-        let (mut tx, mut rx) = std::os::unix::net::UnixStream::pair().unwrap();
+        let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
         tx.set_nonblocking(true).unwrap();
         rx.set_nonblocking(true).unwrap();
 
@@ -168,6 +161,45 @@ mod tests {
         let n =
             write_fd_timed(tx.as_raw_fd(), &data, std::time::Duration::from_millis(500)).unwrap();
         assert_eq!(n, 32);
+    }
+
+    /// Slow drain (partial writes succeed but the buffer refills) must hit
+    /// the deadline and return Timeout, not exceed it.
+    #[test]
+    fn write_fd_timed_returns_timeout_on_slow_drain() {
+        let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
+        tx.set_nonblocking(true).unwrap();
+
+        let drainer = std::thread::spawn(move || {
+            let mut rx = rx;
+            use std::io::Read;
+            let mut buf = [0u8; 4096];
+            loop {
+                match rx.read(&mut buf) {
+                    // Ok(0) is EOF
+                    Ok(0) | Err(_) => break,
+                    Ok(_) => std::thread::sleep(std::time::Duration::from_millis(10)),
+                }
+            }
+        });
+
+        let data = vec![0xAAu8; 512 * 1024];
+        let start = std::time::Instant::now();
+        let result = write_fd_timed(tx.as_raw_fd(), &data, std::time::Duration::from_millis(150));
+        let elapsed = start.elapsed();
+
+        // drop tx so the drainer sees EOF instead of grinding the backlog
+        drop(tx);
+        let _ = drainer.join();
+
+        assert!(
+            matches!(result, Err(TransportError::Timeout)),
+            "got {result:?}"
+        );
+        assert!(
+            elapsed < std::time::Duration::from_millis(2_000),
+            "exceeded deadline: {elapsed:?}"
+        );
     }
 }
 

--- a/crates/lianli-transport/src/hidraw.rs
+++ b/crates/lianli-transport/src/hidraw.rs
@@ -1,22 +1,179 @@
 use crate::error::TransportError;
 use crate::hid_trait::HidTransport;
 use hidapi::HidDevice;
+use std::ffi::OsString;
+use std::os::unix::io::AsRawFd;
+use tracing::{debug, warn};
+
+const WRITE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 pub struct HidrawTransport {
     device: HidDevice,
+    /// hidapi write has no timeout, use a nonblocking fd for writes
+    write_fd: Option<std::fs::File>,
 }
 
 impl HidrawTransport {
-    pub fn new(device: HidDevice) -> Self {
-        Self { device }
+    pub fn new(device: HidDevice, path: Option<OsString>) -> Self {
+        let write_fd =
+            path.and_then(
+                |p| match std::fs::OpenOptions::new().write(true).read(false).open(&p) {
+                    Ok(f) => {
+                        let fd = f.as_raw_fd();
+                        let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+                        if flags >= 0
+                            && unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) }
+                                >= 0
+                        {
+                            Some(f)
+                        } else {
+                            warn!(
+                                "hidraw: failed to set O_NONBLOCK on {:?}, using hidapi write",
+                                p
+                            );
+                            None
+                        }
+                    }
+                    Err(e) => {
+                        debug!(
+                            "hidraw: no parallel write fd for {:?}: {e}, using hidapi write",
+                            p
+                        );
+                        None
+                    }
+                },
+            );
+        Self { device, write_fd }
+    }
+
+    fn write_timed(
+        &self,
+        data: &[u8],
+        timeout: std::time::Duration,
+    ) -> Result<usize, TransportError> {
+        match self.write_fd {
+            Some(ref f) => write_fd_timed(f.as_raw_fd(), data, timeout),
+            None => self
+                .device
+                .write(data)
+                .map_err(|e| TransportError::Write(e.to_string())),
+        }
+    }
+}
+
+fn write_fd_timed(
+    fd: std::os::unix::io::RawFd,
+    data: &[u8],
+    timeout: std::time::Duration,
+) -> Result<usize, TransportError> {
+    let deadline = std::time::Instant::now() + timeout;
+    let mut written = 0usize;
+    loop {
+        let n = unsafe { libc::write(fd, data[written..].as_ptr().cast(), data.len() - written) };
+        if n >= 0 {
+            written += n as usize;
+            if written == data.len() {
+                return Ok(written);
+            }
+            continue;
+        }
+        let err = std::io::Error::last_os_error();
+        match err.raw_os_error() {
+            Some(libc::EAGAIN) | Some(libc::EWOULDBLOCK) => {
+                let Some(remain) = deadline.checked_duration_since(std::time::Instant::now())
+                else {
+                    return Err(TransportError::Write(format!(
+                        "hidraw write timed out after {written}/{} bytes",
+                        data.len()
+                    )));
+                };
+                let mut pfd = libc::pollfd {
+                    fd,
+                    events: libc::POLLOUT,
+                    revents: 0,
+                };
+                let r = unsafe {
+                    libc::poll(
+                        &mut pfd,
+                        1,
+                        remain.as_millis().clamp(1, i32::MAX as u128) as i32,
+                    )
+                };
+                if r < 0 {
+                    let e = std::io::Error::last_os_error();
+                    if e.raw_os_error() == Some(libc::EINTR) {
+                        continue;
+                    }
+                    return Err(TransportError::Write(e.to_string()));
+                }
+                if r == 0 {
+                    return Err(TransportError::Write(format!(
+                        "hidraw write timed out after {written}/{} bytes",
+                        data.len()
+                    )));
+                }
+            }
+            Some(libc::EINTR) => continue,
+            _ => return Err(TransportError::Write(err.to_string())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::os::unix::io::AsRawFd;
+
+    #[test]
+    fn write_fd_timed_times_out_on_full_buffer() {
+        let (mut tx, _rx) = std::os::unix::net::UnixStream::pair().unwrap();
+        tx.set_nonblocking(true).unwrap();
+
+        let chunk = [0u8; 4096];
+        let mut filled = 0usize;
+        loop {
+            match tx.write(&chunk) {
+                Ok(n) => filled += n,
+                Err(_) => break,
+            }
+        }
+        assert!(filled > 0, "socket buffer never filled?");
+
+        let start = std::time::Instant::now();
+        let result = write_fd_timed(
+            tx.as_raw_fd(),
+            &[0xAA; 64],
+            std::time::Duration::from_millis(150),
+        );
+        let elapsed = start.elapsed();
+        assert!(result.is_err(), "expected timeout error");
+        assert!(
+            elapsed >= std::time::Duration::from_millis(120),
+            "returned too fast: {elapsed:?}"
+        );
+        assert!(
+            elapsed < std::time::Duration::from_millis(2_000),
+            "blocked far past deadline: {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn write_fd_timed_writes_when_draining() {
+        let (mut tx, mut rx) = std::os::unix::net::UnixStream::pair().unwrap();
+        tx.set_nonblocking(true).unwrap();
+        rx.set_nonblocking(true).unwrap();
+
+        let data = [0x55u8; 32];
+        let n =
+            write_fd_timed(tx.as_raw_fd(), &data, std::time::Duration::from_millis(500)).unwrap();
+        assert_eq!(n, 32);
     }
 }
 
 impl HidTransport for HidrawTransport {
     fn write(&mut self, data: &[u8]) -> Result<usize, TransportError> {
-        self.device
-            .write(data)
-            .map_err(|e| TransportError::Write(e.to_string()))
+        self.write_timed(data, WRITE_TIMEOUT)
     }
 
     fn read_timeout(&mut self, buf: &mut [u8], timeout_ms: i32) -> Result<usize, TransportError> {

--- a/crates/lianli-transport/src/hidraw.rs
+++ b/crates/lianli-transport/src/hidraw.rs
@@ -79,7 +79,7 @@ fn write_fd_timed(
         }
         let err = std::io::Error::last_os_error();
         match err.raw_os_error() {
-            Some(libc::EAGAIN) | Some(libc::EWOULDBLOCK) => {
+            Some(libc::EAGAIN) => {
                 let Some(remain) = deadline.checked_duration_since(std::time::Instant::now())
                 else {
                     return Err(TransportError::Write(format!(


### PR DESCRIPTION
Various improvements to reduce frequency of deadlock due to hanging devices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved H.264 video streaming to LCD devices with smoother frame pacing, configurable rates from 1–30 FPS, and more reliable recovery.
  * Added faster, more resilient device communication with write timeouts, retries, and graceful fallback handling.
* **Bug Fixes**
  * Hot-plugged wired devices now reinitialize more safely and avoid repeated resets.
  * Long-running operations and busy LCD firmware reads no longer block processing.
  * Malformed, incomplete, or oversized video streams are handled safely.
* **Diagnostics**
  * Device enumeration now reports USB descriptor read failures.
  * Telemetry updates use reduced locking for improved responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->