### PR TITLE
Fix wireless discovery rejecting valid SL v3/v4 device records

### DIFF
--- a/crates/lianli-devices/src/wireless/discovery.rs
+++ b/crates/lianli-devices/src/wireless/discovery.rs
@@ -133,9 +133,9 @@ pub(super) fn parse_device_record(data: &[u8], list_index: u8) -> Option<Discove
     let channel = data[12];
     let rx_type = data[13];
 
-    if mac == [0u8; 6] || channel == 0 || !(1..=14).contains(&rx_type) {
+    if mac == [0u8; 6] {
         debug!(
-            "  Device record {list_index}: invalid mac/ch/rx ({:02x?}, ch={channel}, rx={rx_type})",
+            "  Device record {list_index}: invalid mac ({:02x?}, ch={channel}, rx={rx_type})",
             mac
         );
         return None;
@@ -596,11 +596,17 @@ mod tests {
         buf[41] = 0x1C;
         assert!(parse_device_record(&buf, 0).is_none());
         buf[0..6].copy_from_slice(&[1, 2, 3, 4, 5, 6]);
-        assert!(parse_device_record(&buf, 0).is_none());
+        // channel==0 is a legitimate state (device not yet synced to a
+        // channel, e.g. still associated with a different master) -- not
+        // something we reject.
+        assert!(parse_device_record(&buf, 0).is_some());
         buf[12] = 8;
-        assert!(parse_device_record(&buf, 0).is_none());
-        buf[13] = 15;
-        assert!(parse_device_record(&buf, 0).is_none());
+        assert!(parse_device_record(&buf, 0).is_some());
+        // rx_type is a pass-through slot id, not something we validate the
+        // range of -- some hardware/firmware revisions (e.g. SL v3 dongles)
+        // report values well outside the old 1..=14 range.
+        buf[13] = 254;
+        assert!(parse_device_record(&buf, 0).is_some());
         buf[13] = 1;
         assert!(parse_device_record(&buf, 0).is_some());
     }

--- a/crates/lianli-devices/src/wireless/discovery.rs
+++ b/crates/lianli-devices/src/wireless/discovery.rs
@@ -591,21 +591,15 @@ mod tests {
     }
 
     #[test]
-    fn parse_rejects_degraded_records() {
+    fn parse_rejects_only_zero_mac() {
         let mut buf = [0u8; 42];
         buf[41] = 0x1C;
         assert!(parse_device_record(&buf, 0).is_none());
         buf[0..6].copy_from_slice(&[1, 2, 3, 4, 5, 6]);
-        // channel==0 is a legitimate state (device not yet synced to a
-        // channel, e.g. still associated with a different master) -- not
-        // something we reject.
         assert!(parse_device_record(&buf, 0).is_some());
         buf[12] = 8;
         assert!(parse_device_record(&buf, 0).is_some());
-        // rx_type is a pass-through slot id, not something we validate the
-        // range of -- some hardware/firmware revisions (e.g. SL v3 dongles)
-        // report values well outside the old 1..=14 range.
-        buf[13] = 254;
+        buf[13] = 15;
         assert!(parse_device_record(&buf, 0).is_some());
         buf[13] = 1;
         assert!(parse_device_record(&buf, 0).is_some());


### PR DESCRIPTION
## Summary

Fixes #156. `parse_device_record` rejected any wireless device record where `channel == 0` or `rx_type` fell outside `1..=14` — a check added in 30a53b7 to filter garbage/degraded RF reads. Both conditions turn out to be legitimate states on SL v3/v4 hardware:

- `channel == 0` is what a fan reports while it's still associated with a *different* master (e.g. a previously-used dongle) before it resyncs to the current one.
- `rx_type = 254` is simply how this hardware generation reports its slot — not corruption.

Because `parse_device_record` returns `None` for these, affected records never reached `discovered_devices` at all — not as bound, not as unbound. They were invisible to the daemon, the GUI, and `bind_tool` alike, with no way to bind/rebind them since they never appeared in any device list.

Reproduced on real SL v3/v4 wireless hardware (`0416:8040`/`0416:8041`, Winbond SLV3RX/TX V1.6) where 2 of 4 fans were permanently undiscoverable. Confirmed via an isolated `bind_tool` scan (daemon stopped, no other software in the loop) that the fans were never even reaching the unbound list, and confirmed against two different physical RX dongles to rule out a dongle-specific pairing issue before finding the actual cause in the validation logic.

## Fix

Dropped the `channel == 0` and `rx_type` range checks, keeping only `mac == [0u8; 6]` plus the existing marker-byte (`data[41] == 0x1C`) check — sufficient to filter genuinely empty/corrupt frames without rejecting valid-but-unsynced records.

## Compatibility / robustness

- No config schema changes — this is purely inside RF response parsing, so no existing `config.json` is affected.
- Purely additive at the parsing layer: any record that passed the old checks still passes; only previously-rejected records (`channel==0` or `rx_type` outside `1..=14`) are newly accepted. Users whose hardware already reports values in range see no behavior change.
- The original check existed to filter corrupted/degraded RF reads on a flaky link, so this does relax validation at the parsing layer. That said, the debounce logic from the same commit (`commit_streak`, requiring 3 consistent sightings before a record's `master_mac`/`channel`/`rx_type` is actually published) is untouched and still guards against a single noisy read causing a spurious device or false master-flip — a one-off garbage frame won't survive to affect published state, only a consistently-repeated value would (which is what real hardware produces, not random noise). Flagging this tradeoff explicitly in case there's a stronger validity signal (e.g. the marker byte or record length) worth adding instead of/in addition to removing the range checks outright.

## Test plan

- [x] `cargo test -p lianli-devices --lib wireless::discovery` — all 8 tests pass, including updated `parse_rejects_degraded_records` covering `channel=0` and `rx_type=254`
- [x] Verified against real hardware: previously-invisible fans now discovered and auto-bound within ~5s of daemon startup
- [x] Verified via live telemetry (`GetTelemetry` IPC) that all 4 fan banks (9 fans total) report healthy RPM after the fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wireless device discovery to accept valid records using channel 0 or previously restricted receive types.
  * Continued rejecting records with an invalid zero MAC address.
  * Added coverage to verify these device records are handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
