### PR TITLE
fix: answer OpenRGB profile/plugin list requests so SDK clients don't hang

### DIFF
--- a/crates/lianli-daemon/src/openrgb_server.rs
+++ b/crates/lianli-daemon/src/openrgb_server.rs
@@ -26,6 +26,8 @@ const PKT_REQUEST_CONTROLLER_COUNT: u32 = 0;
 const PKT_REQUEST_CONTROLLER_DATA: u32 = 1;
 const PKT_REQUEST_PROTOCOL_VERSION: u32 = 40;
 const PKT_SET_CLIENT_NAME: u32 = 50;
+const PKT_REQUEST_PROFILE_LIST: u32 = 150;
+const PKT_REQUEST_PLUGIN_LIST: u32 = 200;
 const PKT_RESIZE_ZONE: u32 = 1000;
 const PKT_UPDATE_LEDS: u32 = 1050;
 const PKT_UPDATE_ZONE_LEDS: u32 = 1051;
@@ -341,6 +343,17 @@ impl ClientHandler {
                     .unwrap_or(0);
                 let resp: Vec<u8> = [zone_idx.to_le_bytes(), actual_size.to_le_bytes()].concat();
                 self.send_packet(dev_idx, PKT_RESIZE_ZONE, &resp)?;
+            }
+
+            // We have no profiles or plugins, but clients block waiting for
+            // these replies (openrgb-python hangs during its handshake if
+            // they never arrive), so answer with empty lists:
+            // u32 data_size + u16 entry_count.
+            PKT_REQUEST_PROFILE_LIST | PKT_REQUEST_PLUGIN_LIST => {
+                let mut resp = Vec::with_capacity(6);
+                resp.extend_from_slice(&6u32.to_le_bytes());
+                resp.extend_from_slice(&0u16.to_le_bytes());
+                self.send_packet(0, pkt_id, &resp)?;
             }
 
             _ => {


### PR DESCRIPTION
The SDK server advertises protocol version 4 but silently drops `NET_PACKET_ID_PROFILEMANAGER_GET_PROFILE_LIST` (150) and `NET_PACKET_ID_PLUGINMANAGER_GET_PLUGIN_LIST` (200). Protocol-following clients block waiting for these replies during their initial handshake — openrgb-python raises `TimeoutError` in `update_profiles()` and never gets a device list — so the server is unusable for SDK scripts even though the OpenRGB GUI happens to tolerate the missing replies.

This replies to both requests with well-formed empty lists (`u32 data_size` + `u16 count`, matching `ProfileManager::GetProfileListDescription()`'s wire format), since the daemon has no profiles or plugins to offer.

**Verified**: with openrgb-python 0.3.x, `OpenRGBClient(host, 6743)` previously timed out during the handshake; with this patch it connects and enumerates all six of my controllers (HydroShift II ring + wireless LCD-S, four UNI FAN TL wireless groups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenRGB compatibility by responding to profile-list and plugin-list requests during connection handshakes.
  * Prevented supported clients from waiting indefinitely when requesting these lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->