### PR TITLE
fix: PKGBUILD cargo fetch used literal "host-tuple" as target

### DIFF
--- a/packaging/archlinux/PKGBUILD
+++ b/packaging/archlinux/PKGBUILD
@@ -24,7 +24,7 @@ prepare() {
   cd lian-li-linux
   git submodule update --init --recursive --depth=1
   export RUSTUP_TOOLCHAIN=stable
-  cargo fetch --locked --target host-tuple
+  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
 }
 
 build() {


### PR DESCRIPTION
In `packaging/archlinux/PKGBUILD`, `prepare()` runs:

```
cargo fetch --locked --target host-tuple
```

`host-tuple` is passed as a literal string, which is not a valid target triple, so the offline-fetch step fails. This substitutes the actual host triple per the [Arch Rust package guidelines](https://wiki.archlinux.org/title/Rust_package_guidelines):

```
cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
```

Verified by building the package locally with `makepkg` on x86_64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Arch Linux package preparation by automatically detecting the installed Rust compiler’s target platform.
  * Prevented builds from relying on an unresolved placeholder target value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->