### PR TITLE
fix: HydroShift II LCD bulk write timeout cancels URBs mid-packet on NAK stalls; log stalls

### DIFF
--- a/crates/lianli-devices/src/winusb/lcd/core.rs
+++ b/crates/lianli-devices/src/winusb/lcd/core.rs
@@ -12,6 +12,8 @@ use tracing::{debug, info, warn};
 pub type SharedTransport = Arc<Mutex<RusbBulk>>;
 
 const REOPEN_DELAY: Duration = Duration::from_millis(100);
+/// Chunk writes slower than this are logged: the panel NAKed bulk OUT.
+const SLOW_CHUNK_WRITE: Duration = Duration::from_millis(100);
 const WAIT_BUFFER_POLL: Duration = Duration::from_millis(50);
 const WAIT_BUFFER_NO_STOP_CAP: u32 = 600;
 
@@ -492,7 +494,20 @@ impl WinUsbLcdCore {
         packet[..512].copy_from_slice(&header);
         packet[512..512 + data.len()].copy_from_slice(data);
 
-        match self.tx_write_full(&packet) {
+        let write_started = Instant::now();
+        let write_result = self.tx_write_full(&packet);
+        let write_took = write_started.elapsed();
+        if write_took > SLOW_CHUNK_WRITE {
+            // Device NAK stall: the panel is back-pressuring. Visible at WARN
+            // so field logs show stalls that the write timeout absorbed.
+            warn!(
+                "H264 chunk write stalled {} ms ({} bytes, result {:?})",
+                write_took.as_millis(),
+                packet.len(),
+                write_result.as_ref().map(|_| ()).map_err(|e| e.to_string())
+            );
+        }
+        match write_result {
             Ok(_) => self.note_write_success(),
             Err(e) => {
                 warn!("H264 chunk write failed: {e}");

--- a/crates/lianli-devices/src/winusb/lcd/core.rs
+++ b/crates/lianli-devices/src/winusb/lcd/core.rs
@@ -125,6 +125,32 @@ impl WinUsbLcdCore {
         self.transport.lock().write_full(data, self.write_timeout)
     }
 
+    /// `tx_write_full`, timing only the USB write itself. The lock is taken
+    /// first so a busy `SharedTransport` is not misreported as panel NAK
+    /// backpressure.
+    #[inline]
+    fn tx_write_full_timed(
+        &self,
+        data: &[u8],
+        what: &str,
+    ) -> std::result::Result<(), lianli_transport::TransportError> {
+        let tx = self.transport.lock();
+        let started = Instant::now();
+        let result = tx.write_full(data, self.write_timeout);
+        let took = started.elapsed();
+        if took > SLOW_CHUNK_WRITE {
+            // Device NAK stall: the panel is back-pressuring. Visible at WARN
+            // so field logs show stalls that the write timeout absorbed.
+            warn!(
+                "{what} stalled {} ms ({} bytes, result {:?})",
+                took.as_millis(),
+                data.len(),
+                result.as_ref().map(|_| ()).map_err(|e| e.to_string())
+            );
+        }
+        result
+    }
+
     #[inline]
     fn tx_read(
         &self,
@@ -494,26 +520,13 @@ impl WinUsbLcdCore {
         packet[..512].copy_from_slice(&header);
         packet[512..512 + data.len()].copy_from_slice(data);
 
-        let write_started = Instant::now();
-        let write_result = self.tx_write_full(&packet);
-        let write_took = write_started.elapsed();
-        if write_took > SLOW_CHUNK_WRITE {
-            // Device NAK stall: the panel is back-pressuring. Visible at WARN
-            // so field logs show stalls that the write timeout absorbed.
-            warn!(
-                "H264 chunk write stalled {} ms ({} bytes, result {:?})",
-                write_took.as_millis(),
-                packet.len(),
-                write_result.as_ref().map(|_| ()).map_err(|e| e.to_string())
-            );
-        }
-        match write_result {
+        match self.tx_write_full_timed(&packet, "H264 chunk write") {
             Ok(_) => self.note_write_success(),
             Err(e) => {
                 warn!("H264 chunk write failed: {e}");
                 self.try_recover()
                     .with_context(|| format!("recovering from h264 write error: {e}"))?;
-                self.tx_write_full(&packet)
+                self.tx_write_full_timed(&packet, "H264 chunk write retry")
                     .context("h264 chunk write after recovery")?;
                 self.note_write_success();
             }

--- a/crates/lianli-devices/src/winusb/lcd/h2_lcd.rs
+++ b/crates/lianli-devices/src/winusb/lcd/h2_lcd.rs
@@ -50,8 +50,9 @@ impl H2WinUsbLcd {
 // buffer (usbmon shows 200 ms+ stalls mid-keyframe). A short timeout makes
 // libusb cancel the URB mid-packet; rusb then reports the partial length and
 // `write_full` resumes from it, which desyncs the firmware and wedges the MCU
-// until power-cycled. WinUSB's default pipe timeout is unbounded; wait.
-const WRITE_TIMEOUT: Duration = Duration::from_millis(5_000);
+// until power-cycled. This was the last LCD driver still on the pre-split
+// 200 ms constant; 2 s matches base.rs, slv3.rs and hs2_oled.rs.
+const WRITE_TIMEOUT: Duration = Duration::from_millis(2_000);
 const READ_TIMEOUT: Duration = Duration::from_millis(2_000);
 
 impl WinUsbLcd for H2WinUsbLcd {

--- a/crates/lianli-devices/src/winusb/lcd/h2_lcd.rs
+++ b/crates/lianli-devices/src/winusb/lcd/h2_lcd.rs
@@ -46,7 +46,12 @@ impl H2WinUsbLcd {
     }
 }
 
-const WRITE_TIMEOUT: Duration = Duration::from_millis(200);
+// Bulk OUT writes block on device NAK while the panel drains its h264
+// buffer (usbmon shows 200 ms+ stalls mid-keyframe). A short timeout makes
+// libusb cancel the URB mid-packet; rusb then reports the partial length and
+// `write_full` resumes from it, which desyncs the firmware and wedges the MCU
+// until power-cycled. WinUSB's default pipe timeout is unbounded; wait.
+const WRITE_TIMEOUT: Duration = Duration::from_millis(5_000);
 const READ_TIMEOUT: Duration = Duration::from_millis(2_000);
 
 impl WinUsbLcd for H2WinUsbLcd {


### PR DESCRIPTION
## Summary

Two small changes to the HydroShift II wired LCD (`h2_lcd.rs` / `lcd/core.rs`), complementary to #152:

1. **Raise the h2 LCD bulk write timeout from 200 ms to 2 s.** `h2_lcd.rs` was the only LCD driver still on the pre-split shared 200 ms constant — `slv3.rs`, `hs2_oled.rs` and `base.rs` all use 2 s. A 200 ms timeout matters here because the panel legitimately NAKs bulk OUT for >200 ms while it drains its h264 buffer; when that happens libusb cancels the URB mid-transfer, `rusb` returns the partial count as `Ok(n)` on `LIBUSB_ERROR_TIMEOUT`, and `write_full` resumes from that offset — which desyncs the firmware. The stalls measured on the wire were 196–231 ms, so 2 s leaves ~8x headroom without inventing a new value for this driver.
2. **Log a WARN when an h264 chunk write stalls >100 ms** (`H264 chunk write stalled N ms (bytes, result)`), so field logs show when the panel is back-pressuring instead of only showing the eventual failure. Timing starts after the `SharedTransport` lock is acquired, so transport contention isn't misreported as panel backpressure, and the post-recovery retry is measured the same way.

## Evidence (usbmon on bus 1 + daemon debug log, HydroShift II LCD Square 1cbe:a034, fw 1.7)

Before: during a stream the panel NAKed for >200 ms on a 6 KB chunk (survived — cancelled at 2048/6116 bytes and resumed) and then on a 58 KB keyframe (`C Bo:1:003:1 -2 20480` of 58829, remainder never accepted); the MCU then stopped answering bulk and EP0 and needed a power cycle/reboot to re-enumerate (`Device not responding to setup address`, `-71`).

After (this branch): stalls of 231 / 196 / 218 ms were absorbed with the full packet delivered and the stream continued — visible as the new WARN lines.

## What this does *not* claim

This does not fix the underlying wedge on its own. In our traces every stall starts ~0.3 s after a `SyncPumpFan` write from the AIO fan controller on the shared transport (2x/s in the default config); with concurrent streaming the panel's frame buffer fills and a keyframe on a full buffer kills the firmware in 6–8 s. That is the failure #152 measured at 26 s without streaming, and #152's `SyncPumpFan` rate limit is what stops it — running `main` + #152 + this branch the panel streams cleanly (0 stalls, 0 cancels, `SyncPumpFan` twice at startup then silent). The usbmon details are on #152. This PR just removes the mid-URB-cancel hazard and makes stalls observable; it stands on its own and applies cleanly on top of #152.

## One thing worth knowing while testing

`RusbBulk::write_full` (`lianli-transport/src/usb.rs`) applies the timeout **per URB, not per call** — it loops until the whole buffer is accepted and each `write_bulk` gets the full timeout. So against a panel accepting partial chunks, the worst-case block for a single `write_full` is a multiple of the constant rather than the constant itself, and the `shutting_down()` guard is only checked on entry, not per iteration. That behaviour is pre-existing and not touched here, but raising 200 ms → 2 s does widen the window, which is why I'd rather not go higher than the value the other drivers already use. Happy to look at putting a real deadline across the whole `write_full` as a separate change if you want it — it's shared transport code that every device goes through, so it didn't belong in this PR.

## With #152, this is defense in depth

Worth knowing before you spend hardware time on it: once control writes are kept off the shared pipe during streaming, **this timeout is never reached at all**.

I have the WARN from point 2 running on my daily driver, on a build carrying #152 + #154 plus a local change of my own that also holds control writes during play mode (that one is not filed as a PR; the bug behind it is #163). Over the last 7 days of effectively continuous H.264 streaming — 38,573 chunk-response lines in the journal — there were **zero** stall warnings, i.e. not one chunk write exceeded 100 ms. The only LCD-core warnings in that window were two `Read after GetVer failed` and two `H264 chunk write failed: System call interrupted`, the latter being #152's shutdown guard firing on daemon stop.

So in the fixed configuration the write timeout is inert: 200 ms, 2 s and 5 s are indistinguishable, because nothing ever gets close to any of them. It only matters in the failure regime #152 removes — a stalling panel, where the old 200 ms caused a mid-URB cancel and a resumed partial write. That is the case this PR is for, and it is why I would rather it be a boring 2 s consistent with the other drivers than a novel value.

## Test plan

- `cargo check -p lianli-devices`, `cargo clippy -p lianli-devices` (no new warnings)
- HydroShift II LCD Square, custom template live h264 480x480@30: 15+ min streams on `main`+this, and `main`+#152+this, with usbmon on the bus confirming no `-2` bulk-OUT completions.
- Those runs were made with the timeout at 5 s, before I dropped it to 2 s. I have deliberately **not** re-run them at 2 s, because the soak cannot actually distinguish the two values: in any configuration that includes #152 there are no stalls to absorb (see above), and the only configuration that does produce them is bare `main` + this PR, which wedges the panel and needs a power cycle. The measurement that matters is the stall durations themselves — 196 / 218 / 231 ms across the captures, against a 2 s budget.
