### PR TITLE
fix: bound ffmpeg/ffprobe runs so a hung helper can't wedge the daemon

### DIFF
--- a/crates/lianli-media/src/common.rs
+++ b/crates/lianli-media/src/common.rs
@@ -12,6 +12,8 @@ pub enum MediaError {
     Image(#[from] image::ImageError),
     #[error("ffmpeg failed: {0}")]
     Ffmpeg(String),
+    #[error("{0}")]
+    HelperTimedOut(String),
     #[error("generated frame ({size} bytes) exceeds LCD payload limit")]
     PayloadTooLarge { size: usize },
     #[error("video or animation produced no frames")]

--- a/crates/lianli-media/src/video/ffmpeg.rs
+++ b/crates/lianli-media/src/video/ffmpeg.rs
@@ -1,3 +1,4 @@
+use super::process::{output_with_timeout, ENCODE_TIMEOUT, PROBE_TIMEOUT};
 use crate::common::MediaError;
 use std::path::Path;
 use std::process::Command;
@@ -5,20 +6,25 @@ use std::process::Command;
 /// Probe the source's average frame rate via ffprobe. Returns `None` if the
 /// file isn't a video/animated source or ffprobe is unavailable.
 pub fn probe_source_fps(path: &Path) -> Option<f32> {
-    let output = Command::new("ffprobe")
-        .args([
-            "-v",
-            "error",
-            "-select_streams",
-            "v:0",
-            "-show_entries",
-            "stream=avg_frame_rate",
-            "-of",
-            "default=noprint_wrappers=1:nokey=1",
-        ])
-        .arg(path)
-        .output()
-        .ok()?;
+    let mut cmd = Command::new("ffprobe");
+    cmd.args([
+        "-v",
+        "error",
+        "-select_streams",
+        "v:0",
+        "-show_entries",
+        "stream=avg_frame_rate",
+        "-of",
+        "default=noprint_wrappers=1:nokey=1",
+    ])
+    .arg(path);
+    let output = match output_with_timeout(cmd, PROBE_TIMEOUT) {
+        Ok(output) => output,
+        Err(err) => {
+            tracing::warn!("probing source fps failed: {err}");
+            return None;
+        }
+    };
     if !output.status.success() {
         return None;
     }
@@ -71,10 +77,9 @@ pub(super) fn run_ffmpeg(
         "4".into(),
         output_pattern.to_str().unwrap().into(),
     ]);
-    let output = Command::new("ffmpeg")
-        .args(&args)
-        .output()
-        .map_err(MediaError::Io)?;
+    let mut cmd = Command::new("ffmpeg");
+    cmd.args(&args);
+    let output = output_with_timeout(cmd, ENCODE_TIMEOUT)?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -109,10 +114,9 @@ pub(super) fn run_ffmpeg_rgba(
         "rgba".into(),
         output_pattern.to_str().unwrap().into(),
     ]);
-    let output = Command::new("ffmpeg")
-        .args(&args)
-        .output()
-        .map_err(MediaError::Io)?;
+    let mut cmd = Command::new("ffmpeg");
+    cmd.args(&args);
+    let output = output_with_timeout(cmd, ENCODE_TIMEOUT)?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);

--- a/crates/lianli-media/src/video/h264.rs
+++ b/crates/lianli-media/src/video/h264.rs
@@ -54,10 +54,15 @@ pub fn encode_h264(
                 );
                 return Ok((output, temp, out_fps as f32));
             }
-            Err(stderr) => {
+            // Only a failed ffmpeg exit is encoder-specific; keep walking
+            // the chain. A helper that cannot start or blows its deadline
+            // fails the same way for every encoder, so retrying would
+            // multiply the stall by the chain length - propagate immediately.
+            Err(MediaError::Ffmpeg(stderr)) => {
                 debug!("LCD H.264 encoder {} unavailable: {stderr}", kind.name());
                 last_stderr = Some(stderr);
             }
+            Err(err) => return Err(err),
         }
     }
 
@@ -278,7 +283,7 @@ fn run_encode(
     kind: EncoderKind,
     output: &Path,
     loop_image: bool,
-) -> Result<(), String> {
+) -> Result<(), MediaError> {
     let mut args: Vec<String> = vec!["-y".into(), "-loglevel".into(), "error".into()];
     args.extend(hwaccel_input_args(kind));
     if loop_image {
@@ -297,11 +302,11 @@ fn run_encode(
 
     let mut cmd = Command::new("ffmpeg");
     cmd.args(&args);
-    let output_result = output_with_timeout(cmd, ENCODE_TIMEOUT).map_err(|err| err.to_string())?;
+    let output_result = output_with_timeout(cmd, ENCODE_TIMEOUT)?;
     if output_result.status.success() {
         Ok(())
     } else {
         let stderr = String::from_utf8_lossy(&output_result.stderr);
-        Err(stderr.trim().to_string())
+        Err(MediaError::Ffmpeg(stderr.trim().to_string()))
     }
 }

--- a/crates/lianli-media/src/video/h264.rs
+++ b/crates/lianli-media/src/video/h264.rs
@@ -1,3 +1,4 @@
+use super::process::{output_with_timeout, ENCODE_TIMEOUT};
 use super::target_dimensions;
 use crate::common::{render_dimensions, MediaError};
 use lianli_shared::screen::ScreenInfo;
@@ -294,10 +295,9 @@ fn run_encode(
         output.to_string_lossy().into_owned(),
     ]);
 
-    let output_result = Command::new("ffmpeg")
-        .args(&args)
-        .output()
-        .map_err(|e| format!("spawn ffmpeg: {e}"))?;
+    let mut cmd = Command::new("ffmpeg");
+    cmd.args(&args);
+    let output_result = output_with_timeout(cmd, ENCODE_TIMEOUT).map_err(|err| err.to_string())?;
     if output_result.status.success() {
         Ok(())
     } else {

--- a/crates/lianli-media/src/video/mod.rs
+++ b/crates/lianli-media/src/video/mod.rs
@@ -2,6 +2,7 @@ pub mod ffmpeg;
 pub mod h264;
 pub mod h264_inprocess;
 pub mod h264_live;
+mod process;
 
 pub use ffmpeg::{cap_fps_to_source, probe_source_fps};
 pub use h264::encode_h264;

--- a/crates/lianli-media/src/video/process.rs
+++ b/crates/lianli-media/src/video/process.rs
@@ -1,0 +1,194 @@
+//! Bounded execution for the external ffmpeg/ffprobe helpers.
+//!
+//! Media preparation runs on the daemon's main event loop, so a helper process
+//! that never exits does not just fail one encode: it wedges the daemon for
+//! good. Nothing after it in the loop runs again - no config reloads, so RGB
+//! and fan changes are persisted but never applied, and no device polling, so
+//! wireless devices that drop their binding are never re-bound.
+//!
+//! `std::process::Command::output()` waits without a deadline, so every helper
+//! invocation goes through [`output_with_timeout`] instead.
+
+use std::io::Read;
+use std::process::{Command, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// Deadline for a one-shot transcode (a still image or short clip to H.264).
+/// Generous: large sources on a slow CPU are legitimately slow.
+pub(crate) const ENCODE_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Deadline for a metadata probe, which reads headers and should return
+/// almost immediately.
+pub(crate) const PROBE_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// How often to check whether the child has exited.
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Run `cmd` to completion, killing it if it outlives `timeout`.
+///
+/// Both pipes are drained on their own threads: a child that fills a pipe
+/// buffer would otherwise block before it could ever reach the deadline.
+///
+/// On timeout the child is killed and reaped, so it cannot linger as an
+/// orphan holding the pipes (or the GPU) open.
+pub(crate) fn output_with_timeout(mut cmd: Command, timeout: Duration) -> Result<Output, TimedOut> {
+    let program = cmd.get_program().to_string_lossy().into_owned();
+
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = cmd.spawn().map_err(|source| TimedOut::Spawn {
+        program: program.clone(),
+        source,
+    })?;
+
+    let mut child_stdout = child.stdout.take().expect("stdout was piped");
+    let mut child_stderr = child.stderr.take().expect("stderr was piped");
+    let stdout_reader = thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = child_stdout.read_to_end(&mut buf);
+        buf
+    });
+    let stderr_reader = thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = child_stderr.read_to_end(&mut buf);
+        buf
+    });
+
+    let deadline = Instant::now() + timeout;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    // SIGKILL: the whole point is that the child is wedged and
+                    // may not be servicing signals it could catch.
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    // The pipes close as the child dies, so the readers finish.
+                    let _ = stdout_reader.join();
+                    let _ = stderr_reader.join();
+                    return Err(TimedOut::Deadline { program, timeout });
+                }
+                thread::sleep(POLL_INTERVAL);
+            }
+            Err(source) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(TimedOut::Spawn { program, source });
+            }
+        }
+    };
+
+    Ok(Output {
+        status,
+        stdout: stdout_reader.join().unwrap_or_default(),
+        stderr: stderr_reader.join().unwrap_or_default(),
+    })
+}
+
+impl From<TimedOut> for crate::common::MediaError {
+    fn from(err: TimedOut) -> Self {
+        match err {
+            // A helper that could not be started is an ordinary I/O failure,
+            // as it was before this call became bounded.
+            TimedOut::Spawn { source, .. } => Self::Io(source),
+            deadline => Self::HelperTimedOut(deadline.to_string()),
+        }
+    }
+}
+
+/// Why a bounded run did not produce an exit status.
+#[derive(Debug)]
+pub(crate) enum TimedOut {
+    /// The process could not be started, or could not be waited on.
+    Spawn {
+        program: String,
+        source: std::io::Error,
+    },
+    /// The process outlived its deadline and was killed.
+    Deadline { program: String, timeout: Duration },
+}
+
+impl std::fmt::Display for TimedOut {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Spawn { program, source } => write!(f, "could not run {program}: {source}"),
+            Self::Deadline { program, timeout } => write!(
+                f,
+                "{program} did not exit within {}s and was killed",
+                timeout.as_secs()
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A child that exits normally still yields its output.
+    #[test]
+    fn returns_output_of_a_command_that_exits() {
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "printf out; printf err >&2; exit 3"]);
+
+        let out = output_with_timeout(cmd, Duration::from_secs(30)).expect("should not time out");
+
+        assert_eq!(out.status.code(), Some(3));
+        assert_eq!(out.stdout, b"out");
+        assert_eq!(out.stderr, b"err");
+    }
+
+    /// The regression this module exists for: a child that never exits must not
+    /// block the caller forever.
+    #[test]
+    fn kills_a_child_that_never_exits() {
+        let mut cmd = Command::new("sleep");
+        cmd.arg("600");
+
+        let started = Instant::now();
+        let err = output_with_timeout(cmd, Duration::from_millis(300))
+            .expect_err("a child that outlives the deadline must be reported");
+
+        assert!(
+            matches!(err, TimedOut::Deadline { .. }),
+            "expected a deadline error, got {err:?}"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(20),
+            "returned after {:?}; it should return at the deadline, not wait for the child",
+            started.elapsed()
+        );
+    }
+
+    /// A child that outlives the deadline while holding its pipes open (the
+    /// shape of the hung ffmpeg) is still cut off at the deadline.
+    #[test]
+    fn kills_a_child_that_holds_its_pipes_open() {
+        let mut cmd = Command::new("sh");
+        // Writes, then hangs without closing stdout - so waiting for EOF on the
+        // pipes, as `Command::output()` does, would never return.
+        cmd.args(["-c", "printf partial; sleep 600"]);
+
+        let started = Instant::now();
+        let err = output_with_timeout(cmd, Duration::from_millis(300))
+            .expect_err("a child holding its pipes open must still be cut off");
+
+        assert!(matches!(err, TimedOut::Deadline { .. }), "got {err:?}");
+        assert!(started.elapsed() < Duration::from_secs(20));
+    }
+
+    /// A missing binary is reported rather than treated as a timeout.
+    #[test]
+    fn reports_a_command_that_cannot_be_spawned() {
+        let cmd = Command::new("lianli-no-such-binary-should-exist");
+
+        let err = output_with_timeout(cmd, Duration::from_secs(30))
+            .expect_err("spawning a missing binary must fail");
+
+        assert!(matches!(err, TimedOut::Spawn { .. }), "got {err:?}");
+    }
+}


### PR DESCRIPTION
Fixes #174.

## Problem

Every `ffmpeg` / `ffprobe` invocation in `lianli-media` uses `Command::output()`, which waits for the child with **no deadline**. These calls run on the daemon's main event loop (`IpcUpdate` -> `load_config` -> `prepare_media_assets` -> `encode_h264` -> `run_encode`), so a helper that never exits doesn't just fail one encode — it kills the daemon's event loop for the rest of the process's life, while the daemon still looks healthy.

Observed on v0.8.8: a large still image (5120x1440 PNG) made `ffmpeg` hang before writing a byte, and the daemon sat in `poll()` inside `output()` for **6.9 hours** across three further config changes, none of which were ever applied. Full evidence in #174.

The failure is nasty because it's silent:

- `SetConfig` keeps succeeding and logging `config persisted, notified daemon`, so RGB/fan changes look saved but never reach the hardware.
- `device_poll()` stops, so the device list goes stale and wireless devices that lose their binding are never re-bound.
- RSS grew to **11.3 GB** (healthy: ~34 MB).

## Change

Adds `video::process::output_with_timeout`, and routes all four helper call sites through it — `run_encode`, `run_ffmpeg`, `run_ffmpeg_rgba` and `probe_source_fps`.

It:

- drains stdout and stderr on their own threads, so a child that fills a pipe buffer can't block before the deadline is even reached (this is the case `Command::output()` handles but a naive `wait()`-with-timeout would not);
- SIGKILLs **and reaps** the child if it overruns, so nothing is left orphaned holding the pipes open;
- keeps a spawn failure as an ordinary `MediaError::Io`, exactly as before, so only a genuine deadline produces the new `HelperTimedOut` variant.

Budgets are deliberately generous — 120s for an encode (large sources on slow CPUs are legitimately slow), 20s for a header probe.

I went with a deadline rather than tweaking the ffmpeg arguments on purpose: the hang is intermittent and reproduces with `-t 1` as an output option and with `-frames:v` too, so it looks like an ffmpeg-side problem. Either way the daemon shouldn't be able to die permanently because a helper misbehaved.

## Tests

Four unit tests in the new module cover: normal exit still returns stdout/stderr/status; a child that never exits is cut off at the deadline; a child that **writes and then hangs holding its pipes open** (the shape of the real hang) is also cut off; and a missing binary is reported as a spawn error rather than a timeout. They run in 0.3s.

I confirmed the pre-fix behaviour genuinely hangs, so the tests aren't vacuous — `Command::output()` against that same child was still blocked after 3s with no sign of returning.

End-to-end, against the exact image that caused the original wedge, `encode_h264` now returns after 120.04s with

```
Err(ffmpeg failed: all H.264 encoders failed; last error: ffmpeg did not exit within 120s and was killed)
```

instead of hanging forever, and leaves no orphan `ffmpeg` behind.

`cargo test --workspace` passes (175 tests). `cargo clippy` reports nothing on any touched file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added time limits for video encoding and media inspection operations.
  * Prevented external media tools from hanging indefinitely, including when output streams remain open.
  * Improved error reporting when media helper processes fail to start or exceed their time limits.
  * Added warnings when source frame-rate inspection cannot be completed.
  * Improved encoder fallback behavior by avoiding retries for timeout and system-level failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->