### PR TITLE
fix: re-bind configured wireless devices that were already unbound at startup

### DIFF
--- a/crates/lianli-daemon/src/service/mod.rs
+++ b/crates/lianli-daemon/src/service/mod.rs
@@ -247,7 +247,21 @@ impl ServiceManager {
         }
         let configured = self.configured_wireless_device_ids();
         let now = Instant::now();
-        let Some(mac) = self.wireless.rebind_candidates().into_iter().find(|m| {
+
+        // Devices that drifted to a foreign master after we bound them.
+        let mut candidates = self.wireless.rebind_candidates();
+        // Devices that were *already* bound elsewhere when the daemon started.
+        // Those never gained `bind_intent`, so they never show up in
+        // `rebind_candidates()`, and the one-shot rebind in `try_wireless()`
+        // runs before discovery has enumerated them. Without this they stay
+        // dark until the user re-binds by hand.
+        for mac in self.wireless.unbound_devices().into_iter().map(|d| d.mac) {
+            if !candidates.contains(&mac) {
+                candidates.push(mac);
+            }
+        }
+
+        let Some(mac) = candidates.into_iter().find(|m| {
             let id = format!(
                 "wireless:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
                 m[0], m[1], m[2], m[3], m[4], m[5]


### PR DESCRIPTION
Found while investigating #174, but an independent bug — it needs no wedged daemon to reproduce.

## Problem

A configured wireless device that is bound to a **foreign dongle when the daemon starts** is never recovered automatically. Its fans and RGB stay unresponsive until the user re-binds it by hand, even though the device is discovered fine and shows up in `ListDevices` as `wireless-unbound:<mac>`.

Two paths look like they should catch this, and neither does:

**1. `auto_rebind_configured_wireless()` runs too early.** It's called once from `try_wireless()`, before discovery has enumerated anything, so `unbound_devices()` is still empty and it rebinds nothing. From a local start:

```
2.012473s  INFO wireless::controller: Wireless discovery stable, proceeding with device list
2.019205s  INFO service::init: Wireless links active            <- auto_rebind ran here, saw nothing
2.519502s  INFO wireless::discovery: Discovered 5 wireless device(s) (3 bound, 2 unbound)
2.519517s  INFO wireless::discovery:   <mac-a> (UNI FAN SL-INF Wireless) not bound to this dongle
2.519520s  INFO wireless::discovery:   <mac-b> (UNI FAN SL-INF Wireless) not bound to this dongle
```

500 ms too early — the two devices it was supposed to rebind appear right after it has finished.

**2. `run_wireless_rebind_supervisor()` can't see them.** It runs every `device_poll()`, but only over `rebind_candidates()`, which filters on `h.bind_intent`. Outside `#[cfg(test)]`, `bind_intent` is only ever set by `bind_device()` (`wireless/bind.rs:14`) — every other write site initialises it to `false`. So it's true only for devices *this process* has already bound, and a device that was foreign from the start never qualifies.

Net effect: both devices were in the config's `rgb.devices`, both were discovered every poll, and neither was ever retried. On my machine they sat unbound until I bound them by hand over IPC.

## Change

Have the supervisor also consider configured devices currently reported by `unbound_devices()`, in addition to `rebind_candidates()`.

Deliberately minimal — both sources feed the existing machinery unchanged:

- the same `configured_wireless_device_ids()` filter, so unconfigured devices are still left alone;
- the same 30s per-MAC rate limit via `wireless_rebind_last`;
- the same `wireless_rebind_in_flight` guard and background thread, so `bind_device()` still never blocks the event loop.

I left the one-shot `try_wireless()` call in place; it's harmless, and this makes it no longer load-bearing.

## Testing

`cargo test --workspace` passes.

Behaviour was verified by hand on the affected hardware: binding those two MACs over IPC took discovery from `(3 bound, 2 unbound)` to `(5 bound, 0 unbound)`, they re-appeared as `wireless:<mac>` in `ListDevices`, and an RGB change then reached all of them — which is exactly the recovery this change automates.

I couldn't find an existing harness for the supervisor (it reaches through `ServiceManager` into live `WirelessController` state), so this doesn't add a unit test. Happy to add one if you'd like the seam introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wireless device recovery by automatically rebinding devices that were already associated with another master when the daemon started.
  * Devices missed during the initial binding attempt can now be included in subsequent automatic rebind attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->