### PR TITLE
Fix EVDI AB24 framebuffer channel order

### DIFF
--- a/crates/lianli-daemon/src/desktop_display/worker.rs
+++ b/crates/lianli-daemon/src/desktop_display/worker.rs
@@ -68,7 +68,7 @@ fn run_worker(pid: u16, stop: Arc<AtomicBool>) -> Result<()> {
         width: preferred.width as u32,
         height: preferred.height as u32,
         refresh_hz: preferred.refresh_hz as u32,
-        pixel_format: fourcc(b"XR24"),
+        pixel_format: DRM_FORMAT_XRGB8888,
     };
     let mut buffer: Option<EvdiBuffer> = Some(EvdiBuffer::new(
         1,
@@ -332,11 +332,35 @@ const fn fourcc(code: &[u8; 4]) -> u32 {
 const DRM_FORMAT_ABGR8888: u32 = fourcc(b"AB24");
 /// DRM_FORMAT_XBGR8888, memory layout R then G then B then X.
 const DRM_FORMAT_XBGR8888: u32 = fourcc(b"XB24");
+/// DRM_FORMAT_XRGB8888, memory layout B then G then R then X.
+const DRM_FORMAT_XRGB8888: u32 = fourcc(b"XR24");
+/// DRM_FORMAT_ARGB8888, memory layout B then G then R then A.
+const DRM_FORMAT_ARGB8888: u32 = fourcc(b"AR24");
 
 impl ResolvedMode {
     fn from_evdi(m: lianli_evdi::Mode) -> Result<Self> {
         if m.width <= 0 || m.height <= 0 {
             bail!("evdi mode has non-positive dimensions ({:?})", m);
+        }
+        // Every consumer of the framebuffer assumes four bytes per pixel in
+        // one of the two channel orders. A compositor that negotiates
+        // anything else would hand the encoders a buffer they cannot read
+        // correctly, so refuse the mode instead of producing shifted colors
+        // or reading past a smaller buffer.
+        if m.bits_per_pixel != 32
+            || !matches!(
+                m.pixel_format,
+                DRM_FORMAT_XRGB8888
+                    | DRM_FORMAT_ARGB8888
+                    | DRM_FORMAT_ABGR8888
+                    | DRM_FORMAT_XBGR8888
+            )
+        {
+            bail!(
+                "evdi mode has unsupported format {:#x} at {} bpp",
+                m.pixel_format,
+                m.bits_per_pixel
+            );
         }
         let refresh = m.refresh_hz.max(30) as u32;
         Ok(Self {

--- a/crates/lianli-daemon/src/desktop_display/worker.rs
+++ b/crates/lianli-daemon/src/desktop_display/worker.rs
@@ -61,11 +61,14 @@ fn run_worker(pid: u16, stop: Arc<AtomicBool>) -> Result<()> {
     let sku_area_limit = (caps.max_w as u32).saturating_mul(caps.max_h as u32).max(1);
 
     // Pre-register a buffer at the device's preferred mode BEFORE evdi_connect.
+    // No fourcc is known before the first ModeChanged event, and nothing is
+    // encoded until one arrives, so carry the historical XR24 assumption.
     let preferred = turzx::pick_mode(&caps).context("device advertises no modes")?;
     let preferred_resolved = ResolvedMode {
         width: preferred.width as u32,
         height: preferred.height as u32,
         refresh_hz: preferred.refresh_hz as u32,
+        pixel_format: fourcc(b"XR24"),
     };
     let mut buffer: Option<EvdiBuffer> = Some(EvdiBuffer::new(
         1,
@@ -112,13 +115,16 @@ fn run_worker(pid: u16, stop: Arc<AtomicBool>) -> Result<()> {
         for ev in events {
             match ev {
                 EvdiEvent::ModeChanged(mode) => {
+                    let rgb_first =
+                        matches!(mode.pixel_format, DRM_FORMAT_ABGR8888 | DRM_FORMAT_XBGR8888);
                     info!(
-                        "TURZX {pid:04x} evdi mode: {}×{} @ {}Hz (bpp {}, fmt {:#x})",
+                        "TURZX {pid:04x} evdi mode: {}×{} @ {}Hz (bpp {}, fmt {:#x}, {} first)",
                         mode.width,
                         mode.height,
                         mode.refresh_hz,
                         mode.bits_per_pixel,
-                        mode.pixel_format
+                        mode.pixel_format,
+                        if rgb_first { "red" } else { "blue" }
                     );
                     let resolved =
                         ResolvedMode::from_evdi(mode).context("negotiated mode unsupported")?;
@@ -132,8 +138,13 @@ fn run_worker(pid: u16, stop: Arc<AtomicBool>) -> Result<()> {
                     buffer = Some(new_buf);
                     if !use_jpeg {
                         encoder = Some(
-                            H264Encoder::new(resolved.width, resolved.height, resolved.refresh_hz)
-                                .context("building H264Encoder")?,
+                            H264Encoder::new(
+                                resolved.width,
+                                resolved.height,
+                                resolved.refresh_hz,
+                                resolved.rgb_byte_order(),
+                            )
+                            .context("building H264Encoder")?,
                         );
                     }
                     display
@@ -206,7 +217,11 @@ fn run_worker(pid: u16, stop: Arc<AtomicBool>) -> Result<()> {
                     width: m.width as usize,
                     height: m.height as usize,
                     pitch: m.width as usize * 4,
-                    format: turbojpeg::PixelFormat::RGBX,
+                    format: if m.rgb_byte_order() {
+                        turbojpeg::PixelFormat::RGBX
+                    } else {
+                        turbojpeg::PixelFormat::BGRX
+                    },
                 };
                 match turbojpeg::compress(tj_image, 90, turbojpeg::Subsamp::Sub2x2) {
                     Ok(jpeg) => {
@@ -303,7 +318,20 @@ struct ResolvedMode {
     width: u32,
     height: u32,
     refresh_hz: u32,
+    /// DRM fourcc of the negotiated framebuffer layout.
+    pixel_format: u32,
 }
+
+/// Packs a DRM fourcc code the way the kernel does, first character in the
+/// lowest byte.
+const fn fourcc(code: &[u8; 4]) -> u32 {
+    (code[0] as u32) | ((code[1] as u32) << 8) | ((code[2] as u32) << 16) | ((code[3] as u32) << 24)
+}
+
+/// DRM_FORMAT_ABGR8888, memory layout R then G then B then A.
+const DRM_FORMAT_ABGR8888: u32 = fourcc(b"AB24");
+/// DRM_FORMAT_XBGR8888, memory layout R then G then B then X.
+const DRM_FORMAT_XBGR8888: u32 = fourcc(b"XB24");
 
 impl ResolvedMode {
     fn from_evdi(m: lianli_evdi::Mode) -> Result<Self> {
@@ -315,6 +343,15 @@ impl ResolvedMode {
             width: m.width as u32,
             height: m.height as u32,
             refresh_hz: refresh,
+            pixel_format: m.pixel_format,
         })
+    }
+
+    /// True when the negotiated layout stores red in the first byte of each
+    /// pixel. AB24 and XB24 do, XR24 and AR24 store blue first. The encoders
+    /// read the buffer raw, so they must be told which interpretation to
+    /// use rather than assuming one.
+    fn rgb_byte_order(&self) -> bool {
+        matches!(self.pixel_format, DRM_FORMAT_ABGR8888 | DRM_FORMAT_XBGR8888)
     }
 }

--- a/crates/lianli-daemon/src/desktop_display/worker.rs
+++ b/crates/lianli-daemon/src/desktop_display/worker.rs
@@ -206,7 +206,7 @@ fn run_worker(pid: u16, stop: Arc<AtomicBool>) -> Result<()> {
                     width: m.width as usize,
                     height: m.height as usize,
                     pitch: m.width as usize * 4,
-                    format: turbojpeg::PixelFormat::BGRX,
+                    format: turbojpeg::PixelFormat::RGBX,
                 };
                 match turbojpeg::compress(tj_image, 90, turbojpeg::Subsamp::Sub2x2) {
                     Ok(jpeg) => {

--- a/crates/lianli-media/src/video/h264_inprocess.rs
+++ b/crates/lianli-media/src/video/h264_inprocess.rs
@@ -42,7 +42,7 @@ impl H264Encoder {
                 Ok(encoder) => {
                     info!("H.264 encoder: {name}");
                     let scaler = ffmpeg::software::scaling::Context::get(
-                        ffmpeg::util::format::Pixel::BGRA,
+                        ffmpeg::util::format::Pixel::RGBA,
                         width,
                         height,
                         ffmpeg::util::format::Pixel::YUV420P,
@@ -52,7 +52,7 @@ impl H264Encoder {
                     )
                     .context("building sws scaler BGRA->YUV420P")?;
                     let frame_in =
-                        ffmpeg::frame::Video::new(ffmpeg::util::format::Pixel::BGRA, width, height);
+                        ffmpeg::frame::Video::new(ffmpeg::util::format::Pixel::RGBA, width, height);
                     let frame_out = ffmpeg::frame::Video::new(
                         ffmpeg::util::format::Pixel::YUV420P,
                         width,

--- a/crates/lianli-media/src/video/h264_inprocess.rs
+++ b/crates/lianli-media/src/video/h264_inprocess.rs
@@ -16,8 +16,9 @@ pub fn ensure_ffmpeg_initialized() {
     });
 }
 
-/// libavcodec H.264 encoder specialised for BGRA framebuffers arriving from
-/// evdi. Kept persistent across frames. Returns complete NAL packets
+/// libavcodec H.264 encoder specialised for 32 bit framebuffers arriving
+/// from evdi, in either channel order the negotiated DRM fourcc dictates.
+/// Kept persistent across frames. Returns complete NAL packets
 /// synchronously, unlike the CLI-based [`super::LiveH264Encoder`] which
 /// pipelines via subprocess stdio.
 pub struct H264Encoder {
@@ -32,9 +33,17 @@ pub struct H264Encoder {
 }
 
 impl H264Encoder {
-    pub fn new(width: u32, height: u32, fps: u32) -> Result<Self> {
+    /// `rgb_byte_order` selects the input interpretation: true means the
+    /// framebuffer stores red in the first byte of each pixel, as AB24 and
+    /// XB24 do, false means blue first, as XR24 and AR24 do.
+    pub fn new(width: u32, height: u32, fps: u32, rgb_byte_order: bool) -> Result<Self> {
         ensure_ffmpeg_initialized();
 
+        let src_pixel = if rgb_byte_order {
+            ffmpeg::util::format::Pixel::RGBA
+        } else {
+            ffmpeg::util::format::Pixel::BGRA
+        };
         let gop = (fps / 2).max(1);
         let mut last_err: Option<anyhow::Error> = None;
         for name in ["h264_nvenc", "h264_amf", "libx264"] {
@@ -42,7 +51,7 @@ impl H264Encoder {
                 Ok(encoder) => {
                     info!("H.264 encoder: {name}");
                     let scaler = ffmpeg::software::scaling::Context::get(
-                        ffmpeg::util::format::Pixel::RGBA,
+                        src_pixel,
                         width,
                         height,
                         ffmpeg::util::format::Pixel::YUV420P,
@@ -50,9 +59,8 @@ impl H264Encoder {
                         height,
                         ffmpeg::software::scaling::Flags::BILINEAR,
                     )
-                    .context("building sws scaler BGRA->YUV420P")?;
-                    let frame_in =
-                        ffmpeg::frame::Video::new(ffmpeg::util::format::Pixel::RGBA, width, height);
+                    .with_context(|| format!("building sws scaler {src_pixel:?} -> YUV420P"))?;
+                    let frame_in = ffmpeg::frame::Video::new(src_pixel, width, height);
                     let frame_out = ffmpeg::frame::Video::new(
                         ffmpeg::util::format::Pixel::YUV420P,
                         width,
@@ -78,11 +86,11 @@ impl H264Encoder {
         Err(last_err.unwrap_or_else(|| anyhow!("no H.264 encoder available")))
     }
 
-    pub fn encode(&mut self, bgra: &[u8]) -> Result<Vec<u8>> {
-        self.copy_pixels_in(bgra)?;
+    pub fn encode(&mut self, frame: &[u8]) -> Result<Vec<u8>> {
+        self.copy_pixels_in(frame)?;
         self.scaler
             .run(&self.frame_in, &mut self.frame_out)
-            .context("sws scale BGRA->YUV420P")?;
+            .context("sws scale to YUV420P")?;
         self.frame_out
             .set_pts(Some(self.start.elapsed().as_micros() as i64));
         self.encoder
@@ -98,22 +106,22 @@ impl H264Encoder {
         Ok(out)
     }
 
-    fn copy_pixels_in(&mut self, bgra: &[u8]) -> Result<()> {
+    fn copy_pixels_in(&mut self, frame: &[u8]) -> Result<()> {
         let expected = (self.width as usize) * 4 * (self.height as usize);
-        if bgra.len() < expected {
-            bail!("BGRA buffer too small: {} < {}", bgra.len(), expected);
+        if frame.len() < expected {
+            bail!("frame buffer too small: {} < {}", frame.len(), expected);
         }
         let stride = self.frame_in.stride(0);
         let row_bytes = (self.width as usize) * 4;
         if stride == row_bytes {
-            self.frame_in.data_mut(0)[..expected].copy_from_slice(&bgra[..expected]);
+            self.frame_in.data_mut(0)[..expected].copy_from_slice(&frame[..expected]);
         } else {
             let dst = self.frame_in.data_mut(0);
             for y in 0..self.height as usize {
                 let src_off = y * row_bytes;
                 let dst_off = y * stride;
                 dst[dst_off..dst_off + row_bytes]
-                    .copy_from_slice(&bgra[src_off..src_off + row_bytes]);
+                    .copy_from_slice(&frame[src_off..src_off + row_bytes]);
             }
         }
         Ok(())


### PR DESCRIPTION
## Summary

Fixes the red/blue channel swap seen on the Lian Li Universal Screen 8.8" when EVDI negotiates an `AB24` / `DRM_FORMAT_ABGR8888` framebuffer.

On this display, Desktop Mode negotiated:

```text
1920x480 @ 60 Hz
fmt 0x34324241
```

`0x34324241` decodes to `AB24`. The framebuffer was being interpreted as BGR(A/X), causing colors such as muted gold to render cyan/blue.

## Changes

- Change the TurboJPEG input format from `BGRX` to `RGBX`.
- Change the in-process FFmpeg H.264 input format from `BGRA` to `RGBA`.

## Testing

Tested on:

- Lian Li Universal Screen 8.8"
- TURZX `1a86:ad21`
- EVDI 1.15.0
- COSMIC / Wayland
- 1920x480 @ 60 Hz

The issue was reproduced in both H.264 and forced JPEG mode. After changing the framebuffer interpretation, colors rendered correctly in both paths.

This is the minimal working fix validated on the hardware.

As discussed in the issue, a more general follow-up could preserve `mode.pixel_format` and select RGB/BGR interpretation based on the negotiated DRM FOURCC.

Fixes #177

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved color handling for JPEG-compressed desktop display frames across supported pixel formats.
  * Corrected H.264 video encoding to accurately process different channel orders and preserve colors.
  * Desktop display mode changes now correctly adapt video and image encoding to the negotiated pixel format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->