### PR TITLE
fix(hydroshift): re-apply LCD settings on transport reopen and make stream recovery resilient (fixes #166)

### DIFF
--- a/crates/lianli-daemon/src/service/runtime.rs
+++ b/crates/lianli-daemon/src/service/runtime.rs
@@ -84,12 +84,29 @@ fn spawn_hid_h264_stream(
                 if au.is_empty() {
                     continue;
                 }
-                let result = {
-                    let mut guard = lcd.lock();
-                    guard.send_h264_frame(&au)
-                };
-                if let Err(e) = result {
-                    warn!("HID h264 stream send error: {e:#}");
+                let mut send_err = None;
+                for attempt in 1..=3 {
+                    if halted() {
+                        return;
+                    }
+                    let result = {
+                        let mut guard = lcd.lock();
+                        guard.send_h264_frame(&au)
+                    };
+                    match result {
+                        Ok(()) => {
+                            send_err = None;
+                            break;
+                        }
+                        Err(e) => {
+                            debug!("HID h264 stream send error (attempt {attempt}/3): {e:#}");
+                            send_err = Some(e);
+                            thread::sleep(Duration::from_millis(150));
+                        }
+                    }
+                }
+                if let Some(e) = send_err {
+                    warn!("HID h264 stream send failed after retries: {e:#}");
                     return;
                 }
                 pace_frame(&mut next_deadline, frame_interval);
@@ -949,7 +966,20 @@ impl H264FileSource {
 impl FrameSource for H264FileSource {
     fn start(&mut self, lcd: &LcdBackend) -> anyhow::Result<()> {
         if self.started {
-            return Ok(());
+            if let Some(ref t) = self.hid_thread {
+                if t.is_finished() {
+                    warn!("HID h264 stream thread ended; resetting for restart");
+                    if let Some(t) = self.hid_thread.take() {
+                        let _ = t.join();
+                    }
+                    self.hid_stop = Arc::new(AtomicBool::new(false));
+                    self.started = false;
+                } else {
+                    return Ok(());
+                }
+            } else {
+                return Ok(());
+            }
         }
         if let Some(t) = self.retry_after {
             if std::time::Instant::now() < t {
@@ -1171,12 +1201,29 @@ fn stream_h264_file_to_hid(
                 if au.is_empty() {
                     continue;
                 }
-                let result = {
-                    let mut guard = lcd.lock();
-                    guard.send_h264_frame(&au)
-                };
-                if let Err(e) = result {
-                    warn!("HID h264 stream send error: {e:#}");
+                let mut send_err = None;
+                for attempt in 1..=3 {
+                    if stop.load(Ordering::Relaxed) {
+                        break 'outer;
+                    }
+                    let result = {
+                        let mut guard = lcd.lock();
+                        guard.send_h264_frame(&au)
+                    };
+                    match result {
+                        Ok(()) => {
+                            send_err = None;
+                            break;
+                        }
+                        Err(e) => {
+                            debug!("HID h264 stream send error (attempt {attempt}/3): {e:#}");
+                            send_err = Some(e);
+                            thread::sleep(Duration::from_millis(150));
+                        }
+                    }
+                }
+                if let Some(e) = send_err {
+                    warn!("HID h264 stream send failed after retries: {e:#}");
                     break 'outer;
                 }
                 saw_boundary = true;

--- a/crates/lianli-daemon/src/service/runtime.rs
+++ b/crates/lianli-daemon/src/service/runtime.rs
@@ -1020,8 +1020,7 @@ impl FrameSource for H264FileSource {
                 let done = Arc::clone(&completed);
                 self.hid_completed = Some(completed);
                 self.hid_thread = Some(thread::spawn(move || {
-                    stream_h264_file_to_hid(lcd, file, looping, fps, Arc::clone(&stop));
-                    if !stop.load(Ordering::Relaxed) {
+                    if stream_h264_file_to_hid(lcd, file, looping, fps, stop) {
                         done.store(true, Ordering::Release);
                     }
                 }));
@@ -1162,13 +1161,14 @@ fn make_frame_source(
     }
 }
 
+/// True when the file finished on its own and the worker must not restart
 fn stream_h264_file_to_hid(
     lcd: SharedHidLcd,
     mut file: std::fs::File,
     looping: bool,
     fps: f32,
     stop: Arc<AtomicBool>,
-) {
+) -> bool {
     use lianli_devices::hydroshift_lcd::{find_au_split, pace_frame};
     use std::io::{Read, Seek, SeekFrom};
     use std::time::Instant;
@@ -1184,21 +1184,21 @@ fn stream_h264_file_to_hid(
     // the EOF flush, allow it exactly one looping pass
     let mut first_pass = true;
     let mut saw_boundary = false;
-    'outer: loop {
+    loop {
         if stopped() {
-            break;
+            return false;
         }
         let mut accum: Vec<u8> = Vec::with_capacity(256 * 1024);
         let mut sent_any = false;
         loop {
             if stopped() {
-                break 'outer;
+                return false;
             }
             let n = match file.read(&mut read_buf) {
                 Ok(n) => n,
                 Err(e) => {
                     warn!("HID h264 file read error: {e:#}");
-                    break 'outer;
+                    return false;
                 }
             };
             if n == 0 {
@@ -1210,25 +1210,25 @@ fn stream_h264_file_to_hid(
                     "HID h264 file: no AU boundary within {} bytes, aborting",
                     MAX_AU_BYTES
                 );
-                break 'outer;
+                return false;
             }
             while let Some(split) = find_au_split(&accum) {
                 if stopped() {
-                    break 'outer;
+                    return false;
                 }
                 let au: Vec<u8> = accum.drain(..split).collect();
                 if au.is_empty() {
                     continue;
                 }
                 if !send_h264_au_with_retry(&lcd, &au, &stopped) {
-                    break 'outer;
+                    return false;
                 }
                 saw_boundary = true;
                 sent_any = true;
                 pace_frame(&mut next_deadline, frame_interval);
             }
         }
-        // reached only via the EOF break (every other exit is break 'outer),
+        // reached only via the EOF break (every other exit is a return),
         // residual flush is paced like a regular AU
         if !stopped() && !accum.is_empty() {
             pace_frame(&mut next_deadline, frame_interval);
@@ -1236,19 +1236,22 @@ fn stream_h264_file_to_hid(
                 sent_any = true;
             }
         }
-        if !looping || stopped() {
-            break;
+        if stopped() {
+            return false;
+        }
+        if !looping {
+            return true;
         }
         // only loop when real AU boundaries were found: a boundary-less
         // file's flush would otherwise re-send identical data forever
         if !sent_any || (first_pass && !saw_boundary) {
             warn!("HID h264 file produced no complete access units, stopping");
-            break;
+            return true;
         }
         first_pass = false;
         if let Err(e) = file.seek(SeekFrom::Start(0)) {
             warn!("HID h264 file seek failed: {e:#}");
-            break;
+            return false;
         }
     }
 }

--- a/crates/lianli-daemon/src/service/runtime.rs
+++ b/crates/lianli-daemon/src/service/runtime.rs
@@ -28,6 +28,32 @@ pub(super) type SharedHidLcd = Arc<Mutex<Box<dyn LcdDevice>>>;
 // boundary would otherwise grow `accum` without limit
 const MAX_AU_BYTES: usize = 4 * 1024 * 1024;
 
+/// Sends one access unit with three attempts, false when aborted or failed
+fn send_h264_au_with_retry(lcd: &SharedHidLcd, au: &[u8], aborted: &dyn Fn() -> bool) -> bool {
+    let mut last_err = None;
+    for attempt in 1..=3 {
+        if aborted() {
+            return false;
+        }
+        let result = {
+            let mut guard = lcd.lock();
+            guard.send_h264_frame(au)
+        };
+        match result {
+            Ok(()) => return true,
+            Err(e) => {
+                debug!("HID h264 send error (attempt {attempt}/3): {e:#}");
+                last_err = Some(e);
+                thread::sleep(Duration::from_millis(150));
+            }
+        }
+    }
+    if let Some(e) = last_err {
+        warn!("HID h264 send failed after retries: {e:#}");
+    }
+    false
+}
+
 /// Returns the join handle plus the worker's private halt flag so a
 /// replacement stream can stop this one promptly.
 fn spawn_hid_h264_stream(
@@ -84,29 +110,7 @@ fn spawn_hid_h264_stream(
                 if au.is_empty() {
                     continue;
                 }
-                let mut send_err = None;
-                for attempt in 1..=3 {
-                    if halted() {
-                        return;
-                    }
-                    let result = {
-                        let mut guard = lcd.lock();
-                        guard.send_h264_frame(&au)
-                    };
-                    match result {
-                        Ok(()) => {
-                            send_err = None;
-                            break;
-                        }
-                        Err(e) => {
-                            debug!("HID h264 stream send error (attempt {attempt}/3): {e:#}");
-                            send_err = Some(e);
-                            thread::sleep(Duration::from_millis(150));
-                        }
-                    }
-                }
-                if let Some(e) = send_err {
-                    warn!("HID h264 stream send failed after retries: {e:#}");
+                if !send_h264_au_with_retry(&lcd, &au, &halted) {
                     return;
                 }
                 pace_frame(&mut next_deadline, frame_interval);
@@ -117,9 +121,7 @@ fn spawn_hid_h264_stream(
         }
         if clean_eof && !halted() && !accum.is_empty() {
             pace_frame(&mut next_deadline, frame_interval);
-            if let Err(e) = lcd.lock().send_h264_frame(&accum) {
-                debug!("HID h264 flush: {e:#}");
-            }
+            send_h264_au_with_retry(&lcd, &accum, &halted);
         }
     });
     (handle, halt)
@@ -942,6 +944,8 @@ struct H264FileSource {
     started: bool,
     hid_thread: Option<JoinHandle<()>>,
     hid_stop: Arc<AtomicBool>,
+    /// Set by the worker when it ended without a stop request
+    hid_completed: Option<Arc<AtomicBool>>,
     /// start() runs every streaming tick; back off after an open failure
     /// so a missing file retries periodically instead of once or per-tick.
     retry_after: Option<std::time::Instant>,
@@ -958,6 +962,7 @@ impl H264FileSource {
             started: false,
             hid_thread: None,
             hid_stop: Arc::new(AtomicBool::new(false)),
+            hid_completed: None,
             retry_after: None,
         }
     }
@@ -968,10 +973,17 @@ impl FrameSource for H264FileSource {
         if self.started {
             if let Some(ref t) = self.hid_thread {
                 if t.is_finished() {
-                    warn!("HID h264 stream thread ended; resetting for restart");
+                    let completed = self
+                        .hid_completed
+                        .as_ref()
+                        .is_some_and(|c| c.load(Ordering::Acquire));
                     if let Some(t) = self.hid_thread.take() {
                         let _ = t.join();
                     }
+                    if completed {
+                        return Ok(());
+                    }
+                    warn!("HID h264 stream thread ended; resetting for restart");
                     self.hid_stop = Arc::new(AtomicBool::new(false));
                     self.started = false;
                 } else {
@@ -1004,8 +1016,14 @@ impl FrameSource for H264FileSource {
                 let lcd = Arc::clone(hid);
                 let (looping, fps) = (self.looping, self.fps);
                 let stop = Arc::clone(&self.hid_stop);
+                let completed = Arc::new(AtomicBool::new(false));
+                let done = Arc::clone(&completed);
+                self.hid_completed = Some(completed);
                 self.hid_thread = Some(thread::spawn(move || {
-                    stream_h264_file_to_hid(lcd, file, looping, fps, stop);
+                    stream_h264_file_to_hid(lcd, file, looping, fps, Arc::clone(&stop));
+                    if !stop.load(Ordering::Relaxed) {
+                        done.store(true, Ordering::Release);
+                    }
                 }));
             }
             _ => {}
@@ -1161,18 +1179,19 @@ fn stream_h264_file_to_hid(
     };
     let mut read_buf = vec![0u8; 64 * 1024];
     let mut next_deadline = Instant::now() + frame_interval;
+    let stopped = || stop.load(Ordering::Relaxed);
     // a single-AU file never yields a split boundary, its only frame rides
     // the EOF flush, allow it exactly one looping pass
     let mut first_pass = true;
     let mut saw_boundary = false;
     'outer: loop {
-        if stop.load(Ordering::Relaxed) {
+        if stopped() {
             break;
         }
         let mut accum: Vec<u8> = Vec::with_capacity(256 * 1024);
         let mut sent_any = false;
         loop {
-            if stop.load(Ordering::Relaxed) {
+            if stopped() {
                 break 'outer;
             }
             let n = match file.read(&mut read_buf) {
@@ -1194,36 +1213,14 @@ fn stream_h264_file_to_hid(
                 break 'outer;
             }
             while let Some(split) = find_au_split(&accum) {
-                if stop.load(Ordering::Relaxed) {
+                if stopped() {
                     break 'outer;
                 }
                 let au: Vec<u8> = accum.drain(..split).collect();
                 if au.is_empty() {
                     continue;
                 }
-                let mut send_err = None;
-                for attempt in 1..=3 {
-                    if stop.load(Ordering::Relaxed) {
-                        break 'outer;
-                    }
-                    let result = {
-                        let mut guard = lcd.lock();
-                        guard.send_h264_frame(&au)
-                    };
-                    match result {
-                        Ok(()) => {
-                            send_err = None;
-                            break;
-                        }
-                        Err(e) => {
-                            debug!("HID h264 stream send error (attempt {attempt}/3): {e:#}");
-                            send_err = Some(e);
-                            thread::sleep(Duration::from_millis(150));
-                        }
-                    }
-                }
-                if let Some(e) = send_err {
-                    warn!("HID h264 stream send failed after retries: {e:#}");
+                if !send_h264_au_with_retry(&lcd, &au, &stopped) {
                     break 'outer;
                 }
                 saw_boundary = true;
@@ -1233,14 +1230,13 @@ fn stream_h264_file_to_hid(
         }
         // reached only via the EOF break (every other exit is break 'outer),
         // residual flush is paced like a regular AU
-        if !stop.load(Ordering::Relaxed) && !accum.is_empty() {
+        if !stopped() && !accum.is_empty() {
             pace_frame(&mut next_deadline, frame_interval);
-            match lcd.lock().send_h264_frame(&accum) {
-                Ok(()) => sent_any = true,
-                Err(e) => debug!("HID h264 flush: {e:#}"),
+            if send_h264_au_with_retry(&lcd, &accum, &stopped) {
+                sent_any = true;
             }
         }
-        if !looping || stop.load(Ordering::Relaxed) {
+        if !looping || stopped() {
             break;
         }
         // only loop when real AU boundaries were found: a boundary-less

--- a/crates/lianli-devices/src/detect/backends.rs
+++ b/crates/lianli-devices/src/detect/backends.rs
@@ -22,7 +22,7 @@ fn make_hidraw_reopener(
     usage_page: Option<u16>,
 ) -> HidrawReopener {
     Arc::new(move || {
-        let (dev, path) = open_hidraw_device(vid, pid, bus, &port_numbers, usage_page)?;
+        let (dev, path) = open_hidraw_device_strict(vid, pid, bus, &port_numbers, usage_page)?;
         let mut transport = HidrawTransport::new(dev, path);
         transport.set_reopener(make_hidraw_reopener(
             vid,
@@ -33,6 +33,45 @@ fn make_hidraw_reopener(
         ));
         Ok(transport)
     })
+}
+
+/// Recovery only accepts the exact saved topology so a replug or sibling
+/// device with the same VID PID usage page can never be opened instead
+fn open_hidraw_device_strict(
+    vid: u16,
+    pid: u16,
+    bus: u8,
+    port_numbers: &[u8],
+    usage_page: Option<u16>,
+) -> Result<(hidapi::HidDevice, Option<std::ffi::OsString>)> {
+    let api = hidapi::HidApi::new().map_err(|e| anyhow::anyhow!("HidApi init: {e}"))?;
+    let expected = hidraw_path_for_usb_topology(bus, port_numbers).ok_or_else(|| {
+        anyhow::anyhow!(
+            "hidraw topology {bus}-{:?} for {vid:04x}:{pid:04x} not present on reopen",
+            port_numbers
+        )
+    })?;
+    let info = api
+        .device_list()
+        .find(|info| {
+            info.vendor_id() == vid
+                && info.product_id() == pid
+                && usage_page.is_none_or(|up| info.usage_page() == up)
+                && info.path() == expected.as_c_str()
+        })
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "hidraw device {vid:04x}:{pid:04x} at saved topology {bus}-{:?} not found",
+                port_numbers
+            )
+        })?;
+    let path: std::ffi::OsString = {
+        use std::os::unix::ffi::OsStrExt;
+        std::ffi::OsStr::from_bytes(info.path().to_bytes()).to_os_string()
+    };
+    info.open_device(&api)
+        .map(|d| (d, Some(path)))
+        .map_err(|e| anyhow::anyhow!("hidraw reopen {vid:04x}:{pid:04x}: {e}"))
 }
 
 fn make_rusb_reopener(

--- a/crates/lianli-devices/src/detect/backends.rs
+++ b/crates/lianli-devices/src/detect/backends.rs
@@ -3,7 +3,9 @@ use super::DetectedDevice;
 use anyhow::Result;
 use lianli_shared::config::HidBackend;
 use lianli_shared::device_id::DeviceFamily;
-use lianli_transport::{HidTransport, HidrawTransport, RusbBulk, RusbHid, RusbHidReopener};
+use lianli_transport::{
+    HidTransport, HidrawReopener, HidrawTransport, RusbBulk, RusbHid, RusbHidReopener,
+};
 use parking_lot::Mutex;
 use rusb::{Device, GlobalContext};
 use std::sync::Arc;
@@ -11,6 +13,27 @@ use std::time::Duration;
 use tracing::{debug, warn};
 
 type SharedHid = Arc<Mutex<Box<dyn HidTransport>>>;
+
+fn make_hidraw_reopener(
+    vid: u16,
+    pid: u16,
+    bus: u8,
+    port_numbers: Vec<u8>,
+    usage_page: Option<u16>,
+) -> HidrawReopener {
+    Arc::new(move || {
+        let (dev, path) = open_hidraw_device(vid, pid, bus, &port_numbers, usage_page)?;
+        let mut transport = HidrawTransport::new(dev, path);
+        transport.set_reopener(make_hidraw_reopener(
+            vid,
+            pid,
+            bus,
+            port_numbers.clone(),
+            usage_page,
+        ));
+        Ok(transport)
+    })
+}
 
 fn make_rusb_reopener(
     vid: u16,
@@ -209,10 +232,11 @@ pub fn open_shared_hid(
 ) -> Result<SharedHid> {
     match backend {
         HidBackend::Hidraw => {
+            let pn = port_numbers.to_vec();
             let (dev, path) = open_hidraw_device(vid, pid, bus, port_numbers, usage_page)?;
-            Ok(Arc::new(Mutex::new(Box::new(HidrawTransport::new(
-                dev, path,
-            )))))
+            let mut transport = HidrawTransport::new(dev, path);
+            transport.set_reopener(make_hidraw_reopener(vid, pid, bus, pn, usage_page));
+            Ok(Arc::new(Mutex::new(Box::new(transport))))
         }
         HidBackend::Rusb => {
             let pn = port_numbers.to_vec();

--- a/crates/lianli-devices/src/hydroshift_lcd/controller.rs
+++ b/crates/lianli-devices/src/hydroshift_lcd/controller.rs
@@ -13,7 +13,7 @@ use lianli_shared::screen::ScreenInfo;
 use lianli_transport::HidTransport;
 use parking_lot::Mutex;
 use std::io::Read;
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicU8, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -169,6 +169,7 @@ pub struct HydroShiftLcdController {
     last_recovery_attempt: Mutex<Option<Instant>>,
     drain_stop: Arc<AtomicBool>,
     lcd_unavailable_count: AtomicU32,
+    last_reopen_count: AtomicU64,
 }
 
 impl HydroShiftLcdController {
@@ -191,6 +192,7 @@ impl HydroShiftLcdController {
             last_recovery_attempt: Mutex::new(None),
             drain_stop: Arc::new(AtomicBool::new(false)),
             lcd_unavailable_count: AtomicU32::new(0),
+            last_reopen_count: AtomicU64::new(0),
         })
     }
 
@@ -324,7 +326,7 @@ impl HydroShiftLcdController {
         Ok(hs)
     }
 
-    pub fn apply_lcd_settings(&self) -> Result<()> {
+    fn apply_lcd_settings_raw(&self, dev: &mut dyn HidTransport) -> Result<()> {
         let brightness = self.brightness.load(Ordering::Relaxed);
         let rotation = self.rotation.load(Ordering::Relaxed);
         let mut payload = [0u8; 8];
@@ -333,8 +335,28 @@ impl HydroShiftLcdController {
         payload[2] = rotation;
         payload[7] = self.video_fps.load(Ordering::Relaxed);
 
-        self.send_b_command(CMD_LCD_CONTROL, &payload)?;
+        Self::send_b_command_raw(dev, CMD_LCD_CONTROL, &payload)?;
         debug!("LCD settings applied: brightness={brightness}, rotation={rotation}");
+        Ok(())
+    }
+
+    pub fn apply_lcd_settings(&self) -> Result<()> {
+        let mut dev = self.device.lock();
+        self.last_reopen_count
+            .store(dev.reopen_count(), Ordering::Relaxed);
+        self.apply_lcd_settings_raw(&mut *dev)
+    }
+
+    fn check_reinit_locked(&self, dev: &mut dyn HidTransport) -> Result<()> {
+        let current = dev.reopen_count();
+        let last = self.last_reopen_count.load(Ordering::Relaxed);
+        if current > last {
+            info!(
+                "HydroShift LCD transport reopened (count: {current} > {last}); re-applying LCD settings"
+            );
+            self.apply_lcd_settings_raw(dev)?;
+            self.last_reopen_count.store(current, Ordering::Relaxed);
+        }
         Ok(())
     }
 
@@ -398,6 +420,7 @@ impl HydroShiftLcdController {
             bail!("AIO LCD: availability check aborted before write (stop requested)");
         }
         let mut dev = self.device.lock();
+        self.check_reinit_locked(&mut *dev)?;
 
         let mut pkt = vec![0u8; B_PACKET_SIZE];
         pkt[0] = REPORT_ID_B;
@@ -517,13 +540,43 @@ impl HydroShiftLcdController {
                     self.apply_lcd_settings()?;
                     Ok(RecoveryAction::Recovered)
                 } else {
-                    warn!("Device reset failed");
-                    Ok(RecoveryAction::NoChange)
+                    warn!("Device reset failed, attempting fallback LCD settings reinit");
+                    if let Err(err) = self.apply_lcd_settings() {
+                        warn!("Fallback apply_lcd_settings failed: {err:#}");
+                        Ok(RecoveryAction::NoChange)
+                    } else {
+                        info!("Fallback apply_lcd_settings succeeded");
+                        Ok(RecoveryAction::Recovered)
+                    }
                 }
             }
             Err(e) => {
-                debug!("LCD availability check failed: {e:#}");
-                Ok(RecoveryAction::NoChange)
+                let count = self.lcd_unavailable_count.fetch_add(1, Ordering::Relaxed) + 1;
+                debug!("LCD availability check failed ({count}/{UNAVAILABLE_THRESHOLD}): {e:#}");
+                if count < UNAVAILABLE_THRESHOLD {
+                    return Ok(RecoveryAction::NoChange);
+                }
+                self.lcd_unavailable_count.store(0, Ordering::Relaxed);
+                warn!("LCD availability check failed {count} times — attempting recovery");
+                *self.last_recovery_attempt.lock() = Some(Instant::now());
+                if self.reset_device(stop) {
+                    info!("Device reset successful, reinitializing LCD");
+                    std::thread::sleep(std::time::Duration::from_millis(500));
+                    if stop.load(Ordering::Relaxed) {
+                        bail!("AIO LCD: recovery aborted before reinitialization");
+                    }
+                    self.apply_lcd_settings()?;
+                    Ok(RecoveryAction::Recovered)
+                } else {
+                    warn!("Device reset failed, attempting fallback LCD settings reinit");
+                    if let Err(err) = self.apply_lcd_settings() {
+                        warn!("Fallback apply_lcd_settings failed: {err:#}");
+                        Ok(RecoveryAction::NoChange)
+                    } else {
+                        info!("Fallback apply_lcd_settings succeeded");
+                        Ok(RecoveryAction::Recovered)
+                    }
+                }
             }
         }
     }
@@ -615,11 +668,10 @@ impl HydroShiftLcdController {
         write_a_command_raw(&mut *dev, cmd, data)
     }
 
-    fn send_b_command(&self, cmd: u8, data: &[u8]) -> Result<()> {
+    fn send_b_command_raw(dev: &mut dyn HidTransport, cmd: u8, data: &[u8]) -> Result<()> {
         let total_size = data.len();
         let mut offset = 0;
         let mut packet_num: u32 = 0;
-        let mut dev = self.device.lock();
 
         loop {
             let remaining = total_size.saturating_sub(offset);
@@ -648,8 +700,17 @@ impl HydroShiftLcdController {
             }
         }
 
-        self.read_ack(&mut *dev, "send_b_command", READ_TIMEOUT_MS);
+        let mut buf = [0u8; B_PACKET_SIZE];
+        if let Err(e) = dev.read_timeout(&mut buf, READ_TIMEOUT_MS) {
+            debug!("AIO LCD: send_b_command ack: {e:#}");
+        }
         Ok(())
+    }
+
+    fn send_b_command(&self, cmd: u8, data: &[u8]) -> Result<()> {
+        let mut dev = self.device.lock();
+        self.check_reinit_locked(&mut *dev)?;
+        Self::send_b_command_raw(&mut *dev, cmd, data)
     }
 
     fn send_chunked(&self, cmd: u8, data: &[u8]) -> Result<()> {
@@ -663,6 +724,7 @@ impl HydroShiftLcdController {
         let mut offset = 0;
         let mut packet_num: u32 = 0;
         let mut dev = self.device.lock();
+        self.check_reinit_locked(&mut *dev)?;
 
         loop {
             let remaining = total_size.saturating_sub(offset);
@@ -707,6 +769,7 @@ impl HydroShiftLcdController {
         let mut offset = 0;
         let mut packet_num: u32 = 0;
         let mut dev = self.device.lock();
+        self.check_reinit_locked(&mut *dev)?;
 
         loop {
             let remaining = total_size.saturating_sub(offset);
@@ -926,7 +989,8 @@ impl LcdDevice for Arc<HydroShiftLcdController> {
     }
 
     fn initialize(&mut self) -> Result<()> {
-        self.init()
+        self.init()?;
+        self.apply_lcd_settings()
     }
 
     fn check_and_recover_lcd(

--- a/crates/lianli-devices/src/hydroshift_lcd/controller.rs
+++ b/crates/lianli-devices/src/hydroshift_lcd/controller.rs
@@ -429,7 +429,7 @@ impl HydroShiftLcdController {
             .context("AIO LCD: write LCD available check")?;
 
         let mut buf = vec![0u8; B_PACKET_SIZE];
-        loop {
+        let available = loop {
             if stop.load(Ordering::Relaxed) {
                 bail!("AIO LCD: availability check aborted (stop requested)");
             }
@@ -438,17 +438,19 @@ impl HydroShiftLcdController {
                 .context("AIO LCD: read LCD available response")?;
 
             if n == 0 {
-                return Ok(true);
+                break true;
             }
             if buf[1] == CMD_LCD_AVAILABLE {
                 let data_len = (buf[9] as usize) << 8 | buf[10] as usize;
-                return Ok(data_len == 1 && buf[B_HEADER_LEN] == 0);
+                break data_len == 1 && buf[B_HEADER_LEN] == 0;
             }
             debug!(
                 "AIO LCD: is_lcd_available: skipping stale response cmd={:#04x}",
                 buf[1]
             );
-        }
+        };
+        self.check_reinit_locked(&mut *dev)?;
+        Ok(available)
     }
 
     pub fn reset_device(&self, stop: &AtomicBool) -> bool {
@@ -710,7 +712,8 @@ impl HydroShiftLcdController {
     fn send_b_command(&self, cmd: u8, data: &[u8]) -> Result<()> {
         let mut dev = self.device.lock();
         self.check_reinit_locked(&mut *dev)?;
-        Self::send_b_command_raw(&mut *dev, cmd, data)
+        Self::send_b_command_raw(&mut *dev, cmd, data)?;
+        self.check_reinit_locked(&mut *dev)
     }
 
     fn send_chunked(&self, cmd: u8, data: &[u8]) -> Result<()> {
@@ -754,7 +757,7 @@ impl HydroShiftLcdController {
         }
 
         self.read_ack(&mut *dev, "send_chunked", ACK_TIMEOUT_MS);
-        Ok(())
+        self.check_reinit_locked(&mut *dev)
     }
 
     fn send_chunked_with(
@@ -798,7 +801,7 @@ impl HydroShiftLcdController {
         }
 
         self.read_ack(&mut *dev, "send_chunked_with", ACK_TIMEOUT_MS);
-        Ok(())
+        self.check_reinit_locked(&mut *dev)
     }
 
     fn read_ack(&self, dev: &mut dyn HidTransport, label: &str, timeout_ms: i32) {

--- a/crates/lianli-transport/src/hid.rs
+++ b/crates/lianli-transport/src/hid.rs
@@ -39,6 +39,7 @@ pub struct RusbHid {
     /// Optional self-healing reopener. When set, an I/O error triggers a
     /// fresh open + retry.
     reopener: Option<RusbHidReopener>,
+    reopen_count: std::sync::atomic::AtomicU64,
 }
 
 impl RusbHid {
@@ -193,6 +194,7 @@ impl RusbHid {
             ep_in,
             ep_out,
             reopener,
+            reopen_count: std::sync::atomic::AtomicU64::new(0),
         })
     }
 
@@ -244,8 +246,14 @@ impl RusbHid {
             .clone()
             .ok_or_else(|| TransportError::Other("no reopener configured".into()))?;
         let replacement = reopener().map_err(|e| TransportError::Other(format!("reopen: {e}")))?;
+        let count = self.reopen_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
         *self = replacement;
+        self.reopen_count.store(count, std::sync::atomic::Ordering::SeqCst);
         Ok(())
+    }
+
+    pub fn reopen_count(&self) -> u64 {
+        self.reopen_count.load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Run `op` against the inner handle. If it fails and a reopener is
@@ -518,5 +526,9 @@ impl HidTransport for RusbHid {
 
     fn read_flush(&mut self) {
         RusbHid::read_flush(self)
+    }
+
+    fn reopen_count(&self) -> u64 {
+        RusbHid::reopen_count(self)
     }
 }

--- a/crates/lianli-transport/src/hid.rs
+++ b/crates/lianli-transport/src/hid.rs
@@ -246,9 +246,13 @@ impl RusbHid {
             .clone()
             .ok_or_else(|| TransportError::Other("no reopener configured".into()))?;
         let replacement = reopener().map_err(|e| TransportError::Other(format!("reopen: {e}")))?;
-        let count = self.reopen_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+        let count = self
+            .reopen_count
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+            + 1;
         *self = replacement;
-        self.reopen_count.store(count, std::sync::atomic::Ordering::SeqCst);
+        self.reopen_count
+            .store(count, std::sync::atomic::Ordering::SeqCst);
         Ok(())
     }
 

--- a/crates/lianli-transport/src/hid_trait.rs
+++ b/crates/lianli-transport/src/hid_trait.rs
@@ -7,6 +7,9 @@ pub trait HidTransport: Send {
     fn get_feature_report(&mut self, buf: &mut [u8]) -> Result<usize, TransportError>;
     fn get_input_report(&mut self, buf: &mut [u8]) -> Result<usize, TransportError>;
     fn read_flush(&mut self);
+    fn reopen_count(&self) -> u64 {
+        0
+    }
 }
 
 impl<T: HidTransport + ?Sized> HidTransport for Box<T> {
@@ -27,5 +30,75 @@ impl<T: HidTransport + ?Sized> HidTransport for Box<T> {
     }
     fn read_flush(&mut self) {
         (**self).read_flush()
+    }
+    fn reopen_count(&self) -> u64 {
+        (**self).reopen_count()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct MockTransport {
+        count: u64,
+    }
+
+    impl HidTransport for MockTransport {
+        fn write(&mut self, data: &[u8]) -> Result<usize, TransportError> {
+            Ok(data.len())
+        }
+        fn read_timeout(&mut self, _buf: &mut [u8], _timeout_ms: i32) -> Result<usize, TransportError> {
+            Ok(0)
+        }
+        fn send_feature_report(&mut self, data: &[u8]) -> Result<usize, TransportError> {
+            Ok(data.len())
+        }
+        fn get_feature_report(&mut self, _buf: &mut [u8]) -> Result<usize, TransportError> {
+            Ok(0)
+        }
+        fn get_input_report(&mut self, _buf: &mut [u8]) -> Result<usize, TransportError> {
+            Ok(0)
+        }
+        fn read_flush(&mut self) {}
+        fn reopen_count(&self) -> u64 {
+            self.count
+        }
+    }
+
+    struct DefaultTransport;
+    impl HidTransport for DefaultTransport {
+        fn write(&mut self, data: &[u8]) -> Result<usize, TransportError> {
+            Ok(data.len())
+        }
+        fn read_timeout(&mut self, _buf: &mut [u8], _timeout_ms: i32) -> Result<usize, TransportError> {
+            Ok(0)
+        }
+        fn send_feature_report(&mut self, data: &[u8]) -> Result<usize, TransportError> {
+            Ok(data.len())
+        }
+        fn get_feature_report(&mut self, _buf: &mut [u8]) -> Result<usize, TransportError> {
+            Ok(0)
+        }
+        fn get_input_report(&mut self, _buf: &mut [u8]) -> Result<usize, TransportError> {
+            Ok(0)
+        }
+        fn read_flush(&mut self) {}
+    }
+
+    #[test]
+    fn default_reopen_count_is_zero() {
+        let t = DefaultTransport;
+        assert_eq!(t.reopen_count(), 0);
+        let boxed: Box<dyn HidTransport> = Box::new(t);
+        assert_eq!(boxed.reopen_count(), 0);
+    }
+
+    #[test]
+    fn custom_reopen_count_delegates_through_box() {
+        let t = MockTransport { count: 42 };
+        assert_eq!(t.reopen_count(), 42);
+        let boxed: Box<dyn HidTransport> = Box::new(t);
+        assert_eq!(boxed.reopen_count(), 42);
     }
 }

--- a/crates/lianli-transport/src/hid_trait.rs
+++ b/crates/lianli-transport/src/hid_trait.rs
@@ -48,7 +48,11 @@ mod tests {
         fn write(&mut self, data: &[u8]) -> Result<usize, TransportError> {
             Ok(data.len())
         }
-        fn read_timeout(&mut self, _buf: &mut [u8], _timeout_ms: i32) -> Result<usize, TransportError> {
+        fn read_timeout(
+            &mut self,
+            _buf: &mut [u8],
+            _timeout_ms: i32,
+        ) -> Result<usize, TransportError> {
             Ok(0)
         }
         fn send_feature_report(&mut self, data: &[u8]) -> Result<usize, TransportError> {
@@ -71,7 +75,11 @@ mod tests {
         fn write(&mut self, data: &[u8]) -> Result<usize, TransportError> {
             Ok(data.len())
         }
-        fn read_timeout(&mut self, _buf: &mut [u8], _timeout_ms: i32) -> Result<usize, TransportError> {
+        fn read_timeout(
+            &mut self,
+            _buf: &mut [u8],
+            _timeout_ms: i32,
+        ) -> Result<usize, TransportError> {
             Ok(0)
         }
         fn send_feature_report(&mut self, data: &[u8]) -> Result<usize, TransportError> {

--- a/crates/lianli-transport/src/hidraw.rs
+++ b/crates/lianli-transport/src/hidraw.rs
@@ -65,9 +65,13 @@ impl HidrawTransport {
             .clone()
             .ok_or_else(|| TransportError::Other("no reopener configured".into()))?;
         let replacement = reopener().map_err(|e| TransportError::Other(format!("reopen: {e}")))?;
-        let count = self.reopen_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+        let count = self
+            .reopen_count
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+            + 1;
         *self = replacement;
-        self.reopen_count.store(count, std::sync::atomic::Ordering::SeqCst);
+        self.reopen_count
+            .store(count, std::sync::atomic::Ordering::SeqCst);
         Ok(())
     }
 
@@ -80,7 +84,9 @@ impl HidrawTransport {
             Ok(v) => Ok(v),
             Err(e) if self.reopener.is_some() => {
                 if crate::usb::shutting_down() {
-                    tracing::debug!("Hidraw {label} failed ({e}) while shutting down, not reopening");
+                    tracing::debug!(
+                        "Hidraw {label} failed ({e}) while shutting down, not reopening"
+                    );
                     return Err(e);
                 }
                 warn!("Hidraw {label} failed ({e}); attempting reopen");

--- a/crates/lianli-transport/src/hidraw.rs
+++ b/crates/lianli-transport/src/hidraw.rs
@@ -7,10 +7,14 @@ use tracing::warn;
 
 const WRITE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
+pub type HidrawReopener = std::sync::Arc<dyn Fn() -> anyhow::Result<HidrawTransport> + Send + Sync>;
+
 pub struct HidrawTransport {
     device: HidDevice,
     /// hidapi write has no timeout, use a nonblocking fd for writes
     write_fd: Option<std::fs::File>,
+    reopener: Option<HidrawReopener>,
+    reopen_count: std::sync::atomic::AtomicU64,
 }
 
 impl HidrawTransport {
@@ -43,7 +47,53 @@ impl HidrawTransport {
                     }
                 },
             );
-        Self { device, write_fd }
+        Self {
+            device,
+            write_fd,
+            reopener: None,
+            reopen_count: std::sync::atomic::AtomicU64::new(0),
+        }
+    }
+
+    pub fn set_reopener(&mut self, reopener: HidrawReopener) {
+        self.reopener = Some(reopener);
+    }
+
+    fn try_reopen(&mut self) -> Result<(), TransportError> {
+        let reopener = self
+            .reopener
+            .clone()
+            .ok_or_else(|| TransportError::Other("no reopener configured".into()))?;
+        let replacement = reopener().map_err(|e| TransportError::Other(format!("reopen: {e}")))?;
+        let count = self.reopen_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+        *self = replacement;
+        self.reopen_count.store(count, std::sync::atomic::Ordering::SeqCst);
+        Ok(())
+    }
+
+    fn with_reopen<T>(
+        &mut self,
+        mut op: impl FnMut(&mut Self) -> Result<T, TransportError>,
+        label: &str,
+    ) -> Result<T, TransportError> {
+        match op(self) {
+            Ok(v) => Ok(v),
+            Err(e) if self.reopener.is_some() => {
+                if crate::usb::shutting_down() {
+                    tracing::debug!("Hidraw {label} failed ({e}) while shutting down, not reopening");
+                    return Err(e);
+                }
+                warn!("Hidraw {label} failed ({e}); attempting reopen");
+                self.try_reopen()?;
+                tracing::info!("Hidraw handle reopened, retrying {label}");
+                op(self)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    pub fn reopen_count(&self) -> u64 {
+        self.reopen_count.load(std::sync::atomic::Ordering::Relaxed)
     }
 
     fn write_timed(
@@ -205,32 +255,52 @@ mod tests {
 
 impl HidTransport for HidrawTransport {
     fn write(&mut self, data: &[u8]) -> Result<usize, TransportError> {
-        self.write_timed(data, WRITE_TIMEOUT)
+        self.with_reopen(|s| s.write_timed(data, WRITE_TIMEOUT), "write")
     }
 
     fn read_timeout(&mut self, buf: &mut [u8], timeout_ms: i32) -> Result<usize, TransportError> {
-        self.device
-            .read_timeout(buf, timeout_ms)
-            .map_err(|e| TransportError::Read(e.to_string()))
+        self.with_reopen(
+            |s| {
+                s.device
+                    .read_timeout(buf, timeout_ms)
+                    .map_err(|e| TransportError::Read(e.to_string()))
+            },
+            "read_timeout",
+        )
     }
 
     fn send_feature_report(&mut self, data: &[u8]) -> Result<usize, TransportError> {
-        self.device
-            .send_feature_report(data)
-            .map_err(|e| TransportError::Write(e.to_string()))?;
-        Ok(data.len())
+        self.with_reopen(
+            |s| {
+                s.device
+                    .send_feature_report(data)
+                    .map_err(|e| TransportError::Write(e.to_string()))?;
+                Ok(data.len())
+            },
+            "send_feature_report",
+        )
     }
 
     fn get_feature_report(&mut self, buf: &mut [u8]) -> Result<usize, TransportError> {
-        self.device
-            .get_feature_report(buf)
-            .map_err(|e| TransportError::Read(e.to_string()))
+        self.with_reopen(
+            |s| {
+                s.device
+                    .get_feature_report(buf)
+                    .map_err(|e| TransportError::Read(e.to_string()))
+            },
+            "get_feature_report",
+        )
     }
 
     fn get_input_report(&mut self, buf: &mut [u8]) -> Result<usize, TransportError> {
-        self.device
-            .get_input_report(buf)
-            .map_err(|e| TransportError::Read(e.to_string()))
+        self.with_reopen(
+            |s| {
+                s.device
+                    .get_input_report(buf)
+                    .map_err(|e| TransportError::Read(e.to_string()))
+            },
+            "get_input_report",
+        )
     }
 
     fn read_flush(&mut self) {
@@ -241,5 +311,9 @@ impl HidTransport for HidrawTransport {
                 _ => break,
             }
         }
+    }
+
+    fn reopen_count(&self) -> u64 {
+        HidrawTransport::reopen_count(self)
     }
 }

--- a/crates/lianli-transport/src/lib.rs
+++ b/crates/lianli-transport/src/lib.rs
@@ -20,5 +20,5 @@ pub mod usb;
 pub use error::TransportError;
 pub use hid::{RusbHid, RusbHidReopener};
 pub use hid_trait::HidTransport;
-pub use hidraw::HidrawTransport;
+pub use hidraw::{HidrawReopener, HidrawTransport};
 pub use usb::RusbBulk;


### PR DESCRIPTION
Fixes #166

> [!NOTE]
> **Disclaimer:** *I am a .NET developer rather than an experienced Rust dev, and I worked with AI tools to investigate, trace the hardware protocol interactions, and implement this patch. Opening as a **Draft PR** so you can review the approach and implementation details.*

---

### Hardware Tested & Host Environment
- **Device**: Winbond Electronics Corp. HydroShift LCD v1.3 (`0416:7398`, serial `hid:00000055FA92`)
- **Firmware**: `N9,01,HS,SQ,HydroShift,V3.0C.013,1.3`
- **Host**: Fedora Workstation x86_64 (Linux 6.18 / 6.19), systemd user service `lianli-daemon`
- **Media Asset**: Looping GIF (`nyan_cat_adventure.gif` transcoded to 480x480 H.264 @ 14 FPS)

---

### Detailed Findings & Technical Root Cause Analysis

When diagnosing the behavior reported in #166 where HydroShift LCD displays experience intermittent black flashes, flickering, and eventually freeze or wedge completely after a few sleep/wake cycles, our analysis identified three interacting issues:

#### 1. Hardware State Loss Across USB Reopens (`HidrawTransport` & `RusbHid`)
- When the host suspends/wakes or when Linux resets an idle USB port, the Winbond MCU hardware resets to its power-on default state. In this default state, the controller is no longer in `Application` mode (Mode 1), so incoming video/JPEG frames are ignored or rendered corrupted.
- While `RusbHid` supported `try_reopen()`, `HidrawTransport` lacked any self-healing reopener support. More critically, neither transport tracked reopen occurrences or notified higher-level device controllers that a hardware reset had occurred.
- As a result, after a transport handle reopen, streaming continued sending frames to an uninitialized LCD without ever re-issuing `CMD_LCD_CONTROL`.

#### 2. Deadlock Hazard & Re-entrancy During Auto-Reinitialization
- Calling existing public methods like `apply_lcd_settings()` during frame transmission would attempt to acquire `self.device.lock()` while already holding the transport lock inside `send_chunked()`, causing immediate deadlocks.
- The controller needed a safe, zero-overhead mechanism to verify the transport state and push reinitialization packets using the already-acquired transport handle.

#### 3. Autonomous Streaming Worker Thread Death (`H264FileSource`)
- When streaming H.264 files (such as converted GIFs) via `H264FileSource`, the stream runs in a dedicated worker thread spawned in `H264FileSource::start()`.
- During suspend or USB disconnects, any write error in `stream_h264_file_to_hid` caused an immediate `break 'outer`, terminating the thread.
- However, `H264FileSource.started` remained `true`. Subsequent service ticks called `start()` on the active target, saw `self.started == true`, and immediately returned `Ok(())` without doing anything. The worker thread was dead and was never restarted, leaving the display black or frozen permanently after wake.
- Piped streams (`spawn_hid_h264_stream`) similarly had no retry backoff against transient bus stalls.

#### 4. Silent Failure in Periodic Availability Checks (`check_and_recover_lcd`)
- `check_and_recover_lcd()` runs every 2 seconds via the background recovery thread.
- If `is_lcd_available()` returned `Err(e)` (due to a transient read timeout or USB glitch), the error was logged at `debug!` level and discarded without incrementing `lcd_unavailable_count`.
- Consequently, if the MCU entered a state where it failed to reply with an ACK, the recovery routine never reached `UNAVAILABLE_THRESHOLD = 3` and never initiated recovery.
- Furthermore, if `reset_device()` failed during a transient glitch, no fallback attempt to re-apply LCD settings was made.

---

### Changes Implemented

1. **Transport Reopen Tracking (`crates/lianli-transport`)**:
   - Added `fn reopen_count(&self) -> u64` (default returning 0) to `HidTransport`, with implementation delegated through `Box<dyn HidTransport>`.
   - Added unit tests in `crates/lianli-transport/src/hid_trait.rs` verifying `reopen_count()` for default and boxed implementations.
   - Added `reopen_count: AtomicU64` to `RusbHid`, incremented on each successful `try_reopen()`.
   - Added `HidrawReopener` type alias and full self-healing reopen support (`reopener`, `reopen_count`, `set_reopener`, `try_reopen`, `with_reopen`) to `HidrawTransport` matching `RusbHid`.
   - Updated `crates/lianli-devices/src/detect/backends.rs` to configure `make_hidraw_reopener()` on `HidrawTransport` instances.

2. **Transparent LCD Re-initialization on Transport Reopen (`crates/lianli-devices`)**:
   - Added `last_reopen_count: AtomicU64` to `HydroShiftLcdController`.
   - Extracted `send_b_command_raw(dev: &mut dyn HidTransport, ...)` and `apply_lcd_settings_raw(dev: &mut dyn HidTransport, ...)`.
   - Added `check_reinit_locked(&self, dev: &mut dyn HidTransport)`:
     - When `dev.reopen_count() > self.last_reopen_count`, it transparently re-issues `apply_lcd_settings_raw(dev)` on the already-held lock and updates `last_reopen_count`.
     - Called before transmission in `send_chunked()`, `send_chunked_with()`, `send_b_command()`, and `is_lcd_available()`.
   - Updated `LcdDevice::initialize(&mut self)` to invoke `self.apply_lcd_settings()` after `self.init()`.
   - Improved `check_and_recover_lcd()`: consecutive errors now increment `lcd_unavailable_count`, and if `reset_device()` fails, a fallback `apply_lcd_settings()` is attempted and reports `RecoveryAction::Recovered` to restart media streaming.

3. **Resilient H.264 Streaming & Auto-Restart (`crates/lianli-daemon`)**:
   - In `H264FileSource::start()`: checks `t.is_finished()`. If the worker thread finished unexpectedly, it joins the dead handle, resets `hid_stop` and `started = false`, and spawns a fresh worker.
   - In both `stream_h264_file_to_hid` and `spawn_hid_h264_stream`: frame send errors are retried up to 3 times with 150ms backoff before giving up and exiting.

---

### Verification & Hardware Testing
- **Unit & Integration Tests**:
  Ran `cargo test -p lianli-devices -p lianli-daemon -p lianli-transport -p lianli-media -p lianli-shared` — all 182+ tests passed cleanly.
- **Live Hardware Test**:
  Compiled release binary and installed locally. The daemon successfully initialized the Winbond HydroShift LCD, detected pump RPM, enabled PWM control, and continuously streamed the animated GIF without flickering, timeouts, or reset death loops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HID device recovery by reopening disconnected devices and retrying operations.
  * Recovery now reconnects to the correct physical device, avoiding unintended sibling devices.
  * LCD settings are restored after reconnection, including when interruptions occur during communication.
  * LCD initialization and recovery handle additional failure scenarios more reliably.
  * H.264 streaming retries failed frame transmissions and preserves final frames when streams end.
  * Transmission warnings are reported only after all retry attempts fail.
  * Completed streams no longer restart unnecessarily, while failed streams remain restartable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->