### PR TITLE
Add release notes and changelog generation

### DIFF
--- a/.github/cliff.toml
+++ b/.github/cliff.toml
@@ -1,0 +1,138 @@
+# git-cliff configuration — release notes from the history that already exists.
+#
+# Releases are the `vX.Y.Z` tags, each pointing at its own `bump version`
+# commit, so a tag range is exactly one release. Because the maintainer
+# squash-merges, each PR is one commit whose subject already carries its
+# number as a trailing `(#180)`.
+#
+# The Conventional Commits format is encouraged, not required: a subject that
+# does not follow it still appears, under "Other changes". Nothing about the
+# commit or tagging workflow has to change for this to produce useful output.
+#
+#   git cliff --latest                 # newest release
+#   git cliff --tag v0.8.10 --current  # one release
+#   git cliff --unreleased             # commits since the newest tag
+#   git cliff -o CHANGELOG.md          # every release
+
+[changelog]
+header = """
+# Changelog
+
+Generated from git history by git-cliff (see .github/cliff.toml).
+Regenerate rather than editing by hand.
+"""
+
+# `commits` is pre-grouped by the `group` set in commit_parsers below. The
+# scope is printed only when a commit has one — labelling the absence of a
+# scope would bury the scopes that are real.
+body = """
+{% if version %}\
+## {{ version }} — {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+## Unreleased
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}\
+{# For a conventional commit `message` is just the description, but for an
+   unconventional one it is the whole message, body included. Taking the
+   first line keeps both to a single-line bullet. #}\
+{% set subject = commit.message | split(pat="\n") | first | trim %}\
+- {% if commit.scope %}**{{ commit.scope }}**: {% endif %}\
+{{ subject | upper_first }}\
+{% if not subject is containing("](") %}  (`{{ commit.id | truncate(length=7, end="") }}`){% endif %}
+{% endfor %}\
+{% endfor %}
+"""
+
+# Left off deliberately. `trim` strips leading and trailing whitespace from
+# each rendered release, which eats the newline this template ends with and
+# runs the last bullet of one release straight into the next `##` heading.
+# With it off, the template's own leading newline is the blank line between
+# releases, and `--strip header` still starts a single release at its `##`.
+trim = false
+
+# Turn the bare `#180` a squash merge leaves behind into a link. Order
+# matters: the trailing reference is rewritten before the generic pass runs.
+[[git.commit_preprocessors]]
+# `... (#180)` -> a linked reference. Deliberately not anchored with `$`:
+# preprocessors see the whole commit message, trailing newline included, so
+# an end-of-text anchor never matches the end of the subject line.
+pattern = '\s*\(#(\d+)\)'
+replace = '  ([#${1}](https://github.com/sgtaziz/lian-li-linux/pull/${1}))'
+
+[[git.commit_preprocessors]]
+# `fixes #166` anywhere else in the subject.
+pattern = '\b([Ff]ix(?:e[sd])?|[Cc]lose[sd]?|[Rr]esolve[sd]?)\s+#(\d+)'
+replace = '${1} [#${2}](https://github.com/sgtaziz/lian-li-linux/issues/${2})'
+
+[git]
+conventional_commits = true
+
+# The point of the whole configuration: unconventional subjects are kept, not
+# dropped. Only 15 of 231 commits in this history use the convention, so
+# filtering them out would discard 93% of the changelog.
+filter_unconventional = false
+
+filter_commits = false
+protect_breaking_commits = true
+split_commits = false
+topo_order = false
+sort_commits = "oldest"
+
+# Tag names are `vX.Y.Z`; nothing else is a release.
+tag_pattern = "v[0-9]*"
+
+[[git.commit_parsers]]
+# The version bump IS the release, not a change within it.
+message = "^bump version"
+skip = true
+
+[[git.commit_parsers]]
+message = "^feat"
+group = "Features"
+
+[[git.commit_parsers]]
+message = "^fix"
+group = "Fixes"
+
+[[git.commit_parsers]]
+message = "^perf"
+group = "Performance"
+
+[[git.commit_parsers]]
+message = "^refactor"
+group = "Refactoring"
+
+[[git.commit_parsers]]
+message = "^docs"
+group = "Documentation"
+
+[[git.commit_parsers]]
+message = "^test"
+group = "Tests"
+
+[[git.commit_parsers]]
+message = "^build"
+group = "Build"
+
+[[git.commit_parsers]]
+message = "^ci"
+group = "CI"
+
+[[git.commit_parsers]]
+message = "^style"
+group = "Style"
+
+[[git.commit_parsers]]
+message = "^chore"
+group = "Chores"
+
+[[git.commit_parsers]]
+message = "^revert"
+group = "Reverts"
+
+[[git.commit_parsers]]
+# Everything that follows no convention. Listed, never dropped.
+message = ".*"
+group = "Other changes"

--- a/.github/cliff.toml
+++ b/.github/cliff.toml
@@ -80,8 +80,12 @@ split_commits = false
 topo_order = false
 sort_commits = "oldest"
 
-# Tag names are `vX.Y.Z`; nothing else is a release.
-tag_pattern = "v[0-9]*"
+# Tag names are `vX.Y.Z`; nothing else is a release. Anchored, because the
+# pattern is an unanchored regex: `v[0-9]` alone matches anywhere in a name,
+# so a tag like `preview-v2-old` would be read as a release boundary. Left
+# open at the end so a prerelease tag such as `v1.0.0-rc1`, should one ever
+# be cut, still counts as the release it names.
+tag_pattern = '^v[0-9]+\.[0-9]+\.[0-9]+'
 
 [[git.commit_parsers]]
 # The version bump IS the release, not a change within it.

--- a/.github/cliff.toml
+++ b/.github/cliff.toml
@@ -80,12 +80,14 @@ split_commits = false
 topo_order = false
 sort_commits = "oldest"
 
-# Tag names are `vX.Y.Z`; nothing else is a release. Anchored, because the
-# pattern is an unanchored regex: `v[0-9]` alone matches anywhere in a name,
-# so a tag like `preview-v2-old` would be read as a release boundary. Left
-# open at the end so a prerelease tag such as `v1.0.0-rc1`, should one ever
-# be cut, still counts as the release it names.
-tag_pattern = '^v[0-9]+\.[0-9]+\.[0-9]+'
+# Tag names are `vX.Y.Z`; nothing else is a release. Anchored at both ends
+# because this is a regex and not a glob: unanchored, `v[0-9]` matches
+# anywhere in a name, so `preview-v2-old` would be read as a release
+# boundary. A prerelease tag, should one ever be cut, is then not a boundary
+# either — its commits stay under "Unreleased" and land whole under the
+# version they lead to, rather than leaving an `-rc1` heading in the
+# changelog for good with the release's commits split across the two.
+tag_pattern = '^v[0-9]+\.[0-9]+\.[0-9]+$'
 
 [[git.commit_parsers]]
 # The version bump IS the release, not a change within it.

--- a/.github/scripts/bump-version.sh
+++ b/.github/scripts/bump-version.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Cut a release: set the version everywhere it is recorded, regenerate the
+# changelog, commit, and tag — in that order, in one commit.
+#
+#   .github/scripts/bump-version.sh 0.8.11
+#
+# It stops before pushing. Review the commit, then send it and its tag with
+# `git push --follow-tags`, which is what the release workflow reacts to.
+#
+# Using this is optional. Tagging by hand still works: the release workflow
+# regenerates the changelog from the tag and opens a pull request with it if
+# the committed copy has fallen behind. The script is the tidier path because
+# the changelog then lands *inside* the release commit, so the tag covers it.
+set -euo pipefail
+
+version="${1:-}"
+if [ -z "$version" ]; then
+    echo "usage: ${0##*/} X.Y.Z" >&2
+    exit 1
+fi
+
+case "$version" in
+    v*)
+        echo "Pass the bare version, not the tag name: ${version#v}" >&2
+        exit 1
+        ;;
+    [0-9]*.[0-9]*.[0-9]*) ;;
+    *)
+        echo "Not a version: $version" >&2
+        exit 1
+        ;;
+esac
+
+cd "$(git rev-parse --show-toplevel)"
+
+tag="v$version"
+if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+    echo "Tag $tag already exists" >&2
+    exit 1
+fi
+
+# A release commit should contain the release and nothing else. Refuse to
+# build one on top of unrelated edits rather than sweeping them in.
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "Working tree is dirty; commit or stash first" >&2
+    exit 1
+fi
+
+# The three places the version is written. Anywhere else derives it:
+# packaging/archlinux/PKGBUILD computes pkgver() from git describe, and every
+# crate takes `version.workspace = true`.
+sed -i '/^\[workspace\.package\]/,/^\[/ s/^version = ".*"/version = "'"$version"'"/' Cargo.toml
+sed -i 's/^Version:.*/Version:        '"$version"'/' packaging/fedora/lian-li-linux.spec
+
+# Rewrites only the workspace members' own entries in the lock file, which is
+# the 14-line diff every previous bump commit shows. A bare `cargo update`
+# would re-resolve every dependency and bury the release in unrelated churn.
+cargo update --workspace --quiet
+
+# --tag names a version that has no tag yet, so the commits since the last
+# release are filed under it instead of under "Unreleased".
+git cliff --config .github/cliff.toml --tag "$tag" -o CHANGELOG.md
+
+git add Cargo.toml Cargo.lock packaging/fedora/lian-li-linux.spec CHANGELOG.md
+git commit -m "bump version $version"
+
+# Annotated, and made now rather than left for later: git-cliff dates an
+# as-yet-untagged release from the clock, so a tag created on a later day
+# would disagree with the date already written into the changelog.
+git tag -a "$tag" -m "$tag"
+
+echo
+echo "Committed and tagged $tag. Review it, then:"
+echo "    git push --follow-tags"

--- a/.github/scripts/bump-version.sh
+++ b/.github/scripts/bump-version.sh
@@ -48,6 +48,15 @@ if ! git diff --quiet || ! git diff --cached --quiet; then
     exit 1
 fi
 
+# Checked before the first file is rewritten so a missing tool leaves no
+# half done version bump behind.
+for tool in cargo git-cliff; do
+    command -v "$tool" >/dev/null 2>&1 || {
+        echo "$tool not found on PATH" >&2
+        exit 1
+    }
+done
+
 # The three places the version is written. Anywhere else derives it:
 # packaging/archlinux/PKGBUILD computes pkgver() from git describe, and every
 # crate takes `version.workspace = true`.

--- a/.github/scripts/bump-version.sh
+++ b/.github/scripts/bump-version.sh
@@ -25,12 +25,13 @@ case "$version" in
         echo "Pass the bare version, not the tag name: ${version#v}" >&2
         exit 1
         ;;
-    [0-9]*.[0-9]*.[0-9]*) ;;
-    *)
-        echo "Not a version: $version" >&2
-        exit 1
-        ;;
 esac
+# Exactly X.Y.Z. A glob would accept `1.2.3.4` and `1a.2.3` as well, and the
+# first thing that would notice is cargo, several irreversible steps later.
+if ! [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Not a version: $version" >&2
+    exit 1
+fi
 
 cd "$(git rev-parse --show-toplevel)"
 

--- a/.github/scripts/test-workflow.py
+++ b/.github/scripts/test-workflow.py
@@ -13,16 +13,25 @@ or the full expression language. Steps that use an action are reported as
 skipped; the working tree stands in for whatever they would have produced.
 For real runner fidelity, `act` is the tool.
 
-Nothing is ever published. `gh` is replaced with a shim that reports the
-command it was handed and exits without calling GitHub, so even a run that
-reaches the publish step cannot touch a real release.
+Nothing ever leaves your machine. `gh` is replaced with a shim that reports
+the command it was handed and exits without calling GitHub, and `git` with one
+that passes everything through except `push`. So a run that reaches the
+publish step cannot touch a real release, and one that reaches the changelog
+job cannot create a branch on the remote.
+
+Local branches and worktrees that a run does create are removed afterwards,
+the same way files it writes are.
+
+One job at a time, named as the first argument; there is no `needs` between
+them here, which is why each job in release-notes.yml resolves the tag itself.
 
 Usage:
-    .github/scripts/test-workflow.py                          # dispatch, newest release
-    .github/scripts/test-workflow.py --tag v0.8.9             # dispatch, one tag
-    .github/scripts/test-workflow.py --event push --tag v0.8.9
-    .github/scripts/test-workflow.py --publish                # exercise the gh path
-    .github/scripts/test-workflow.py --repository me/my-fork  # prove the fork guard
+    .github/scripts/test-workflow.py notes                      # dispatch, newest release
+    .github/scripts/test-workflow.py notes --tag v0.8.9         # dispatch, one tag
+    .github/scripts/test-workflow.py notes --event push --tag v0.8.9
+    .github/scripts/test-workflow.py notes --publish            # exercise the gh path
+    .github/scripts/test-workflow.py notes --repository me/my-fork  # prove the fork guard
+    .github/scripts/test-workflow.py changelog --event push --tag v0.8.9
 
 Requires yq (brew install yq) to turn the workflow YAML into JSON.
 """
@@ -225,16 +234,31 @@ def untracked(root: Path) -> set[str]:
     return {line[3:] for line in out.splitlines() if line.startswith("?? ")}
 
 
+def local_branches(root: Path) -> set[str]:
+    """Local branch names, so a run's leftovers can be told from yours."""
+    out = subprocess.run(
+        ["git", "-C", str(root), "for-each-ref", "--format=%(refname:short)",
+         "refs/heads"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return set(out.splitlines())
+
+
 def make_gh_shim(bindir: Path) -> None:
     """Put a fake `gh` first on PATH so nothing can reach GitHub.
 
-    `gh release view` exits non-zero so the workflow takes its create branch,
-    which is the interesting path; everything else reports and succeeds.
+    It answers as though nothing exists yet — no release, no pull request — so
+    the workflow takes its create branches, which are the interesting ones.
+    The trace goes to stderr because the workflow captures `gh pr list` in a
+    command substitution: on stdout it would read as "a pull request is
+    already open" and the create path would never run.
     """
     shim = bindir / "gh"
     shim.write_text(
         "#!/usr/bin/env bash\n"
-        'echo "[shim] gh $*"\n'
+        'echo "[shim] gh $*" >&2\n'
         'if [ "$1" = "release" ] && [ "$2" = "view" ]; then\n'
         '  echo "[shim] pretending no release exists yet" >&2\n'
         "  exit 1\n"
@@ -244,7 +268,42 @@ def make_gh_shim(bindir: Path) -> None:
     shim.chmod(0o755)
 
 
-def run_step(step: dict, ctx: Context, root: Path, workdir: Path, bindir: Path) -> bool:
+def make_git_shim(bindir: Path) -> None:
+    """Put a `git` first on PATH that will not push.
+
+    Everything else runs for real: the workflow reads history, adds worktrees
+    and makes a commit on a throwaway branch, and all of that has to work for
+    the test to mean anything. Only the one irreversible, outward-facing verb
+    is stubbed.
+    """
+    real = shutil.which("git")
+    if real is None:  # pragma: no cover - git is required to get this far
+        sys.exit("git is not on PATH")
+    shim = bindir / "git"
+    shim.write_text(
+        "#!/usr/bin/env bash\n"
+        "# Find the subcommand: the first argument that is neither a global\n"
+        "# option nor the value of one, so `git -C dir push` is still a push.\n"
+        "sub=\"\"\n"
+        "skip=0\n"
+        'for arg in "$@"; do\n'
+        '  if [ "$skip" = 1 ]; then skip=0; continue; fi\n'
+        '  case "$arg" in\n'
+        "    -C|-c|--git-dir|--work-tree|--namespace|--exec-path) skip=1 ;;\n"
+        "    -*) ;;\n"
+        '    *) sub="$arg"; break ;;\n'
+        "  esac\n"
+        "done\n"
+        'if [ "$sub" = "push" ]; then\n'
+        '  echo "[shim] refused: git $*" >&2\n'
+        "  exit 0\n"
+        "fi\n"
+        f'exec {real} "$@"\n'
+    )
+    shim.chmod(0o755)
+
+
+def run_step(step: dict, ctx: Context, root: Path, workdir: Path) -> bool:
     """Execute one step. Returns False if it failed."""
     name = step.get("name") or step.get("uses") or "(unnamed)"
 
@@ -260,10 +319,12 @@ def run_step(step: dict, ctx: Context, root: Path, workdir: Path, bindir: Path) 
 
     out_file = workdir / "step_output"
     summary_file = workdir / "step_summary"
+    runner_temp = workdir / "runner-temp"
+    runner_temp.mkdir(exist_ok=True)
     out_file.write_text("")
 
     env = dict(os.environ)
-    env["PATH"] = f"{bindir}:{env['PATH']}"
+    env["PATH"] = f"{workdir / 'bin'}:{env['PATH']}"
     env.update(
         {
             "GITHUB_OUTPUT": str(out_file),
@@ -272,6 +333,10 @@ def run_step(step: dict, ctx: Context, root: Path, workdir: Path, bindir: Path) 
             "GITHUB_REPOSITORY": ctx.github["repository"],
             "GITHUB_EVENT_NAME": ctx.github["event_name"],
             "GITHUB_WORKSPACE": str(root),
+            # The changelog job puts its worktrees and its generated file
+            # here. Pointing it at the throwaway directory is what keeps them
+            # out of the repository.
+            "RUNNER_TEMP": str(runner_temp),
             "CI": "true",
         }
     )
@@ -315,12 +380,17 @@ def main() -> int:
     parser = argparse.ArgumentParser(
         description="Run a workflow's shell steps locally.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog=__doc__.split("Usage:")[1].split("Requires yq")[0].strip(),
+        # Keeps the docstring's own indentation, and its heading: .strip()
+        # alone dedents the first example and leaves the others sitting four
+        # spaces in, which is what RawDescriptionHelpFormatter then prints.
+        epilog="Usage:" + __doc__.split("Usage:")[1].split("Requires yq")[0].rstrip(),
     )
     parser.add_argument(
         "-w", "--workflow", default=DEFAULT_WORKFLOW, help=f"default: {DEFAULT_WORKFLOW}"
     )
-    parser.add_argument("-j", "--job", help="job to run (default: the only one)")
+    parser.add_argument(
+        "job", nargs="?", help="job to run (default: the only one in the workflow)"
+    )
     parser.add_argument(
         "--event",
         default="workflow_dispatch",
@@ -350,8 +420,9 @@ def main() -> int:
 
     jobs = workflow.get("jobs", {})
     job_id = args.job or (list(jobs)[0] if len(jobs) == 1 else None)
-    if job_id is None or job_id not in jobs:
-        sys.exit(f"Pick a job with --job. Available: {', '.join(jobs)}")
+    if job_id not in jobs:
+        named = f"No such job: {job_id}. " if args.job else "Name a job. "
+        sys.exit(f"{named}Available: {', '.join(jobs)}")
     job = jobs[job_id]
 
     ctx = Context(
@@ -381,6 +452,7 @@ def main() -> int:
     # behind. Snapshot first and remove only what this run actually created —
     # never a file that was already sitting there untracked.
     before = untracked(root)
+    branches_before = local_branches(root)
     failed = False
 
     try:
@@ -389,9 +461,10 @@ def main() -> int:
             bindir = workdir / "bin"
             bindir.mkdir()
             make_gh_shim(bindir)
+            make_git_shim(bindir)
 
             for step in job.get("steps", []):
-                if not run_step(step, ctx, root, workdir, bindir):
+                if not run_step(step, ctx, root, workdir):
                     failed = True
                     break
 
@@ -406,9 +479,23 @@ def main() -> int:
             path = root / name
             if path.is_file():
                 path.unlink()
-        if created:
+
+        # The worktrees themselves went with the temporary directory; this
+        # clears the administrative files git keeps for them. The branch the
+        # changelog job cuts is real and local, so it has to go too.
+        subprocess.run(["git", "-C", str(root), "worktree", "prune"], check=False)
+        new_branches = sorted(local_branches(root) - branches_before)
+        for branch in new_branches:
+            subprocess.run(
+                ["git", "-C", str(root), "branch", "-D", branch],
+                check=False,
+                capture_output=True,
+            )
+
+        leftovers = created + new_branches
+        if leftovers:
             print()
-            print(color(f"cleaned up: {', '.join(created)}", DIM))
+            print(color(f"cleaned up: {', '.join(leftovers)}", DIM))
 
     print()
     if failed:

--- a/.github/scripts/test-workflow.py
+++ b/.github/scripts/test-workflow.py
@@ -246,6 +246,33 @@ def local_branches(root: Path) -> set[str]:
     return set(out.splitlines())
 
 
+def worktree_branches(root: Path, workdir: Path) -> set[str]:
+    """Branches checked out in worktrees this run created under `workdir`.
+
+    Attribution by who made the branch, rather than by "it was not there when
+    we started": a branch you create in another terminal while a run is going
+    is not the harness's to delete. `git worktree list` still reports a
+    worktree whose directory has already gone, which is what makes this
+    readable after the temporary directory is removed and before the prune.
+    """
+    out = subprocess.run(
+        ["git", "-C", str(root), "worktree", "list", "--porcelain"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    branches: set[str] = set()
+    mine = False
+    ours = workdir.resolve()
+    for line in out.splitlines():
+        if line.startswith("worktree "):
+            path = Path(line[len("worktree ") :]).resolve()
+            mine = path == ours or ours in path.parents
+        elif line.startswith("branch ") and mine:
+            branches.add(line[len("branch ") :].removeprefix("refs/heads/"))
+    return branches
+
+
 def make_gh_shim(bindir: Path) -> None:
     """Put a fake `gh` first on PATH so nothing can reach GitHub.
 
@@ -454,6 +481,9 @@ def main() -> int:
     before = untracked(root)
     branches_before = local_branches(root)
     failed = False
+    # Bound outside the `with` so the cleanup below can still name the
+    # directory the run worked in after it has been removed.
+    workdir: Path | None = None
 
     try:
         with tempfile.TemporaryDirectory(prefix="test-workflow-") as tmp:
@@ -482,9 +512,13 @@ def main() -> int:
 
         # The worktrees themselves went with the temporary directory; this
         # clears the administrative files git keeps for them. The branch the
-        # changelog job cuts is real and local, so it has to go too.
+        # changelog job cuts is real and local, so it has to go too — but only
+        # a branch one of this run's own worktrees created, and only if it was
+        # not already there beforehand. Read before the prune, which is what
+        # forgets the worktrees this asks about.
+        mine = worktree_branches(root, workdir) if workdir else set()
         subprocess.run(["git", "-C", str(root), "worktree", "prune"], check=False)
-        new_branches = sorted(local_branches(root) - branches_before)
+        new_branches = sorted(mine & (local_branches(root) - branches_before))
         for branch in new_branches:
             subprocess.run(
                 ["git", "-C", str(root), "branch", "-D", branch],

--- a/.github/scripts/test-workflow.py
+++ b/.github/scripts/test-workflow.py
@@ -225,13 +225,15 @@ class Context:
 
 def untracked(root: Path) -> set[str]:
     """Paths git currently considers untracked, as a set of repo-relative names."""
+    # ls-files does not C-quote unusual paths the way `status --porcelain`
+    # does, and -z makes the split unambiguous.
     out = subprocess.run(
-        ["git", "-C", str(root), "status", "--porcelain", "--untracked-files=all"],
+        ["git", "-C", str(root), "ls-files", "--others", "--exclude-standard", "-z"],
         capture_output=True,
         text=True,
         check=True,
     ).stdout
-    return {line[3:] for line in out.splitlines() if line.startswith("?? ")}
+    return {name for name in out.split("\0") if name}
 
 
 def local_branches(root: Path) -> set[str]:

--- a/.github/scripts/test-workflow.py
+++ b/.github/scripts/test-workflow.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""Run a workflow's shell steps locally, without Docker or a runner.
+
+This is a test harness, not a GitHub Actions implementation. It reads the
+`run:` blocks straight out of the workflow file and executes them with the
+environment a runner would provide, so what gets tested is the text that
+ships rather than a retyped copy of it. That is enough to catch the bugs
+these workflows actually have — shell quoting, tag parsing, a condition
+written the wrong way round.
+
+What it does NOT do: containers, `uses:` steps, matrices, services, caches,
+or the full expression language. Steps that use an action are reported as
+skipped; the working tree stands in for whatever they would have produced.
+For real runner fidelity, `act` is the tool.
+
+Nothing is ever published. `gh` is replaced with a shim that reports the
+command it was handed and exits without calling GitHub, so even a run that
+reaches the publish step cannot touch a real release.
+
+Usage:
+    .github/scripts/test-workflow.py                          # dispatch, newest release
+    .github/scripts/test-workflow.py --tag v0.8.9             # dispatch, one tag
+    .github/scripts/test-workflow.py --event push --tag v0.8.9
+    .github/scripts/test-workflow.py --publish                # exercise the gh path
+    .github/scripts/test-workflow.py --repository me/my-fork  # prove the fork guard
+
+Requires yq (brew install yq) to turn the workflow YAML into JSON.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+DEFAULT_WORKFLOW = ".github/workflows/release-notes.yml"
+
+# `${{ github.event_name }}` and friends. Only the contexts these workflows
+# actually use are resolved; anything else is reported rather than guessed at,
+# so the harness can never quietly test something other than what runs in CI.
+EXPR_RE = re.compile(r"\$\{\{\s*(?P<expr>.+?)\s*\}\}")
+
+GREEN, RED, YELLOW, DIM, RESET = "\033[32m", "\033[31m", "\033[33m", "\033[2m", "\033[0m"
+
+
+def color(text: str, c: str) -> str:
+    return f"{c}{text}{RESET}" if sys.stdout.isatty() else text
+
+
+def repo_root() -> Path:
+    out = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return Path(out.stdout.strip())
+
+
+def origin_slug(root: Path) -> str:
+    """Best guess at owner/repo, so the default run matches the real one."""
+    try:
+        url = subprocess.run(
+            ["git", "-C", str(root), "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    except subprocess.CalledProcessError:
+        return "owner/repo"
+    match = re.search(r"[:/]([^/:]+/[^/]+?)(?:\.git)?$", url)
+    return match.group(1) if match else "owner/repo"
+
+
+def default_branch(root: Path) -> str:
+    """The branch origin/HEAD points at, which is what GitHub calls default."""
+    try:
+        ref = subprocess.run(
+            ["git", "-C", str(root), "symbolic-ref", "refs/remotes/origin/HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        return ref.rsplit("/", 1)[-1]
+    except subprocess.CalledProcessError:
+        return "main"
+
+
+def load_workflow(path: Path) -> dict:
+    """Parse the workflow via yq, which is the only external dependency."""
+    if not shutil.which("yq"):
+        sys.exit("yq not found. Install it (brew install yq) or use act instead.")
+    out = subprocess.run(
+        ["yq", "-o=json", str(path)], capture_output=True, text=True
+    )
+    if out.returncode != 0:
+        sys.exit(f"yq could not parse {path}:\n{out.stderr.strip()}")
+    return json.loads(out.stdout)
+
+
+class Context:
+    """The slice of the GitHub expression contexts these workflows read."""
+
+    def __init__(
+        self,
+        event: str,
+        repository: str,
+        ref_name: str,
+        inputs: dict,
+        default_branch: str = "main",
+    ):
+        self.github = {
+            "event_name": event,
+            "repository": repository,
+            "ref_name": ref_name,
+            "ref_type": "tag" if event == "push" else "branch",
+            "token": "fake-token-for-local-run",
+            # The event payload, as far as these workflows read into it.
+            "event": {"repository": {"default_branch": default_branch}},
+        }
+        self.inputs = inputs
+        self.steps: dict[str, dict[str, str]] = {}
+
+    def lookup(self, path: str):
+        """Resolve a dotted context reference, e.g. steps.resolve.outputs.tag.
+
+        Walks nested dicts, so a deeper payload path such as
+        github.event.repository.default_branch resolves without a special
+        case for every depth.
+        """
+        parts = path.split(".")
+        roots = {"github": self.github, "inputs": self.inputs, "steps": self.steps}
+        if parts[0] not in roots:
+            raise KeyError(path)
+        value = roots[parts[0]]
+        for part in parts[1:]:
+            if not isinstance(value, dict) or part not in value:
+                # A step output read before that step has run is legitimately
+                # empty. Only the documented 4-part shape is treated that way,
+                # so a mistyped path still surfaces as unsupported rather than
+                # silently resolving to "".
+                if parts[0] == "steps" and len(parts) == 4 and parts[2] == "outputs":
+                    return ""
+                raise KeyError(path)
+            value = value[part]
+        return value
+
+    def substitute(self, value: str) -> str:
+        """Expand every ${{ ... }} in a string to its context value."""
+
+        def replace(match: re.Match[str]) -> str:
+            expr = match.group("expr")
+            try:
+                return str(self.lookup(expr))
+            except KeyError:
+                print(
+                    color(f"    ! unsupported expression: {expr}", YELLOW),
+                    file=sys.stderr,
+                )
+                return ""
+
+        return EXPR_RE.sub(replace, value)
+
+    def evaluate(self, condition: str) -> bool:
+        """Evaluate an `if:` expression.
+
+        Handles the subset these workflows use: context references, string
+        literals, ==, !=, && , || and !. The expression is translated to
+        Python and evaluated with no builtins in scope. Input comes from a
+        workflow file in this repo, not from anything a third party controls.
+        """
+        expr = EXPR_RE.sub(lambda m: m.group("expr"), condition).strip()
+
+        # Stash string literals before touching identifiers: without this the
+        # identifier pass rewrites the *contents* of 'workflow_dispatch' and
+        # 'sgtaziz/lian-li-linux', and every comparison silently becomes False.
+        literals: list[str] = []
+
+        def stash(match: re.Match[str]) -> str:
+            literals.append(match.group(0))
+            return f"__LIT{len(literals) - 1}__"
+
+        expr = re.sub(r"'[^']*'|\"[^\"]*\"", stash, expr)
+
+        def to_literal(match: re.Match[str]) -> str:
+            path = match.group(0)
+            if path.startswith("__LIT") or path in ("true", "false", "and", "or", "not"):
+                return path
+            try:
+                value = self.lookup(path)
+            except KeyError:
+                print(color(f"    ! unsupported in if: {path}", YELLOW), file=sys.stderr)
+                return "False"
+            if isinstance(value, bool):
+                return str(value)
+            # An empty string is falsey in both languages, which is what an
+            # unset input should be.
+            return repr(str(value))
+
+        expr = expr.replace("&&", " and ").replace("||", " or ")
+        expr = re.sub(r"!(?!=)", " not ", expr)
+        expr = re.sub(r"[A-Za-z_][A-Za-z0-9_.]*", to_literal, expr)
+        expr = re.sub(r"__LIT(\d+)__", lambda m: literals[int(m.group(1))], expr)
+        try:
+            return bool(eval(expr, {"__builtins__": {}}, {}))  # noqa: S307
+        except Exception as exc:  # pragma: no cover - surfaced to the user
+            print(color(f"    ! could not evaluate: {condition} ({exc})", YELLOW))
+            return False
+
+
+def untracked(root: Path) -> set[str]:
+    """Paths git currently considers untracked, as a set of repo-relative names."""
+    out = subprocess.run(
+        ["git", "-C", str(root), "status", "--porcelain", "--untracked-files=all"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return {line[3:] for line in out.splitlines() if line.startswith("?? ")}
+
+
+def make_gh_shim(bindir: Path) -> None:
+    """Put a fake `gh` first on PATH so nothing can reach GitHub.
+
+    `gh release view` exits non-zero so the workflow takes its create branch,
+    which is the interesting path; everything else reports and succeeds.
+    """
+    shim = bindir / "gh"
+    shim.write_text(
+        "#!/usr/bin/env bash\n"
+        'echo "[shim] gh $*"\n'
+        'if [ "$1" = "release" ] && [ "$2" = "view" ]; then\n'
+        '  echo "[shim] pretending no release exists yet" >&2\n'
+        "  exit 1\n"
+        "fi\n"
+        "exit 0\n"
+    )
+    shim.chmod(0o755)
+
+
+def run_step(step: dict, ctx: Context, root: Path, workdir: Path, bindir: Path) -> bool:
+    """Execute one step. Returns False if it failed."""
+    name = step.get("name") or step.get("uses") or "(unnamed)"
+
+    if "uses" in step:
+        print(color(f"  ~ {name}", DIM))
+        print(color("    skipped: action steps are not run locally", DIM))
+        return True
+
+    if "if" in step and not ctx.evaluate(str(step["if"])):
+        print(color(f"  ~ {name}", DIM))
+        print(color(f"    skipped by if: {step['if']}", DIM))
+        return True
+
+    out_file = workdir / "step_output"
+    summary_file = workdir / "step_summary"
+    out_file.write_text("")
+
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}:{env['PATH']}"
+    env.update(
+        {
+            "GITHUB_OUTPUT": str(out_file),
+            "GITHUB_STEP_SUMMARY": str(summary_file),
+            "GITHUB_REF_NAME": ctx.github["ref_name"],
+            "GITHUB_REPOSITORY": ctx.github["repository"],
+            "GITHUB_EVENT_NAME": ctx.github["event_name"],
+            "GITHUB_WORKSPACE": str(root),
+            "CI": "true",
+        }
+    )
+    for key, value in (step.get("env") or {}).items():
+        env[key] = ctx.substitute(str(value))
+
+    print(color(f"  > {name}", GREEN))
+    proc = subprocess.run(
+        ["bash", "-e", "-o", "pipefail", "-c", step["run"]],
+        cwd=root,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    for line in (proc.stdout + proc.stderr).splitlines():
+        print(f"    {line}")
+
+    # Feed `key=value` lines back into the steps context for later steps.
+    step_id = step.get("id")
+    if step_id:
+        outputs = {}
+        for line in out_file.read_text().splitlines():
+            if "=" in line:
+                key, _, value = line.partition("=")
+                outputs[key] = value
+        if outputs:
+            # Stored under an "outputs" key because that is the shape the
+            # expression `steps.<id>.outputs.<name>` walks. Flattening it here
+            # makes every such reference resolve to "" instead of failing.
+            ctx.steps[step_id] = {"outputs": outputs}
+            print(color(f"    outputs: {outputs}", DIM))
+
+    if proc.returncode != 0:
+        print(color(f"    FAILED (exit {proc.returncode})", RED))
+        return False
+    return True
+
+
+def main() -> int:
+    root = repo_root()
+    parser = argparse.ArgumentParser(
+        description="Run a workflow's shell steps locally.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__.split("Usage:")[1].split("Requires yq")[0].strip(),
+    )
+    parser.add_argument(
+        "-w", "--workflow", default=DEFAULT_WORKFLOW, help=f"default: {DEFAULT_WORKFLOW}"
+    )
+    parser.add_argument("-j", "--job", help="job to run (default: the only one)")
+    parser.add_argument(
+        "--event",
+        default="workflow_dispatch",
+        choices=["workflow_dispatch", "push"],
+        help="event to simulate (default: workflow_dispatch)",
+    )
+    parser.add_argument("--tag", default="", help="tag input, or the pushed tag")
+    parser.add_argument(
+        "--publish", action="store_true", help="set the publish input to true"
+    )
+    parser.add_argument(
+        "--repository",
+        default=origin_slug(root),
+        help="owner/repo to run as; change it to test a repository guard",
+    )
+    parser.add_argument(
+        "--default-branch",
+        default=default_branch(root),
+        help="branch a release is allowed to come from (default: origin/HEAD)",
+    )
+    args = parser.parse_args()
+
+    workflow_path = root / args.workflow
+    if not workflow_path.exists():
+        sys.exit(f"No such workflow: {workflow_path}")
+    workflow = load_workflow(workflow_path)
+
+    jobs = workflow.get("jobs", {})
+    job_id = args.job or (list(jobs)[0] if len(jobs) == 1 else None)
+    if job_id is None or job_id not in jobs:
+        sys.exit(f"Pick a job with --job. Available: {', '.join(jobs)}")
+    job = jobs[job_id]
+
+    ctx = Context(
+        event=args.event,
+        repository=args.repository,
+        # On a tag push the ref name IS the tag, which is what the workflow reads.
+        ref_name=args.tag if args.event == "push" else "main",
+        inputs={"tag": args.tag, "publish": args.publish},
+        default_branch=args.default_branch,
+    )
+
+    print(f"workflow : {args.workflow}")
+    print(f"job      : {job_id}")
+    print(f"event    : {args.event}")
+    print(f"repo     : {args.repository}")
+    print(f"branch   : {args.default_branch}")
+    print(f"inputs   : tag={args.tag!r} publish={args.publish}")
+    print()
+
+    if "if" in job and not ctx.evaluate(str(job["if"])):
+        print(color(f"job skipped by its if: {job['if']}", YELLOW))
+        print(color("(this is a result, not a failure)", DIM))
+        return 0
+
+    # A runner works in a throwaway checkout; here the steps run against your
+    # real tree, so anything they write (notes.md, for one) would be left
+    # behind. Snapshot first and remove only what this run actually created —
+    # never a file that was already sitting there untracked.
+    before = untracked(root)
+    failed = False
+
+    try:
+        with tempfile.TemporaryDirectory(prefix="test-workflow-") as tmp:
+            workdir = Path(tmp)
+            bindir = workdir / "bin"
+            bindir.mkdir()
+            make_gh_shim(bindir)
+
+            for step in job.get("steps", []):
+                if not run_step(step, ctx, root, workdir, bindir):
+                    failed = True
+                    break
+
+            summary = workdir / "step_summary"
+            if not failed and summary.exists() and summary.read_text().strip():
+                print()
+                print(color("--- job summary ---", DIM))
+                print(summary.read_text().rstrip())
+    finally:
+        created = sorted(untracked(root) - before)
+        for name in created:
+            path = root / name
+            if path.is_file():
+                path.unlink()
+        if created:
+            print()
+            print(color(f"cleaned up: {', '.join(created)}", DIM))
+
+    print()
+    if failed:
+        print(color("workflow FAILED", RED))
+        return 1
+    print(color("workflow passed", GREEN))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -39,6 +39,12 @@ on:
 permissions:
   contents: write
 
+# One run per ref at a time: two runs for the same tag race the release
+# edit and the changelog branch push. Never cancel, queued runs catch up.
+concurrency:
+  group: release-notes-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   notes:
     # Automatic runs are limited to the source repository. A fork inherits both
@@ -98,6 +104,12 @@ jobs:
             exit 1
             ;;
         esac
+        # Only vX.Y.Z is a release. Anything else is a typo or a test tag and
+        # must not reach the publish step.
+        if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "::error::Not a release tag: $TAG (expected vX.Y.Z)"
+          exit 1
+        fi
         # A typo in the manual input would otherwise surface further down as
         # whatever git says about an unknown revision.
         if ! git rev-parse -q --verify "refs/tags/$TAG^{commit}" >/dev/null; then
@@ -235,6 +247,12 @@ jobs:
             exit 1
             ;;
         esac
+        # Only vX.Y.Z is a release. Anything else is a typo or a test tag and
+        # must not reach the changelog job.
+        if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "::error::Not a release tag: $TAG (expected vX.Y.Z)"
+          exit 1
+        fi
         if ! git rev-parse -q --verify "refs/tags/$TAG^{commit}" >/dev/null; then
           echo "::error::No such tag: $TAG"
           exit 1

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,159 @@
+name: Release Notes
+
+# Publishes the notes for a release from the history that already exists.
+# Nothing about the commit or tagging workflow has to change: push a `vX.Y.Z`
+# tag exactly as before and the Release page is filled in from the commits
+# that tag introduced.
+#
+# Run it manually first (Actions -> Release Notes -> Run workflow) to see the
+# output for any tag in the job summary. That preview publishes nothing unless
+# you tick "publish".
+#
+# Tag pushes only trigger this in the source repository — see the guard on the
+# job below — so forks stay quiet unless their owner runs it by hand.
+
+on:
+  push:
+    tags: [ "v*" ]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to generate notes for (blank = newest)'
+        required: false
+        default: ''
+      publish:
+        description: 'Publish to the GitHub Release (otherwise preview only)'
+        type: boolean
+        required: false
+        default: false
+
+# Only the Release body is written. No commits are pushed by this workflow.
+permissions:
+  contents: write
+
+jobs:
+  notes:
+    # Automatic runs are limited to the source repository. A fork inherits both
+    # this workflow and, on the first `git push --tags`, every upstream tag —
+    # without this guard each of those pushes would publish releases on the
+    # fork. Manual dispatch is deliberately exempt so a fork owner can still
+    # preview or test the workflow from the Actions tab.
+    #
+    # The slug is spelled out rather than read from a top-level `env:` because
+    # a job-level `if:` cannot see the env context (only github, needs, vars
+    # and inputs). Keep it in step with the URLs in .github/cliff.toml.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.repository == 'sgtaziz/lian-li-linux'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        # The generator needs the full history and every tag: notes for
+        # v0.8.10 are the commits in v0.8.9..v0.8.10, and the default
+        # fetch-depth of 1 has neither. Submodules are not fetched because
+        # nothing here builds — this reads git metadata only.
+        fetch-depth: 0
+
+    - name: Verify the tag is on the default branch
+      if: github.event_name == 'push'
+      env:
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+      run: |
+        # `on.push.branches` cannot express this. A tag push carries
+        # refs/tags/<name> and belongs to no branch, so GitHub ignores a
+        # branch filter on it entirely — the workflow would still run.
+        #
+        # It matters because a tag can be created on any commit, including one
+        # on a feature branch that never merged. Publishing a release from
+        # such a commit would announce code that is not on the default branch,
+        # so the containment check has to be made explicitly.
+        #
+        # ^{commit} dereferences the annotated tag object to the commit it
+        # points at; GITHUB_SHA is not reliably that commit for annotated tags.
+        if git merge-base --is-ancestor "${GITHUB_REF_NAME}^{commit}" "origin/$DEFAULT_BRANCH"; then
+          echo "$GITHUB_REF_NAME is on $DEFAULT_BRANCH"
+        else
+          echo "::error::$GITHUB_REF_NAME points at a commit that is not on $DEFAULT_BRANCH; refusing to publish"
+          exit 1
+        fi
+
+    - name: Resolve tag
+      id: resolve
+      env:
+        # Passed as an environment variable rather than interpolated into the
+        # script body: `${{ inputs.tag }}` expands before bash sees the line,
+        # so a crafted input would run as shell. Via env it is only ever data.
+        INPUT_TAG: ${{ inputs.tag }}
+        EVENT: ${{ github.event_name }}
+      run: |
+        if [ "$EVENT" = "push" ]; then
+          TAG="$GITHUB_REF_NAME"
+        else
+          TAG="$INPUT_TAG"
+        fi
+        # A tag name cannot contain whitespace, and anything outside this set
+        # has no business reaching $GITHUB_OUTPUT, where a newline would let
+        # the value forge a second output.
+        case "$TAG" in
+          *[!A-Za-z0-9._/-]*)
+            echo "Refusing suspicious tag name: $TAG" >&2
+            exit 1
+            ;;
+        esac
+        echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+    # Installs the pinned binary and verifies its checksum. Skipped by the
+    # local harness, which uses whatever git-cliff is already on PATH.
+    - name: Install git-cliff
+      uses: taiki-e/install-action@v2
+      with:
+        tool: git-cliff@2.14.1
+
+    - name: Generate notes
+      id: generate
+      env:
+        TAG: ${{ steps.resolve.outputs.tag }}
+      run: |
+        # One release is the range from its predecessor, which is what
+        # `git describe --abbrev=0 <tag>^` finds. The oldest tag has no
+        # predecessor, so it takes everything up to itself instead.
+        # An empty TAG means the newest release: --latest.
+        if [ -z "$TAG" ]; then
+          range=(--latest)
+        else
+          prev=$(git describe --tags --abbrev=0 "${TAG}^" 2>/dev/null || true)
+          if [ -z "$prev" ]; then
+            # The oldest tag has no predecessor to diff against, so start from
+            # the root commit instead. git ranges exclude their start point,
+            # so the repository's initial commit is the one thing this cannot
+            # list — only ever reachable by previewing the very first release.
+            prev=$(git rev-list --max-parents=0 "$TAG" | tail -1)
+          fi
+          range=("${prev}..${TAG}")
+        fi
+        # --strip header: the document header belongs on a CHANGELOG file,
+        # not in the body of a single GitHub Release.
+        git cliff --config .github/cliff.toml --strip header "${range[@]}" -o notes.md
+
+    - name: Add to job summary
+      run: cat notes.md >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Publish to GitHub Release
+      if: github.event_name == 'push' || inputs.publish
+      env:
+        GH_TOKEN: ${{ github.token }}
+        TAG: ${{ steps.resolve.outputs.tag }}
+      run: |
+        # A tag push may or may not already have a Release attached: the
+        # maintainer may have drafted one by hand, and re-running this job
+        # must not fail on the second attempt. So edit when one exists and
+        # create when it does not, rather than assuming either.
+        if gh release view "$TAG" >/dev/null 2>&1; then
+          gh release edit "$TAG" --notes-file notes.md
+          echo "Updated the notes on release $TAG"
+        else
+          gh release create "$TAG" --title "$TAG" --notes-file notes.md
+          echo "Created release $TAG"
+        fi

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -11,6 +11,13 @@ name: Release Notes
 #
 # Tag pushes only trigger this in the source repository — see the guard on the
 # job below — so forks stay quiet unless their owner runs it by hand.
+#
+# A second job keeps CHANGELOG.md current. It regenerates the file from the
+# tag and opens a pull request when the committed copy has fallen behind, so
+# tagging by hand loses nothing. .github/scripts/bump-version.sh does the same
+# work locally as part of cutting the release, which is tidier — the changelog
+# lands inside the release commit, so the tag covers it — and leaves that job
+# with nothing to open.
 
 on:
   push:
@@ -27,7 +34,8 @@ on:
         required: false
         default: false
 
-# Only the Release body is written. No commits are pushed by this workflow.
+# What the `notes` job needs: the Release body, and nothing else. The
+# `changelog` job asks for more, and asks for it itself.
 permissions:
   contents: write
 
@@ -137,6 +145,8 @@ jobs:
         # not in the body of a single GitHub Release.
         git cliff --config .github/cliff.toml --strip header "${range[@]}" -o notes.md
 
+    # Where the notes are read: rendered, and on the run's own page. Echoing
+    # the file here as well would put the whole thing on screen twice.
     - name: Add to job summary
       run: cat notes.md >> "$GITHUB_STEP_SUMMARY"
 
@@ -156,4 +166,139 @@ jobs:
         else
           gh release create "$TAG" --title "$TAG" --notes-file notes.md
           echo "Created release $TAG"
+        fi
+
+  # The safety net for a release tagged by hand. It regenerates the changelog
+  # from the tag and opens a pull request if the committed copy differs, so
+  # the file stays current whether or not .github/scripts/bump-version.sh was
+  # used. When it was, the regenerated file matches and this job does nothing.
+  #
+  # A pull request rather than a push to the default branch: pushing a new
+  # branch is not what branch protection guards, so this needs no exception
+  # and the merge stays a human decision.
+  changelog:
+    needs: notes
+    if: github.event_name == 'push' || inputs.publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write        # push the branch the pull request is opened from
+      pull-requests: write   # open it
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    # Recomputed rather than read from `needs.notes.outputs`, so this job
+    # stays runnable — and testable — on its own.
+    - name: Resolve tag
+      id: resolve
+      env:
+        INPUT_TAG: ${{ inputs.tag }}
+        EVENT: ${{ github.event_name }}
+      run: |
+        if [ "$EVENT" = "push" ]; then
+          TAG="$GITHUB_REF_NAME"
+        else
+          TAG="$INPUT_TAG"
+        fi
+        if [ -z "$TAG" ]; then
+          echo "::error::A changelog needs a specific release; pass a tag."
+          exit 1
+        fi
+        case "$TAG" in
+          *[!A-Za-z0-9._/-]*)
+            echo "Refusing suspicious tag name: $TAG" >&2
+            exit 1
+            ;;
+        esac
+        echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+    - name: Install git-cliff
+      uses: taiki-e/install-action@v2
+      with:
+        tool: git-cliff@2.14.1
+
+    - name: Regenerate the changelog at the tag
+      id: regen
+      env:
+        TAG: ${{ steps.resolve.outputs.tag }}
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+      run: |
+        # Both checkouts are worktrees, so the job never moves the primary
+        # checkout off its ref. A re-run then starts from the same state as
+        # the first, and a local test cannot strand your tree on a branch.
+        tag_tree="$RUNNER_TEMP/at-tag"
+        git worktree add --detach "$tag_tree" "$TAG"
+
+        # git-cliff walks from HEAD, so it has to stand on the tag. Generated
+        # from the default branch instead, any commit that landed after the
+        # tag would render as an "Unreleased" section inside the changelog
+        # for this release.
+        git -C "$tag_tree" cliff \
+          --config "$GITHUB_WORKSPACE/.github/cliff.toml" \
+          -o "$RUNNER_TEMP/CHANGELOG.md"
+
+        # Generated at the tag, but committed onto the default branch: the
+        # pull request's merge base is then current main and its diff is this
+        # one file. A branch cut from the tag would look right and be stale.
+        branch="chore/changelog-$TAG"
+        pr_tree="$RUNNER_TEMP/pr"
+        git worktree add -B "$branch" "$pr_tree" "origin/$DEFAULT_BRANCH"
+        cp "$RUNNER_TEMP/CHANGELOG.md" "$pr_tree/CHANGELOG.md"
+
+        # Staged before comparing because `git diff` alone says nothing about
+        # a file the default branch does not have yet — the first release to
+        # run this would look like a no-op.
+        git -C "$pr_tree" add CHANGELOG.md
+        if git -C "$pr_tree" diff --cached --quiet; then
+          echo "CHANGELOG.md is already current for $TAG; nothing to open."
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          echo "worktree=$pr_tree" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Open the changelog pull request
+      if: steps.regen.outputs.changed == 'true'
+      env:
+        GH_TOKEN: ${{ github.token }}
+        TAG: ${{ steps.resolve.outputs.tag }}
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        BRANCH: ${{ steps.regen.outputs.branch }}
+        WORKTREE: ${{ steps.regen.outputs.worktree }}
+      run: |
+        git -C "$WORKTREE" \
+          -c user.name='github-actions[bot]' \
+          -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+          commit -m "docs(changelog): regenerate for $TAG"
+
+        # --force-with-lease so re-running the workflow for a tag replaces the
+        # branch rather than failing, while still refusing to overwrite a push
+        # this job has not seen.
+        git -C "$WORKTREE" push --force-with-lease origin "$BRANCH"
+
+        cat > "$RUNNER_TEMP/body.md" <<EOF
+        Regenerated from the history at \`$TAG\` by \`.github/workflows/release-notes.yml\`.
+
+        Nothing was written by hand: rerun the workflow to refresh this branch.
+        Committing the changelog as part of the release instead — so the tag
+        covers it and this pull request is never opened — is what
+        \`.github/scripts/bump-version.sh\` does.
+
+        No checks will report here. A pull request opened with \`GITHUB_TOKEN\`
+        does not raise the \`pull_request\` event, so \`Rust\` does not run on it.
+        EOF
+
+        # A branch can already have an open pull request from an earlier run
+        # for the same tag; the push above has already updated it.
+        if [ -n "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')" ]; then
+          echo "A pull request for $BRANCH is already open; its branch now has the notes for $TAG."
+        else
+          gh pr create \
+            --base "$DEFAULT_BRANCH" \
+            --head "$BRANCH" \
+            --title "docs(changelog): regenerate for $TAG" \
+            --body-file "$RUNNER_TEMP/body.md"
         fi

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -64,29 +64,6 @@ jobs:
         # nothing here builds — this reads git metadata only.
         fetch-depth: 0
 
-    - name: Verify the tag is on the default branch
-      if: github.event_name == 'push'
-      env:
-        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-      run: |
-        # `on.push.branches` cannot express this. A tag push carries
-        # refs/tags/<name> and belongs to no branch, so GitHub ignores a
-        # branch filter on it entirely — the workflow would still run.
-        #
-        # It matters because a tag can be created on any commit, including one
-        # on a feature branch that never merged. Publishing a release from
-        # such a commit would announce code that is not on the default branch,
-        # so the containment check has to be made explicitly.
-        #
-        # ^{commit} dereferences the annotated tag object to the commit it
-        # points at; GITHUB_SHA is not reliably that commit for annotated tags.
-        if git merge-base --is-ancestor "${GITHUB_REF_NAME}^{commit}" "origin/$DEFAULT_BRANCH"; then
-          echo "$GITHUB_REF_NAME is on $DEFAULT_BRANCH"
-        else
-          echo "::error::$GITHUB_REF_NAME points at a commit that is not on $DEFAULT_BRANCH; refusing to publish"
-          exit 1
-        fi
-
     - name: Resolve tag
       id: resolve
       env:
@@ -101,6 +78,17 @@ jobs:
         else
           TAG="$INPUT_TAG"
         fi
+        # A blank tag input means "the newest release". Turning that into the
+        # tag itself here, rather than leaving it empty for each later step to
+        # interpret, is what lets the containment check, the commit range and
+        # the release being written to all name one concrete release.
+        if [ -z "$TAG" ]; then
+          TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null || true)
+          if [ -z "$TAG" ]; then
+            echo "::error::No release tag found; nothing to generate notes for."
+            exit 1
+          fi
+        fi
         # A tag name cannot contain whitespace, and anything outside this set
         # has no business reaching $GITHUB_OUTPUT, where a newline would let
         # the value forge a second output.
@@ -110,7 +98,41 @@ jobs:
             exit 1
             ;;
         esac
+        # A typo in the manual input would otherwise surface further down as
+        # whatever git says about an unknown revision.
+        if ! git rev-parse -q --verify "refs/tags/$TAG^{commit}" >/dev/null; then
+          echo "::error::No such tag: $TAG"
+          exit 1
+        fi
         echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+    # Not only on a tag push. Manual dispatch is exempt from the repository
+    # guard above so a fork owner can preview, and a preview publishes nothing
+    # — but the moment `publish` is ticked it writes a real release, so the
+    # same rule has to hold.
+    - name: Verify the tag is on the default branch
+      if: github.event_name == 'push' || inputs.publish
+      env:
+        TAG: ${{ steps.resolve.outputs.tag }}
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+      run: |
+        # `on.push.branches` cannot express this. A tag push carries
+        # refs/tags/<name> and belongs to no branch, so GitHub ignores a
+        # branch filter on it entirely — the workflow would still run.
+        #
+        # It matters because a tag can be created on any commit, including one
+        # on a feature branch that never merged. Publishing a release from
+        # such a commit would announce code that is not on the default branch,
+        # so the containment check has to be made explicitly.
+        #
+        # ^{commit} dereferences the annotated tag object to the commit it
+        # points at; GITHUB_SHA is not reliably that commit for annotated tags.
+        if git merge-base --is-ancestor "${TAG}^{commit}" "origin/$DEFAULT_BRANCH"; then
+          echo "$TAG is on $DEFAULT_BRANCH"
+        else
+          echo "::error::$TAG points at a commit that is not on $DEFAULT_BRANCH; refusing to publish"
+          exit 1
+        fi
 
     # Installs the pinned binary and verifies its checksum. Skipped by the
     # local harness, which uses whatever git-cliff is already on PATH.
@@ -125,25 +147,20 @@ jobs:
         TAG: ${{ steps.resolve.outputs.tag }}
       run: |
         # One release is the range from its predecessor, which is what
-        # `git describe --abbrev=0 <tag>^` finds. The oldest tag has no
-        # predecessor, so it takes everything up to itself instead.
-        # An empty TAG means the newest release: --latest.
-        if [ -z "$TAG" ]; then
-          range=(--latest)
-        else
-          prev=$(git describe --tags --abbrev=0 "${TAG}^" 2>/dev/null || true)
-          if [ -z "$prev" ]; then
-            # The oldest tag has no predecessor to diff against, so start from
-            # the root commit instead. git ranges exclude their start point,
-            # so the repository's initial commit is the one thing this cannot
-            # list — only ever reachable by previewing the very first release.
-            prev=$(git rev-list --max-parents=0 "$TAG" | tail -1)
-          fi
-          range=("${prev}..${TAG}")
+        # `git describe --abbrev=0 <tag>^` finds. The tag is always concrete
+        # by now, so there is one range to compute rather than a special case
+        # for "newest" — for the newest release this is what --latest means.
+        prev=$(git describe --tags --abbrev=0 --match 'v[0-9]*' "${TAG}^" 2>/dev/null || true)
+        if [ -z "$prev" ]; then
+          # The oldest tag has no predecessor to diff against, so start from
+          # the root commit instead. git ranges exclude their start point, so
+          # the repository's initial commit is the one thing this cannot list
+          # — only ever reachable by previewing the very first release.
+          prev=$(git rev-list --max-parents=0 "$TAG" | tail -1)
         fi
         # --strip header: the document header belongs on a CHANGELOG file,
         # not in the body of a single GitHub Release.
-        git cliff --config .github/cliff.toml --strip header "${range[@]}" -o notes.md
+        git cliff --config .github/cliff.toml --strip header "${prev}..${TAG}" -o notes.md
 
     # Where the notes are read: rendered, and on the run's own page. Echoing
     # the file here as well would put the whole thing on screen twice.
@@ -202,9 +219,15 @@ jobs:
         else
           TAG="$INPUT_TAG"
         fi
+        # Resolved the same way as in `notes`, so a manual run with the tag
+        # left blank regenerates the changelog for the release whose notes
+        # that job just published, rather than refusing.
         if [ -z "$TAG" ]; then
-          echo "::error::A changelog needs a specific release; pass a tag."
-          exit 1
+          TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null || true)
+          if [ -z "$TAG" ]; then
+            echo "::error::No release tag found; nothing to regenerate for."
+            exit 1
+          fi
         fi
         case "$TAG" in
           *[!A-Za-z0-9._/-]*)
@@ -212,6 +235,10 @@ jobs:
             exit 1
             ;;
         esac
+        if ! git rev-parse -q --verify "refs/tags/$TAG^{commit}" >/dev/null; then
+          echo "::error::No such tag: $TAG"
+          exit 1
+        fi
         echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
     - name: Install git-cliff

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -39,10 +39,10 @@ on:
 permissions:
   contents: write
 
-# One run per ref at a time: two runs for the same tag race the release
-# edit and the changelog branch push. Never cancel, queued runs catch up.
+# One release run at a time. A fixed key, not the ref: a manual run on a
+# branch and a tag push for the same release must still serialize.
 concurrency:
-  group: release-notes-${{ github.ref }}
+  group: release-notes
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
I noticed this repo did not have much along the lines of "release notes" or a running changelog, so.. would you perhaps be interested in any of these changes?

I tried to implement this in the least intrusive way possible, such as release notes being generated automatically in response to a new release tag appearing on `main`.. but I wasn't sure how you bump the project version for new releases, so that is covered here by a new `bump-version.sh` script, matching existing bump commits, but with `CHANGELOG.md` generation built in. failing that, there is also a conditional GitHub Actions job that can automatically open a PR with the changelog updates after a release has been cut.

this also includes a `test-workflows.py` script, which can be used to do mock test runs of these GitHub Actions workflows locally. run `python .github/scripts/test-workflows.py --help` to see what it does.

and yes, in case the commit messages weren't clear enough: I did indeed enlist the help of Claude Code for some of this. feel free to request changes and/or change any of this yourself if you would like.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Release notes can be generated automatically when version tags are created or manually requested.
  - GitHub Releases can be created or updated with changes since the previous release.
  - The project changelog is regenerated and submitted for review when release content changes.

- **Release Management**
  - Release tooling validates version numbers, updates project metadata, refreshes the changelog, commits release changes, and creates annotated tags.
  - Changes are organized into readable sections, including support for unconventional commits and linked issue or pull request references.
  - Release workflows can be tested locally before execution.
  - Release operations include checks for existing tags, uncommitted changes, and required tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->