### PR TITLE
Fix HID H.264 stalls caused by periodic recovery checks

### DIFF
--- a/crates/lianli-daemon/src/service/media.rs
+++ b/crates/lianli-daemon/src/service/media.rs
@@ -307,7 +307,7 @@ impl ServiceManager {
                             if let Some(d) =
                                 self.registry.aio_lcd_devices.remove(&candidate.device_id)
                             {
-                                Ok(LcdBackend::HidLcd(Arc::new(parking_lot::Mutex::new(d))))
+                                Ok(LcdBackend::HidLcd(Arc::new(super::runtime::HidLcd::new(d))))
                             } else if let Some(backend) =
                                 self.registry.hid_backends.get(&candidate.device_id)
                             {
@@ -317,7 +317,7 @@ impl ServiceManager {
                                     Arc::clone(backend),
                                 ) {
                                     Some(result) => result.map(|d| {
-                                        LcdBackend::HidLcd(Arc::new(parking_lot::Mutex::new(d)))
+                                        LcdBackend::HidLcd(Arc::new(super::runtime::HidLcd::new(d)))
                                     }),
                                     None => Err(anyhow::anyhow!("Not an LCD device")),
                                 }
@@ -338,7 +338,7 @@ impl ServiceManager {
                                     Arc::clone(backend),
                                 ) {
                                     Some(result) => result.map(|d| {
-                                        LcdBackend::HidLcd(Arc::new(parking_lot::Mutex::new(d)))
+                                        LcdBackend::HidLcd(Arc::new(super::runtime::HidLcd::new(d)))
                                     }),
                                     None => Err(anyhow::anyhow!("Not an LCD device")),
                                 }
@@ -357,7 +357,7 @@ impl ServiceManager {
                                 };
                                 match open_hid_lcd_device(&det, self.hid_backend()) {
                                     Some(result) => result.map(|d| {
-                                        LcdBackend::HidLcd(Arc::new(parking_lot::Mutex::new(d)))
+                                        LcdBackend::HidLcd(Arc::new(super::runtime::HidLcd::new(d)))
                                     }),
                                     None => Err(anyhow::anyhow!("Not an LCD device")),
                                 }

--- a/crates/lianli-daemon/src/service/mod.rs
+++ b/crates/lianli-daemon/src/service/mod.rs
@@ -237,6 +237,13 @@ impl ServiceManager {
             let Some(lcd) = lcd else {
                 continue;
             };
+            // Defer the read while an H.264 stream runs, reads interrupt playback
+            let Some(_idle) = lcd.recovery_idle() else {
+                debug!("AIO LCD {device_id}: stream active, deferring firmware read by 10s");
+                self.aio_lcd_firmware
+                    .schedule(&device_id, Duration::from_secs(10), enable_512);
+                continue;
+            };
             let Some(mut guard) = lcd.try_lock_for(Duration::from_millis(500)) else {
                 debug!("AIO LCD {device_id}: busy, deferring firmware read by 10s");
                 self.aio_lcd_firmware

--- a/crates/lianli-daemon/src/service/renderers.rs
+++ b/crates/lianli-daemon/src/service/renderers.rs
@@ -384,6 +384,9 @@ impl AsyncCustomH264Renderer {
                     next_deadline = Instant::now() + frame_interval;
                 }
 
+                if !restarter.try_start_pending() {
+                    continue;
+                }
                 let outcome = asset.render_frame_rgba_with(true, |rgba| {
                     let mut enc = encoder_clone.lock();
                     enc.write_frame(rgba)
@@ -470,8 +473,13 @@ impl AsyncSensorH264Renderer {
         let frame_interval =
             Duration::from_secs_f32(1.0 / fps.max(1.0)).max(Duration::from_millis(16));
 
-        if let Err(e) = encoder_clone.lock().write_frame(initial.as_raw()) {
-            warn!("sensor h264 initial frame write failed: {e}");
+        if stream_thread
+            .as_mut()
+            .is_none_or(HidStreamWorker::try_start)
+        {
+            if let Err(e) = encoder_clone.lock().write_frame(initial.as_raw()) {
+                warn!("sensor h264 initial frame write failed: {e}");
+            }
         }
 
         let restarter = lcd
@@ -496,6 +504,9 @@ impl AsyncSensorH264Renderer {
                     next_deadline = Instant::now() + frame_interval;
                 }
 
+                if !restarter.try_start_pending() {
+                    continue;
+                }
                 match asset.render_frame_rgba(true) {
                     Ok(Some(rgba)) => {
                         let mut enc = encoder_clone.lock();

--- a/crates/lianli-daemon/src/service/runtime.rs
+++ b/crates/lianli-daemon/src/service/runtime.rs
@@ -21,7 +21,51 @@ use std::thread::{self, JoinHandle};
 use std::time::Duration;
 use tracing::{debug, info, warn};
 
-pub(super) type SharedHidLcd = Arc<Mutex<Box<dyn LcdDevice>>>;
+pub(super) type SharedHidLcd = Arc<HidLcd>;
+
+pub(super) struct HidLcd {
+    device: Mutex<Box<dyn LcdDevice>>,
+    // Separate from the LCD mutex: recovery must not even take that mutex
+    // while a worker is feeding H.264. Count overlapping replacement workers.
+    streams: Mutex<usize>,
+}
+
+impl HidLcd {
+    pub(super) fn new(device: Box<dyn LcdDevice>) -> Self {
+        Self {
+            device: Mutex::new(device),
+            streams: Mutex::new(0),
+        }
+    }
+
+    fn begin_stream(self: &Arc<Self>) -> HidStreamLease {
+        *self.streams.lock() += 1;
+        HidStreamLease(Arc::clone(self))
+    }
+
+    fn recovery_idle(&self) -> Option<parking_lot::MutexGuard<'_, usize>> {
+        let streams = self.streams.try_lock()?;
+        (*streams == 0).then_some(streams)
+    }
+}
+
+impl std::ops::Deref for HidLcd {
+    type Target = Mutex<Box<dyn LcdDevice>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.device
+    }
+}
+
+/// Registered before spawning and owned by the worker until every exit path,
+/// including unwinding. A detached old worker cannot clear a new one's state.
+struct HidStreamLease(SharedHidLcd);
+
+impl Drop for HidStreamLease {
+    fn drop(&mut self) {
+        *self.0.streams.lock() -= 1;
+    }
+}
 
 // lock per access unit only, never for the whole stream
 // no sane access unit comes close; malformed streams without a second
@@ -69,7 +113,9 @@ fn spawn_hid_h264_stream(
     let halt = Arc::new(AtomicBool::new(false));
     let worker_halt = Arc::clone(&halt);
     let worker_stop = Arc::clone(&stop);
+    let lease = lcd.begin_stream();
     let handle = thread::spawn(move || {
+        let _lease = lease;
         let halted = || worker_stop.load(Ordering::Relaxed) || worker_halt.load(Ordering::Relaxed);
         let fps = {
             let mut guard = lcd.lock();
@@ -520,9 +566,17 @@ fn spawn_recovery_thread(
             if stop.load(Ordering::Relaxed) {
                 break;
             }
+            // Hold the gate through the probe so a worker cannot start between
+            // the idle check and LCD access. Active streams never take this path.
+            let Some(_idle) = lcd.recovery_idle() else {
+                continue;
+            };
             let Some(mut guard) = lcd.try_lock_for(Duration::from_secs(2)) else {
                 continue;
             };
+            if stop.load(Ordering::Relaxed) {
+                break;
+            }
             match guard.check_and_recover_lcd(&stop) {
                 Ok(RecoveryAction::Recovered) => {
                     if let Some(tx) = &tx {
@@ -561,9 +615,10 @@ impl ActiveTarget {
             LcdBackend::HidLcd(d) => {
                 // bounded: the init worker holds this mutex across the 10s
                 // settle on some paths
-                let supports = d
-                    .try_lock_for(Duration::from_millis(200))
-                    .is_some_and(|guard| guard.supports_c_command());
+                let supports = d.recovery_idle().is_some_and(|_idle| {
+                    d.try_lock_for(Duration::from_millis(200))
+                        .is_some_and(|guard| guard.supports_c_command())
+                });
                 if supports {
                     Some(spawn_recovery_thread(
                         Arc::clone(d),
@@ -607,6 +662,9 @@ impl ActiveTarget {
             return;
         }
         let LcdBackend::HidLcd(d) = &self.lcd else {
+            return;
+        };
+        let Some(_idle) = d.recovery_idle() else {
             return;
         };
         let Some(guard) = d.try_lock_for(wait) else {
@@ -1019,7 +1077,9 @@ impl FrameSource for H264FileSource {
                 let completed = Arc::new(AtomicBool::new(false));
                 let done = Arc::clone(&completed);
                 self.hid_completed = Some(completed);
+                let lease = lcd.begin_stream();
                 self.hid_thread = Some(thread::spawn(move || {
+                    let _lease = lease;
                     if stream_h264_file_to_hid(lcd, file, looping, fps, stop) {
                         done.store(true, Ordering::Release);
                     }
@@ -1232,9 +1292,10 @@ fn stream_h264_file_to_hid(
         // residual flush is paced like a regular AU
         if !stopped() && !accum.is_empty() {
             pace_frame(&mut next_deadline, frame_interval);
-            if send_h264_au_with_retry(&lcd, &accum, &stopped) {
-                sent_any = true;
+            if !send_h264_au_with_retry(&lcd, &accum, &stopped) {
+                return false;
             }
+            sent_any = true;
         }
         if stopped() {
             return false;
@@ -1259,4 +1320,247 @@ fn stream_h264_file_to_hid(
 pub(super) enum SendError {
     Usb(lianli_transport::TransportError),
     Other(anyhow::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+
+    struct TestLcd {
+        sends: Arc<AtomicUsize>,
+        fail_on: usize,
+        fail_count: usize,
+    }
+
+    impl LcdDevice for TestLcd {
+        fn screen_info(&self) -> &ScreenInfo {
+            &ScreenInfo::AIO_LCD_480
+        }
+        fn send_jpeg_frame(&mut self, _: &[u8]) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn set_brightness(&self, _: u8) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn set_rotation(&self, _: u16) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn initialize(&mut self) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn send_h264_frame(&mut self, _: &[u8]) -> anyhow::Result<()> {
+            let n = self.sends.fetch_add(1, Ordering::Relaxed) + 1;
+            anyhow::ensure!(
+                !(self.fail_on..self.fail_on + self.fail_count).contains(&n),
+                "injected send failure"
+            );
+            Ok(())
+        }
+    }
+
+    fn lcd(fail_on: usize) -> (SharedHidLcd, Arc<AtomicUsize>) {
+        lcd_with_failures(fail_on, 1)
+    }
+
+    fn lcd_with_failures(fail_on: usize, fail_count: usize) -> (SharedHidLcd, Arc<AtomicUsize>) {
+        let sends = Arc::new(AtomicUsize::new(0));
+        (
+            Arc::new(HidLcd::new(Box::new(TestLcd {
+                sends: Arc::clone(&sends),
+                fail_on,
+                fail_count,
+            }))),
+            sends,
+        )
+    }
+
+    #[test]
+    fn overlapping_workers_exclude_recovery_without_lcd_access() {
+        let (lcd, _) = lcd(0);
+        let old = lcd.begin_stream();
+        let new = lcd.begin_stream();
+        let _device = lcd.lock();
+        assert!(lcd.recovery_idle().is_none());
+        drop(old);
+        assert!(lcd.recovery_idle().is_none());
+        drop(new);
+        assert!(lcd.recovery_idle().is_some());
+    }
+
+    #[test]
+    fn recovery_gate_serializes_stream_start() {
+        let (lcd, _) = lcd(0);
+        let idle = lcd.recovery_idle().unwrap();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let worker_lcd = Arc::clone(&lcd);
+        let worker = thread::spawn(move || {
+            tx.send(()).unwrap();
+            let lease = worker_lcd.begin_stream();
+            tx.send(()).unwrap();
+            lease
+        });
+        rx.recv().unwrap();
+        assert!(rx.recv_timeout(Duration::from_millis(50)).is_err());
+        drop(idle);
+        rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        let lease = worker.join().unwrap();
+        assert!(lcd.recovery_idle().is_none());
+        drop(lease);
+        assert!(lcd.recovery_idle().is_some());
+    }
+
+    #[test]
+    fn live_worker_releases_recovery_on_eof_error_stop_and_panic() {
+        struct PanicReader;
+        impl std::io::Read for PanicReader {
+            fn read(&mut self, _: &mut [u8]) -> std::io::Result<usize> {
+                panic!("injected reader panic")
+            }
+        }
+        struct ErrorReader;
+        impl std::io::Read for ErrorReader {
+            fn read(&mut self, _: &mut [u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::other("injected read error"))
+            }
+        }
+        // Two slice NALs: one normal send and one EOF flush.
+        let data = vec![0, 0, 0, 1, 5, 128, 0, 0, 0, 1, 1, 128];
+        for (fail_on, stopped, reader, panics) in [
+            (
+                0,
+                false,
+                Box::new(std::io::Cursor::new(data.clone())) as Box<dyn std::io::Read + Send>,
+                false,
+            ),
+            (
+                1,
+                false,
+                Box::new(std::io::Cursor::new(data.clone())),
+                false,
+            ),
+            (
+                2,
+                false,
+                Box::new(std::io::Cursor::new(data.clone())),
+                false,
+            ),
+            (0, true, Box::new(std::io::Cursor::new(data)), false),
+            (0, false, Box::new(ErrorReader), false),
+            (0, false, Box::new(PanicReader), true),
+        ] {
+            let (lcd, sends) = lcd(fail_on);
+            let (worker, _) = spawn_hid_h264_stream(
+                Arc::clone(&lcd),
+                reader,
+                Arc::new(AtomicBool::new(stopped)),
+                30.0,
+            );
+            assert_eq!(worker.join().is_err(), panics);
+            assert!(lcd.recovery_idle().is_some());
+            if fail_on > 0 {
+                assert_eq!(sends.load(Ordering::Relaxed), 3);
+            }
+            if stopped {
+                assert_eq!(sends.load(Ordering::Relaxed), 0);
+            }
+        }
+    }
+
+    fn wait_for_file_worker(source: &H264FileSource) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(3);
+        while !source.hid_thread.as_ref().unwrap().is_finished() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "file worker did not exit"
+            );
+            thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    #[test]
+    fn file_flush_retries_release_gate_and_restart_with_a_new_lease() {
+        let path =
+            std::env::temp_dir().join(format!("lianli-recovery-test-{}.h264", std::process::id()));
+        std::fs::write(&path, [0, 0, 0, 1, 5, 128, 0, 0, 0, 1, 1, 128]).unwrap();
+        for looping in [false, true] {
+            // First AU succeeds; all three attempts at the EOF flush fail.
+            let (lcd, sends) = lcd_with_failures(2, 3);
+            let backend = LcdBackend::HidLcd(Arc::clone(&lcd));
+            let mut source = H264FileSource::new(path.clone(), looping, 30.0);
+            source.start(&backend).unwrap();
+            assert!(lcd.recovery_idle().is_none());
+            wait_for_file_worker(&source);
+            assert_eq!(sends.load(Ordering::Relaxed), 4);
+            assert!(!source
+                .hid_completed
+                .as_ref()
+                .unwrap()
+                .load(Ordering::Acquire));
+            assert!(lcd.recovery_idle().is_some());
+
+            // Holding the device makes it deterministic that the restarted worker
+            // is still alive when we check its separately registered lease.
+            source.looping = false;
+            let device = lcd.lock();
+            source.start(&backend).unwrap();
+            assert!(lcd.recovery_idle().is_none());
+            drop(device);
+            wait_for_file_worker(&source);
+            assert_eq!(sends.load(Ordering::Relaxed), 6);
+            assert!(source
+                .hid_completed
+                .as_ref()
+                .unwrap()
+                .load(Ordering::Acquire));
+            assert!(lcd.recovery_idle().is_some());
+            source.start(&backend).unwrap();
+            assert!(
+                source.hid_thread.is_none(),
+                "normal completion must not restart"
+            );
+            assert_eq!(sends.load(Ordering::Relaxed), 6);
+        }
+        // A single transient EOF-flush failure succeeds on retry and counts
+        // as normal completion, without restarting the worker.
+        let (lcd, sends) = lcd(2);
+        let backend = LcdBackend::HidLcd(Arc::clone(&lcd));
+        let mut source = H264FileSource::new(path.clone(), false, 30.0);
+        source.start(&backend).unwrap();
+        wait_for_file_worker(&source);
+        assert_eq!(sends.load(Ordering::Relaxed), 3);
+        assert!(source
+            .hid_completed
+            .as_ref()
+            .unwrap()
+            .load(Ordering::Acquire));
+        assert!(lcd.recovery_idle().is_some());
+        source.start(&backend).unwrap();
+        assert!(source.hid_thread.is_none());
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn stream_lease_covers_retry_sleeps_and_exhausted_failures() {
+        let (lcd, sends) = lcd_with_failures(1, 3);
+        let (worker, _) = spawn_hid_h264_stream(
+            Arc::clone(&lcd),
+            Box::new(std::io::Cursor::new(vec![0, 0, 0, 1, 5, 128])),
+            Arc::new(AtomicBool::new(false)),
+            30.0,
+        );
+        let deadline = std::time::Instant::now() + Duration::from_secs(3);
+        while sends.load(Ordering::Relaxed) == 0 {
+            assert!(std::time::Instant::now() < deadline);
+            thread::yield_now();
+        }
+        // The failed send releases the LCD mutex during upstream's retry sleep,
+        // but recovery must remain excluded by the worker's lease.
+        let device = lcd.lock();
+        assert!(lcd.recovery_idle().is_none());
+        drop(device);
+        worker.join().unwrap();
+        assert_eq!(sends.load(Ordering::Relaxed), 3);
+        assert!(lcd.recovery_idle().is_some());
+    }
 }

--- a/crates/lianli-daemon/src/service/runtime.rs
+++ b/crates/lianli-daemon/src/service/runtime.rs
@@ -45,7 +45,10 @@ impl HidLcd {
     /// Recovery may hold the gate for seconds; let the caller retry next tick.
     fn begin_stream(self: &Arc<Self>) -> Option<HidStreamLease> {
         *self.streams.try_lock()? += 1;
-        Some(HidStreamLease(Arc::clone(self)))
+        Some(HidStreamLease {
+            lcd: Arc::clone(self),
+            released: Arc::new(AtomicBool::new(false)),
+        })
     }
 
     pub(super) fn recovery_idle(&self) -> Option<parking_lot::MutexGuard<'_, usize>> {
@@ -64,11 +67,33 @@ impl std::ops::Deref for HidLcd {
 
 /// Registered before spawning and owned by the worker until every exit path,
 /// including unwinding. A detached old worker cannot clear a new one's state.
-struct HidStreamLease(SharedHidLcd);
+/// Release is idempotent so stop() can drop the gate early, a halted worker
+/// never touches the device again.
+struct HidStreamLease {
+    lcd: SharedHidLcd,
+    released: Arc<AtomicBool>,
+}
+
+impl Clone for HidStreamLease {
+    fn clone(&self) -> Self {
+        Self {
+            lcd: Arc::clone(&self.lcd),
+            released: Arc::clone(&self.released),
+        }
+    }
+}
+
+impl HidStreamLease {
+    fn release(&self) {
+        if !self.released.swap(true, Ordering::AcqRel) {
+            *self.lcd.streams.lock() -= 1;
+        }
+    }
+}
 
 impl Drop for HidStreamLease {
     fn drop(&mut self) {
-        *self.0.streams.lock() -= 1;
+        self.release();
     }
 }
 
@@ -305,6 +330,7 @@ impl LcdBackend {
 pub(super) struct HidStreamWorker {
     handle: Option<JoinHandle<()>>,
     halt: Arc<AtomicBool>,
+    lease: Option<HidStreamLease>,
     pending: Option<PendingHidStream>,
 }
 
@@ -325,6 +351,7 @@ impl HidStreamWorker {
         let mut worker = Self {
             handle: None,
             halt: Arc::new(AtomicBool::new(false)),
+            lease: None,
             pending: Some(PendingHidStream {
                 lcd,
                 reader,
@@ -350,10 +377,11 @@ impl HidStreamWorker {
             pending.reader,
             pending.stop,
             pending.fps,
-            lease,
+            lease.clone(),
         );
         self.handle = Some(handle);
         self.halt = halt;
+        self.lease = Some(lease);
         true
     }
 
@@ -361,6 +389,11 @@ impl HidStreamWorker {
     /// once the caller replaces the encoder, so join is bounded.
     fn stop(&self, timeout: Duration) {
         self.halt.store(true, Ordering::Relaxed);
+        // A halted worker never touches the device again, release the gate
+        // now so a detached thread parked in its read cannot defer recovery
+        if let Some(lease) = &self.lease {
+            lease.release();
+        }
         // No handle means the worker never spawned, the pending reader drops with it
         let Some(handle) = &self.handle else {
             return;
@@ -1670,6 +1703,55 @@ mod tests {
         drop(device);
         worker.join().unwrap();
         assert_eq!(sends.load(Ordering::Relaxed), 3);
+        assert!(lcd.recovery_idle().is_some());
+    }
+
+    #[test]
+    fn stop_releases_the_lease_while_the_worker_stays_parked() {
+        // A reader that blocks until released, like an encoder stdout whose
+        // child has not exited yet
+        struct ParkedReader {
+            go: Arc<AtomicBool>,
+            in_read: Arc<AtomicBool>,
+        }
+        impl std::io::Read for ParkedReader {
+            fn read(&mut self, _: &mut [u8]) -> std::io::Result<usize> {
+                self.in_read.store(true, Ordering::Release);
+                while !self.go.load(Ordering::Relaxed) {
+                    thread::sleep(Duration::from_millis(5));
+                }
+                Ok(0)
+            }
+        }
+
+        let (lcd, _) = lcd(0);
+        let go = Arc::new(AtomicBool::new(false));
+        let in_read = Arc::new(AtomicBool::new(false));
+        let mut worker = HidStreamWorker::new(
+            Arc::clone(&lcd),
+            Box::new(ParkedReader {
+                go: Arc::clone(&go),
+                in_read: Arc::clone(&in_read),
+            }),
+            Arc::new(AtomicBool::new(false)),
+            30.0,
+        );
+        let deadline = std::time::Instant::now() + Duration::from_secs(3);
+        while !in_read.load(Ordering::Acquire) {
+            assert!(std::time::Instant::now() < deadline);
+            thread::sleep(Duration::from_millis(5));
+        }
+        assert!(lcd.recovery_idle().is_none());
+
+        worker.stop(Duration::from_millis(50));
+        // The thread stays parked inside its read, yet the gate is free
+        assert!(!worker.handle.as_ref().unwrap().is_finished());
+        assert!(lcd.recovery_idle().is_some());
+
+        // Let the thread exit, its own lease drop must not double decrement
+        go.store(true, Ordering::Release);
+        worker.handle.take().unwrap().join().unwrap();
+        assert_eq!(*lcd.streams.lock(), 0);
         assert!(lcd.recovery_idle().is_some());
     }
 }

--- a/crates/lianli-daemon/src/service/runtime.rs
+++ b/crates/lianli-daemon/src/service/runtime.rs
@@ -38,9 +38,10 @@ impl HidLcd {
         }
     }
 
-    fn begin_stream(self: &Arc<Self>) -> HidStreamLease {
-        *self.streams.lock() += 1;
-        HidStreamLease(Arc::clone(self))
+    /// Recovery may hold the gate for seconds; let the caller retry next tick.
+    fn begin_stream(self: &Arc<Self>) -> Option<HidStreamLease> {
+        *self.streams.try_lock()? += 1;
+        Some(HidStreamLease(Arc::clone(self)))
     }
 
     fn recovery_idle(&self) -> Option<parking_lot::MutexGuard<'_, usize>> {
@@ -105,6 +106,7 @@ fn spawn_hid_h264_stream(
     mut reader: Box<dyn std::io::Read + Send>,
     stop: Arc<AtomicBool>,
     fps: f32,
+    lease: HidStreamLease,
 ) -> (JoinHandle<()>, Arc<AtomicBool>) {
     use lianli_devices::hydroshift_lcd::{find_au_split, pace_frame};
     use std::io::Read;
@@ -113,7 +115,6 @@ fn spawn_hid_h264_stream(
     let halt = Arc::new(AtomicBool::new(false));
     let worker_halt = Arc::clone(&halt);
     let worker_stop = Arc::clone(&stop);
-    let lease = lcd.begin_stream();
     let handle = thread::spawn(move || {
         let _lease = lease;
         let halted = || worker_stop.load(Ordering::Relaxed) || worker_halt.load(Ordering::Relaxed);
@@ -263,11 +264,12 @@ impl LcdBackend {
         fps: f32,
     ) -> anyhow::Result<Option<HidStreamWorker>> {
         match self {
-            Self::HidLcd(lcd) => {
-                let (handle, halt) =
-                    spawn_hid_h264_stream(Arc::clone(lcd), Box::new(stdout), stop, fps);
-                Ok(Some(HidStreamWorker { handle, halt }))
-            }
+            Self::HidLcd(lcd) => Ok(Some(HidStreamWorker::new(
+                Arc::clone(lcd),
+                Box::new(stdout),
+                stop,
+                fps,
+            ))),
             Self::WinUsb(sender) => {
                 sender.stream_h264_reader(stdout, fps)?;
                 Ok(None)
@@ -297,20 +299,72 @@ impl LcdBackend {
 }
 
 pub(super) struct HidStreamWorker {
-    handle: JoinHandle<()>,
+    handle: Option<JoinHandle<()>>,
     halt: Arc<AtomicBool>,
+    pending: Option<PendingHidStream>,
+}
+
+struct PendingHidStream {
+    lcd: SharedHidLcd,
+    reader: Box<dyn std::io::Read + Send + Sync>,
+    stop: Arc<AtomicBool>,
+    fps: f32,
 }
 
 impl HidStreamWorker {
+    fn new(
+        lcd: SharedHidLcd,
+        reader: Box<dyn std::io::Read + Send + Sync>,
+        stop: Arc<AtomicBool>,
+        fps: f32,
+    ) -> Self {
+        let mut worker = Self {
+            handle: None,
+            halt: Arc::new(AtomicBool::new(false)),
+            pending: Some(PendingHidStream {
+                lcd,
+                reader,
+                stop,
+                fps,
+            }),
+        };
+        worker.try_start();
+        worker
+    }
+
+    /// Keep the reader for the next render tick when recovery owns the gate.
+    pub(super) fn try_start(&mut self) -> bool {
+        let Some(pending) = self.pending.as_ref() else {
+            return true;
+        };
+        let Some(lease) = pending.lcd.begin_stream() else {
+            return false;
+        };
+        let pending = self.pending.take().unwrap();
+        let (handle, halt) = spawn_hid_h264_stream(
+            pending.lcd,
+            pending.reader,
+            pending.stop,
+            pending.fps,
+            lease,
+        );
+        self.handle = Some(handle);
+        self.halt = halt;
+        true
+    }
+
     /// The worker may be parked reading an encoder stdout that only EOFs
     /// once the caller replaces the encoder, so join is bounded.
     fn stop(&self, timeout: Duration) {
         self.halt.store(true, Ordering::Relaxed);
+        let Some(handle) = &self.handle else {
+            return;
+        };
         let deadline = std::time::Instant::now() + timeout;
-        while !self.handle.is_finished() && std::time::Instant::now() < deadline {
+        while !handle.is_finished() && std::time::Instant::now() < deadline {
             thread::sleep(Duration::from_millis(25));
         }
-        if !self.handle.is_finished() {
+        if !handle.is_finished() {
             debug!("h264 stream worker did not stop within {timeout:?}, detaching");
         }
     }
@@ -323,6 +377,17 @@ pub(super) enum StreamRestarter {
 }
 
 impl StreamRestarter {
+    /// Called before feeding the encoder so a deferred reader cannot fill its pipe.
+    pub(super) fn try_start_pending(&self) -> bool {
+        match self {
+            Self::HidLcd(_, current) => current
+                .lock()
+                .as_mut()
+                .is_none_or(HidStreamWorker::try_start),
+            Self::WinUsb(..) => true,
+        }
+    }
+
     /// Start a new h264 stream reading from the given stdout. The old
     /// stream is halted and joined (bounded) first.
     pub(super) fn start_stream(
@@ -337,9 +402,12 @@ impl StreamRestarter {
                 if let Some(old) = current.take() {
                     old.stop(Duration::from_secs(1));
                 }
-                let (handle, halt) =
-                    spawn_hid_h264_stream(Arc::clone(lcd), Box::new(stdout), stop, fps);
-                *current = Some(HidStreamWorker { handle, halt });
+                *current = Some(HidStreamWorker::new(
+                    Arc::clone(lcd),
+                    Box::new(stdout),
+                    stop,
+                    fps,
+                ));
                 Ok(())
             }
             Self::WinUsb(tx, h264_stop) => {
@@ -1077,7 +1145,9 @@ impl FrameSource for H264FileSource {
                 let completed = Arc::new(AtomicBool::new(false));
                 let done = Arc::clone(&completed);
                 self.hid_completed = Some(completed);
-                let lease = lcd.begin_stream();
+                let Some(lease) = lcd.begin_stream() else {
+                    return Ok(());
+                };
                 self.hid_thread = Some(thread::spawn(move || {
                     let _lease = lease;
                     if stream_h264_file_to_hid(lcd, file, looping, fps, stop) {
@@ -1378,8 +1448,8 @@ mod tests {
     #[test]
     fn overlapping_workers_exclude_recovery_without_lcd_access() {
         let (lcd, _) = lcd(0);
-        let old = lcd.begin_stream();
-        let new = lcd.begin_stream();
+        let old = lcd.begin_stream().unwrap();
+        let new = lcd.begin_stream().unwrap();
         let _device = lcd.lock();
         assert!(lcd.recovery_idle().is_none());
         drop(old);
@@ -1389,24 +1459,43 @@ mod tests {
     }
 
     #[test]
-    fn recovery_gate_serializes_stream_start() {
+    fn recovery_gate_defers_stream_start_without_blocking() {
         let (lcd, _) = lcd(0);
         let idle = lcd.recovery_idle().unwrap();
         let (tx, rx) = std::sync::mpsc::channel();
         let worker_lcd = Arc::clone(&lcd);
-        let worker = thread::spawn(move || {
-            tx.send(()).unwrap();
-            let lease = worker_lcd.begin_stream();
-            tx.send(()).unwrap();
-            lease
+        let caller = thread::spawn(move || {
+            let worker = HidStreamWorker::new(
+                worker_lcd,
+                Box::new(std::io::empty()),
+                Arc::new(AtomicBool::new(false)),
+                30.0,
+            );
+            tx.send(worker).unwrap();
         });
-        rx.recv().unwrap();
-        assert!(rx.recv_timeout(Duration::from_millis(50)).is_err());
+        let result = rx.recv_timeout(Duration::from_secs(1));
+        drop(idle); // Release even on failure so the test cannot strand the caller.
+        caller.join().unwrap();
+        let worker = result.expect("stream start blocked on recovery");
+        assert!(worker.handle.is_none());
+        let restarter = StreamRestarter::HidLcd(Arc::clone(&lcd), Mutex::new(Some(worker)));
+        let idle = lcd.recovery_idle().unwrap();
+        assert!(!restarter.try_start_pending());
         drop(idle);
-        rx.recv_timeout(Duration::from_secs(2)).unwrap();
-        let lease = worker.join().unwrap();
+        let device = lcd.lock();
+        assert!(restarter.try_start_pending());
         assert!(lcd.recovery_idle().is_none());
-        drop(lease);
+        drop(device);
+        let StreamRestarter::HidLcd(_, current) = restarter else {
+            unreachable!()
+        };
+        current
+            .into_inner()
+            .unwrap()
+            .handle
+            .unwrap()
+            .join()
+            .unwrap();
         assert!(lcd.recovery_idle().is_some());
     }
 
@@ -1455,6 +1544,7 @@ mod tests {
                 reader,
                 Arc::new(AtomicBool::new(stopped)),
                 30.0,
+                lcd.begin_stream().unwrap(),
             );
             assert_eq!(worker.join().is_err(), panics);
             assert!(lcd.recovery_idle().is_some());
@@ -1488,6 +1578,11 @@ mod tests {
             let (lcd, sends) = lcd_with_failures(2, 3);
             let backend = LcdBackend::HidLcd(Arc::clone(&lcd));
             let mut source = H264FileSource::new(path.clone(), looping, 30.0);
+            let idle = lcd.recovery_idle().unwrap();
+            source.start(&backend).unwrap();
+            assert!(!source.started);
+            assert!(source.hid_thread.is_none());
+            drop(idle);
             source.start(&backend).unwrap();
             assert!(lcd.recovery_idle().is_none());
             wait_for_file_worker(&source);
@@ -1502,6 +1597,11 @@ mod tests {
             // Holding the device makes it deterministic that the restarted worker
             // is still alive when we check its separately registered lease.
             source.looping = false;
+            let idle = lcd.recovery_idle().unwrap();
+            source.start(&backend).unwrap();
+            assert!(!source.started);
+            assert!(source.hid_thread.is_none());
+            drop(idle);
             let device = lcd.lock();
             source.start(&backend).unwrap();
             assert!(lcd.recovery_idle().is_none());
@@ -1548,6 +1648,7 @@ mod tests {
             Box::new(std::io::Cursor::new(vec![0, 0, 0, 1, 5, 128])),
             Arc::new(AtomicBool::new(false)),
             30.0,
+            lcd.begin_stream().unwrap(),
         );
         let deadline = std::time::Instant::now() + Duration::from_secs(3);
         while sends.load(Ordering::Relaxed) == 0 {

--- a/crates/lianli-daemon/src/service/runtime.rs
+++ b/crates/lianli-daemon/src/service/runtime.rs
@@ -27,6 +27,10 @@ pub(super) struct HidLcd {
     device: Mutex<Box<dyn LcdDevice>>,
     // Separate from the LCD mutex: recovery must not even take that mutex
     // while a worker is feeding H.264. Count overlapping replacement workers.
+    //
+    // Ungated device access is limited to non autonomous frame sends,
+    // brightness applies and the init worker, only brightness can overlap
+    // a live stream
     streams: Mutex<usize>,
 }
 
@@ -44,7 +48,7 @@ impl HidLcd {
         Some(HidStreamLease(Arc::clone(self)))
     }
 
-    fn recovery_idle(&self) -> Option<parking_lot::MutexGuard<'_, usize>> {
+    pub(super) fn recovery_idle(&self) -> Option<parking_lot::MutexGuard<'_, usize>> {
         let streams = self.streams.try_lock()?;
         (*streams == 0).then_some(streams)
     }
@@ -357,6 +361,7 @@ impl HidStreamWorker {
     /// once the caller replaces the encoder, so join is bounded.
     fn stop(&self, timeout: Duration) {
         self.halt.store(true, Ordering::Relaxed);
+        // No handle means the worker never spawned, the pending reader drops with it
         let Some(handle) = &self.handle else {
             return;
         };
@@ -683,10 +688,11 @@ impl ActiveTarget {
             LcdBackend::HidLcd(d) => {
                 // bounded: the init worker holds this mutex across the 10s
                 // settle on some paths
-                let supports = d.recovery_idle().is_some_and(|_idle| {
-                    d.try_lock_for(Duration::from_millis(200))
-                        .is_some_and(|guard| guard.supports_c_command())
-                });
+                // Not gated on recovery_idle, renderer targets already hold
+                // a lease here. The thread idles itself while streams run
+                let supports = d
+                    .try_lock_for(Duration::from_millis(200))
+                    .is_some_and(|guard| guard.supports_c_command());
                 if supports {
                     Some(spawn_recovery_thread(
                         Arc::clone(d),
@@ -1112,6 +1118,8 @@ impl FrameSource for H264FileSource {
                     warn!("HID h264 stream thread ended; resetting for restart");
                     self.hid_stop = Arc::new(AtomicBool::new(false));
                     self.started = false;
+                    // Back off so a wedged device cannot spin the restart loop
+                    self.retry_after = Some(std::time::Instant::now() + FILE_OPEN_RETRY);
                 } else {
                     return Ok(());
                 }
@@ -1594,14 +1602,14 @@ mod tests {
                 .load(Ordering::Acquire));
             assert!(lcd.recovery_idle().is_some());
 
-            // Holding the device makes it deterministic that the restarted worker
-            // is still alive when we check its separately registered lease.
             source.looping = false;
             let idle = lcd.recovery_idle().unwrap();
             source.start(&backend).unwrap();
             assert!(!source.started);
             assert!(source.hid_thread.is_none());
             drop(idle);
+            // Clear the restart backoff the dead worker armed
+            source.retry_after = None;
             let device = lcd.lock();
             source.start(&backend).unwrap();
             assert!(lcd.recovery_idle().is_none());


### PR DESCRIPTION
## Problem

I have had problems with H.264/GIF playback on my HydroShift LCD for a while.

Playback would occasionally stall and, after running for longer periods, I also saw strange reinitializations of the LCD, fan control and RGB which initially looked like USB reconnects.

I started looking into this more closely on the then-current release.

## Findings

The first thing I checked was whether the device was actually disconnecting.

`udevadm` and the kernel log showed no physical USB disconnect when the daemon reinitialized the devices.

During further testing it became clear that control access to the LCD can interfere with H.264 playback. Reading information from the controller or running recovery checks while the stream is active can visibly interrupt frame sending.

Based on that, I built an initial fix around the recovery/stream handling and tested it successfully on my hardware.

After upstream had moved on, I updated the work to the current `main`. While testing plain `main` before integrating the fix, I noticed an additional very regular stutter roughly every 2 seconds.

That behavior was easy to reproduce, so I used `git bisect`:

- `4243d11^` works
- `4243d11` reproduces the periodic stutter

The recovery thread introduced there wakes every 2 seconds and calls `check_and_recover_lcd()` while using the same LCD access needed by the H.264 sender.

As a direct test, I disabled the recovery thread on the bad commit without changing the H.264 stream itself. Playback immediately became smooth.

A firmware read during startup also causes one short visible freeze, which matches the same general behavior: control access to the LCD can interrupt active streaming.

I have separately seen the device serial temporarily become unavailable and the daemon fall back to the topology ID, which can trigger reinitialization. I have not proven that this has exactly the same root cause, so this PR does not try to fix the identity handling separately.

## Solution

This combines the previous recovery work with the findings from the 2-second stutter regression.

HID H.264 workers now hold a separate stream/recovery gate for their complete lifetime.

While an H.264 worker is active, background recovery is skipped before it can take the LCD mutex. Once all workers are gone, recovery is available again.

The gate uses a counted RAII lease, so overlapping workers, automatic restarts, errors and panics cannot accidentally enable recovery while another stream is still active or leave it blocked permanently.

The current upstream transport reopen, retry and worker restart behavior is kept intact.

Tested with:

- `cargo test -p lianli-daemon` — 19 tests passed
- `cargo build --release`
- >10 hours continuous H.264 playback on my HydroShift LCD
- no periodic stutter
- no recovery/reconnect events during the hardware test

## Disclaimer

I worked on debugging this together with ChatGPT/Codex.

I am not a Rust expert. The implementation is AI-assisted; I reviewed the code as far as I reasonably could and tested the result on my hardware.

English is also not my native language, so this PR description was translated and polished with AI assistance as well.

Please treat this as a proposed fix rather than me claiming this is necessarily the best implementation. It has been running on my system for more than 10 hours without a playback or recovery issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved LCD recovery behavior by preventing recovery operations from interfering with active video streaming.
  - Improved coordination between LCD initialization, recovery, firmware updates, and H.264 streaming workflows.
  - Video streams now defer startup and retry automatically when recovery is in progress, reducing interruptions and avoiding blocked streaming.
  - Rendering waits for streams to start successfully, helping prevent incomplete or inconsistent display updates.
  - Improved handling of stream termination and restart recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->