### PR TITLE
fix(h2): wired PushRgbData wedges the panel after any H.264 stream; skip it on bridged units and drop it at stream end

### DIFF
--- a/crates/lianli-daemon/src/controllers/rgb/mod.rs
+++ b/crates/lianli-daemon/src/controllers/rgb/mod.rs
@@ -485,6 +485,7 @@ impl RgbController {
                 supported_scopes: dev.supported_scopes(),
                 supports_direction: dev.supports_direction(),
                 supports_merge_lighting: dev.supports_merge_lighting(),
+                rf_owned: dev.rf_owned(),
             });
         }
 
@@ -527,10 +528,20 @@ impl RgbController {
                 supported_scopes: vec![],
                 supports_direction: false,
                 supports_merge_lighting: !state.fan_type.is_rgb_only(),
+                rf_owned: false,
             });
         }
 
         caps
+    }
+
+    /// Capabilities minus RF-owned entries, for the OpenRGB SDK, whose
+    /// device indices must stay stable across every request that uses them.
+    pub fn exposed_capabilities(&self) -> Vec<RgbDeviceCapabilities> {
+        self.capabilities()
+            .into_iter()
+            .filter(|c| !c.rf_owned)
+            .collect()
     }
 
     pub fn set_mb_rgb_sync(&mut self, device_id: &str, enabled: bool) -> anyhow::Result<()> {

--- a/crates/lianli-daemon/src/controllers/rgb/mod.rs
+++ b/crates/lianli-daemon/src/controllers/rgb/mod.rs
@@ -775,3 +775,50 @@ fn render_zone_color(effect: &RgbEffect, led_count: usize) -> Vec<[u8; 3]> {
     };
     vec![color; led_count]
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct MockRgb {
+        rf: bool,
+    }
+
+    impl RgbDevice for MockRgb {
+        fn device_name(&self) -> String {
+            "mock".into()
+        }
+        fn supported_modes(&self) -> Vec<RgbMode> {
+            vec![RgbMode::Static]
+        }
+        fn zone_info(&self) -> Vec<RgbZoneInfo> {
+            vec![]
+        }
+        fn set_zone_effect(&self, _zone: u8, _effect: &RgbEffect) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn rf_owned(&self) -> bool {
+            self.rf
+        }
+    }
+
+    #[test]
+    fn exposed_capabilities_hides_rf_owned_entries() {
+        let mut wired: HashMap<String, Arc<dyn RgbDevice>> = HashMap::new();
+        wired.insert(
+            "hid:kept".into(),
+            Arc::new(MockRgb { rf: false }) as Arc<dyn RgbDevice>,
+        );
+        wired.insert(
+            "hid:rf".into(),
+            Arc::new(MockRgb { rf: true }) as Arc<dyn RgbDevice>,
+        );
+        let ctrl = RgbController::new(wired, None);
+        let ids: Vec<String> = ctrl
+            .exposed_capabilities()
+            .into_iter()
+            .map(|c| c.device_id)
+            .collect();
+        assert_eq!(ids, ["hid:kept"]);
+    }
+}

--- a/crates/lianli-daemon/src/openrgb_server.rs
+++ b/crates/lianli-daemon/src/openrgb_server.rs
@@ -204,14 +204,14 @@ impl ClientHandler {
     /// Get capabilities, caching on first call to avoid mutex contention during streaming.
     fn caps(&mut self) -> &[RgbDeviceCapabilities] {
         if self.cached_caps.is_none() {
-            self.cached_caps = Some(self.rgb.lock().capabilities());
+            self.cached_caps = Some(self.rgb.lock().exposed_capabilities());
         }
         self.cached_caps.as_ref().unwrap()
     }
 
     /// Force-refresh the cached capabilities (e.g., after mode changes).
     fn refresh_caps(&mut self) {
-        self.cached_caps = Some(self.rgb.lock().capabilities());
+        self.cached_caps = Some(self.rgb.lock().exposed_capabilities());
     }
 
     fn run(&mut self) -> anyhow::Result<()> {
@@ -463,7 +463,7 @@ impl ClientHandler {
             }
 
             let mut rgb = self.rgb.lock();
-            let caps = rgb.capabilities();
+            let caps = rgb.exposed_capabilities();
             if let Some(cap) = caps.get(dev_idx as usize) {
                 let device_id = cap.device_id.clone();
                 debug!(

--- a/crates/lianli-devices/src/traits.rs
+++ b/crates/lianli-devices/src/traits.rs
@@ -327,6 +327,14 @@ pub trait RgbDevice: Send + Sync {
         false
     }
 
+    /// True when the LEDs this device exposes are driven over RF by a bound
+    /// wireless device, so writes here are skipped. The GUI and the OpenRGB
+    /// server hide such devices, as the fan list already hides bound wired
+    /// fan entries.
+    fn rf_owned(&self) -> bool {
+        false
+    }
+
     /// Enable or disable motherboard ARGB sync.
     /// When enabled, the device reads ARGB from the motherboard header instead of using
     /// software-controlled effects.
@@ -378,6 +386,9 @@ impl<T: RgbDevice + ?Sized> RgbDevice for Arc<T> {
     }
     fn set_direct_colors(&self, zone: u8, colors: &[[u8; 3]]) -> Result<()> {
         (**self).set_direct_colors(zone, colors)
+    }
+    fn rf_owned(&self) -> bool {
+        (**self).rf_owned()
     }
     fn supports_direct(&self) -> bool {
         (**self).supports_direct()

--- a/crates/lianli-devices/src/winusb/h2_aio.rs
+++ b/crates/lianli-devices/src/winusb/h2_aio.rs
@@ -79,6 +79,9 @@ pub struct H2AioController {
     last_sync: Mutex<Option<(std::time::Instant, u8, [u8; 3])>>,
     /// When the "telemetry held back while streaming" line was last logged.
     stale_params_logged_at: Mutex<Option<std::time::Instant>>,
+    /// Raw ring bytes and interval of the last PushRgbData that went out
+    /// or was queued, so an unchanged ring is not resent.
+    last_rgb_payload: Mutex<Option<(Vec<u8>, u8)>>,
 }
 
 impl H2AioController {
@@ -94,6 +97,7 @@ impl H2AioController {
             params_cache: Mutex::new(None),
             last_sync: Mutex::new(None),
             stale_params_logged_at: Mutex::new(None),
+            last_rgb_payload: Mutex::new(None),
         };
         wake(&transport);
         tracing::info!("HydroShift II control channel opened (shared transport)");
@@ -169,10 +173,12 @@ impl H2AioController {
         Ok(true)
     }
 
-    /// Send commands left in the queue by the teardown race above. The stream
-    /// is over, so these go straight out.
+    /// Send play-safe commands left in the queue by the teardown race above.
+    /// The stream is over, so these go straight out. Commands that need the
+    /// panel reinitialised first (PushRgbData) stay queued for the LCD
+    /// stream thread, which owns the raw device handle.
     fn send_stranded(&self) {
-        for cmd in self.transport.take_pending() {
+        for cmd in self.transport.take_play_safe() {
             debug!("H2: sending {} stranded by stream teardown", cmd.label);
             match self.write_control(cmd.label, &cmd.packet, cmd.reply_wait) {
                 Ok(true) => {}
@@ -397,6 +403,14 @@ impl H2AioController {
         if frames.is_empty() {
             return Ok(());
         }
+        // Bridged to a wireless AIO: the same 24-LED ring is driven over RF
+        // through the pump-head device, as the fan and pump paths already
+        // are, so this packet is redundant here and the wired write is
+        // skipped.
+        if self.is_wireless.load(Ordering::Relaxed) {
+            debug!("H2: PushRgbData skipped — ring is driven over RF (wireless mode)");
+            return Ok(());
+        }
         let total_frames = frames.len();
 
         let mut raw = Vec::with_capacity(total_frames * RING_LED_COUNT * 3);
@@ -405,6 +419,16 @@ impl H2AioController {
                 let c = frame.get(led).copied().unwrap_or([0, 0, 0]);
                 raw.extend_from_slice(&c);
             }
+        }
+
+        // The daemon re-applies every configured effect on each config
+        // reload, including LCD media switches. Each write here costs a
+        // stop/push/reopen cycle and a second of LCD pause, so an unchanged
+        // ring is not resent.
+        let payload_key = (raw.clone(), interval_ms);
+        if self.last_rgb_payload.lock().as_ref() == Some(&payload_key) {
+            debug!("H2: PushRgbData skipped — ring unchanged");
+            return Ok(());
         }
 
         let compressed = crate::tinyuz::compress(&raw).context("compressing RGB data")?;
@@ -426,24 +450,76 @@ impl H2AioController {
         // This packet is a full 512-byte header plus the compressed RGB payload,
         // so it exceeds one bulk packet; send_control uses write_full so every
         // byte goes out (a plain write() merely warned on the short write).
+        //
         // Not play-safe: a PushRgbData during H.264 play mode hangs the panel
-        // even at buffer level 1 (2026-08-23) — presumably the firmware feeds
-        // the payload after the header to its stream parser. While the LCD
-        // streams, the ring is reachable over RF through the bridged wireless
-        // AIO instead; this frame is held until the stream ends.
-        let sent = self.send_control("PushRgbData", packet, Duration::from_millis(100), false)?;
-        if !sent {
-            tracing::warn!(
-                "H2: ring RGB held until the LCD stream ends (PushRgbData hangs the panel in play mode); \
-                 use the wireless pump-head device to recolour the ring while streaming"
-            );
-        }
+        // even at buffer level 1 (2026-08-23), and one sent after the stream
+        // ended hangs it too (2026-09-06), even after an acknowledged
+        // StopPlay. Once the panel has played anything, the packet is
+        // therefore handed to the LCD stream thread, which stops play,
+        // reopens the handle, reruns the init sequence, sends it, and
+        // resumes (`reinit_and_flush_unsafe`). Straight after enumeration it
+        // goes out directly, as it always did.
+        let cmd = PendingCmd {
+            label: "PushRgbData",
+            packet,
+            reply_wait: Duration::from_millis(100),
+            queued_at: std::time::Instant::now(),
+            play_safe: false,
+        };
+        let sent = if self.transport.is_streaming() {
+            debug!("H2: PushRgbData queued — the stream thread will stop play, send it and reopen");
+            self.transport.defer(cmd);
+            false
+        } else {
+            // No stream thread is going to run the cycle, so run it here.
+            // Straight after enumeration the panel copes with a bare write
+            // (pid 22766: one lost GetVer reply, then fine), but a bare
+            // write between two streams silenced it (pid 39118, 250 s), so
+            // every write off the stream thread takes the full cycle.
+            // StopPlay/StopClock re-arm the control channel first; if a
+            // stream begins under us, queue instead.
+            // A ring write still queued from an earlier stream is stale
+            // now: latest wins, as `defer` does.
+            self.transport.take_unsafe();
+            let mut builder = PacketBuilder::new();
+            let stop = builder.stop_play_header_winusb();
+            let stop_clock = builder.stop_clock_header_winusb();
+            let armed = self.write_control("StopPlay", &stop, LCD_READ_TIMEOUT)?
+                && self.write_control("StopClock", &stop_clock, LCD_READ_TIMEOUT)?;
+            let pushed = if armed {
+                match self.transport.push_and_recover(
+                    "HydroShift II control",
+                    std::slice::from_ref(&cmd),
+                    LCD_WRITE_TIMEOUT,
+                    false,
+                ) {
+                    Ok(pushed) => pushed,
+                    Err(e) => {
+                        // Not delivered: keep it queued for the next stream
+                        // start, and let the caller see the failure.
+                        self.transport.defer(cmd);
+                        return Err(e);
+                    }
+                }
+            } else {
+                false
+            };
+            if !pushed {
+                debug!("H2: PushRgbData queued — a stream began first");
+                self.transport.defer(cmd);
+            }
+            pushed
+        };
+        // Queued writes count too: the queue keeps the latest ring write
+        // until it is delivered (stream end no longer drops it), so a later
+        // identical apply has nothing to add.
+        *self.last_rgb_payload.lock() = Some(payload_key);
         debug!(
             "H2: PushRgbData {} frame(s), {} LEDs, {} bytes{}",
             total_frames,
             RING_LED_COUNT,
             payload.len(),
-            if sent { "" } else { " (deferred)" }
+            if sent { "" } else { " (queued)" }
         );
         Ok(())
     }

--- a/crates/lianli-devices/src/winusb/h2_aio.rs
+++ b/crates/lianli-devices/src/winusb/h2_aio.rs
@@ -606,6 +606,10 @@ impl RgbDevice for H2AioController {
         true
     }
 
+    fn rf_owned(&self) -> bool {
+        self.is_wireless_mode()
+    }
+
     fn set_zone_effect(&self, zone: u8, effect: &RgbEffect) -> Result<()> {
         if zone != 0 {
             anyhow::bail!("H2 RGB: zone {zone} out of range (only zone 0)");

--- a/crates/lianli-devices/src/winusb/h2_aio.rs
+++ b/crates/lianli-devices/src/winusb/h2_aio.rs
@@ -470,39 +470,41 @@ impl H2AioController {
             debug!("H2: PushRgbData queued — the stream thread will stop play, send it and reopen");
             self.transport.defer(cmd);
             false
+        } else if !self.transport.hold_allowed() {
+            // Same spacing as the stream thread path, bursty saves or sdk
+            // clients must not run stop and reopen cycles back to back
+            debug!("H2: PushRgbData queued — reinit cycle throttled");
+            self.transport.defer(cmd);
+            false
         } else {
             // No stream thread is going to run the cycle, so run it here.
             // Straight after enumeration the panel copes with a bare write
             // (pid 22766: one lost GetVer reply, then fine), but a bare
             // write between two streams silenced it (pid 39118, 250 s), so
             // every write off the stream thread takes the full cycle.
-            // StopPlay/StopClock re-arm the control channel first; if a
-            // stream begins under us, queue instead.
+            // If a stream begins under us the cycle refuses and we queue.
             // A ring write still queued from an earlier stream is stale
             // now: latest wins, as `defer` does.
             self.transport.take_unsafe();
             let mut builder = PacketBuilder::new();
             let stop = builder.stop_play_header_winusb();
             let stop_clock = builder.stop_clock_header_winusb();
-            let armed = self.write_control("StopPlay", &stop, LCD_READ_TIMEOUT)?
-                && self.write_control("StopClock", &stop_clock, LCD_READ_TIMEOUT)?;
-            let pushed = if armed {
-                match self.transport.push_and_recover(
-                    "HydroShift II control",
-                    std::slice::from_ref(&cmd),
-                    LCD_WRITE_TIMEOUT,
-                    false,
-                ) {
-                    Ok(pushed) => pushed,
-                    Err(e) => {
-                        // Not delivered: keep it queued for the next stream
-                        // start, and let the caller see the failure.
-                        self.transport.defer(cmd);
-                        return Err(e);
-                    }
+            // The wake commands ride inside the cycle under one bulk guard,
+            // so a stream that begins meanwhile cannot see them land mid play
+            let pushed = match self.transport.push_and_recover(
+                "HydroShift II control",
+                &[("StopPlay", stop), ("StopClock", stop_clock)],
+                std::slice::from_ref(&cmd),
+                LCD_WRITE_TIMEOUT,
+                false,
+            ) {
+                Ok(pushed) => pushed,
+                Err(e) => {
+                    // Not delivered: keep it queued for the next stream
+                    // start, and let the caller see the failure.
+                    self.transport.defer(cmd);
+                    return Err(e);
                 }
-            } else {
-                false
             };
             if !pushed {
                 debug!("H2: PushRgbData queued — a stream began first");

--- a/crates/lianli-devices/src/winusb/h2_aio.rs
+++ b/crates/lianli-devices/src/winusb/h2_aio.rs
@@ -79,9 +79,6 @@ pub struct H2AioController {
     last_sync: Mutex<Option<(std::time::Instant, u8, [u8; 3])>>,
     /// When the "telemetry held back while streaming" line was last logged.
     stale_params_logged_at: Mutex<Option<std::time::Instant>>,
-    /// Raw ring bytes and interval of the last PushRgbData that went out
-    /// or was queued, so an unchanged ring is not resent.
-    last_rgb_payload: Mutex<Option<(Vec<u8>, u8)>>,
 }
 
 impl H2AioController {
@@ -97,7 +94,6 @@ impl H2AioController {
             params_cache: Mutex::new(None),
             last_sync: Mutex::new(None),
             stale_params_logged_at: Mutex::new(None),
-            last_rgb_payload: Mutex::new(None),
         };
         wake(&transport);
         tracing::info!("HydroShift II control channel opened (shared transport)");
@@ -145,6 +141,7 @@ impl H2AioController {
             reply_wait,
             queued_at: std::time::Instant::now(),
             play_safe,
+            ring_key: None,
         });
         // The stream can end between the check above and the queueing:
         // stream_end() has then already drained the queue, and nothing
@@ -426,7 +423,7 @@ impl H2AioController {
         // stop/push/reopen cycle and a second of LCD pause, so an unchanged
         // ring is not resent.
         let payload_key = (raw.clone(), interval_ms);
-        if self.last_rgb_payload.lock().as_ref() == Some(&payload_key) {
+        if self.transport.last_ring_payload().as_ref() == Some(&payload_key) {
             debug!("H2: PushRgbData skipped — ring unchanged");
             return Ok(());
         }
@@ -465,6 +462,7 @@ impl H2AioController {
             reply_wait: Duration::from_millis(100),
             queued_at: std::time::Instant::now(),
             play_safe: false,
+            ring_key: Some(payload_key),
         };
         let sent = if self.transport.is_streaming() {
             debug!("H2: PushRgbData queued — the stream thread will stop play, send it and reopen");
@@ -512,10 +510,6 @@ impl H2AioController {
             }
             pushed
         };
-        // Queued writes count too: the queue keeps the latest ring write
-        // until it is delivered (stream end no longer drops it), so a later
-        // identical apply has nothing to add.
-        *self.last_rgb_payload.lock() = Some(payload_key);
         debug!(
             "H2: PushRgbData {} frame(s), {} LEDs, {} bytes{}",
             total_frames,

--- a/crates/lianli-devices/src/winusb/lcd/core.rs
+++ b/crates/lianli-devices/src/winusb/lcd/core.rs
@@ -20,8 +20,9 @@ pub struct PendingCmd {
     pub queued_at: Instant,
     /// May this go out between chunks once the panel reports headroom? False
     /// for commands that hang the panel in play mode regardless of buffer
-    /// level (PushRgbData — tested at levels 4 and 1, 2026-08-23); those wait
-    /// for the stream to end.
+    /// level (PushRgbData — tested at levels 4 and 1, 2026-08-23) and also
+    /// after it (2026-09-06); those only go out once the stream thread has
+    /// stopped play and reinitialised the panel (see `reinit_and_flush_unsafe`).
     pub play_safe: bool,
 }
 
@@ -37,15 +38,26 @@ pub struct PendingCmd {
 /// headroom.
 pub struct LcdLink {
     bulk: Mutex<RusbBulk>,
+    /// The rusb device the handle was opened from, so any core on this
+    /// transport can close and reopen it (vendor ReInitDev).
+    raw_device: Option<Device<GlobalContext>>,
     streaming: AtomicBool,
+    /// Set by `push_and_recover`: the handle was reopened behind the LCD
+    /// driver's back, so it must rerun its init before the next frame.
+    needs_init: AtomicBool,
+    /// When the last push-and-recover cycle ran, to space cycles out.
+    last_hold: Mutex<Option<Instant>>,
     pending: Mutex<Vec<PendingCmd>>,
 }
 
 impl LcdLink {
-    pub fn new(bulk: RusbBulk) -> Self {
+    pub fn new(bulk: RusbBulk, raw_device: Option<Device<GlobalContext>>) -> Self {
         Self {
             bulk: Mutex::new(bulk),
+            raw_device,
             streaming: AtomicBool::new(false),
+            needs_init: AtomicBool::new(false),
+            last_hold: Mutex::new(None),
             pending: Mutex::new(Vec::new()),
         }
     }
@@ -63,6 +75,147 @@ impl LcdLink {
         self.streaming.store(on, Ordering::Release);
     }
 
+    /// True after `push_and_recover` reopened the handle: the LCD driver
+    /// must rerun its init sequence before it streams or draws again.
+    pub(crate) fn needs_init(&self) -> bool {
+        self.needs_init.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn set_needs_init(&self, on: bool) {
+        self.needs_init.store(on, Ordering::Release);
+    }
+
+    pub(crate) fn can_reopen(&self) -> bool {
+        self.raw_device.is_some()
+    }
+
+    /// Enough time since the last push-and-recover cycle for another one.
+    /// A colour drag in the GUI queues a write per tick; `defer` keeps only
+    /// the latest, and this keeps the stream from being stopped for each.
+    pub(crate) fn hold_allowed(&self) -> bool {
+        self.last_hold
+            .lock()
+            .is_none_or(|at| at.elapsed() >= HOLD_MIN_INTERVAL)
+    }
+
+    /// Close the bulk handle and reopen it from the raw device (the vendor
+    /// driver's ReInitDev), swapping the new handle in under the guard the
+    /// caller already holds. No USB port reset is involved: that would take
+    /// down composite siblings like the LED MCU, and on the HydroShift II
+    /// locks the header until a power cycle.
+    fn reopen_locked(&self, bulk: &mut RusbBulk, name: &str) -> Result<()> {
+        let raw = self
+            .raw_device
+            .as_ref()
+            .context("no raw device handle to reopen from")?;
+        // FIX: release the interfaces the current handle holds *before*
+        // reopening. The replacement only lands once the new open succeeds,
+        // so without this the old handle still owns interface 0 and every
+        // claim_interface(0) returns EBUSY — the recovery path could never
+        // succeed, it just retried 20 times against a device already in an
+        // error state.
+        bulk.release();
+        std::thread::sleep(REOPEN_DELAY);
+        let mut t = RusbBulk::open_device(raw.clone()).context("reopening device")?;
+        t.detach_and_configure(name)
+            .context("configuring reopened device")?;
+        *bulk = t;
+        Ok(())
+    }
+
+    /// Reopen the handle from the raw device. Used by the LCD driver's
+    /// write-error recovery.
+    pub(crate) fn reopen(&self, name: &str) -> Result<()> {
+        let mut bulk = self.bulk.lock();
+        self.reopen_locked(&mut bulk, name)
+    }
+
+    /// Write PushRgbData (or any command the panel goes quiet after) and
+    /// bring the panel back: the packet goes out, the handle is closed and
+    /// reopened, then GetVer is polled until the panel answers. Everything
+    /// happens under one bulk guard so no stream chunk can interleave.
+    ///
+    /// Measured 2026-09-06 on a HydroShift II Square (fw 1.7): after the
+    /// packet the panel stops answering bulk IN and does not come back on
+    /// its own within 80 s, but answers GetVer 0.5 s after a reopen. Six
+    /// cycles in a row all recovered in 3.1 s with the reopen at 2.5 s.
+    ///
+    /// `from_stream_thread` says the caller is the stream thread itself;
+    /// any other caller is refused (`Ok(false)`) if a stream has begun in
+    /// the meantime, and must queue the command instead.
+    pub(crate) fn push_and_recover(
+        &self,
+        name: &str,
+        cmds: &[PendingCmd],
+        write_timeout: Duration,
+        from_stream_thread: bool,
+    ) -> Result<bool> {
+        let mut bulk = self.bulk.lock();
+        if !from_stream_thread && self.is_streaming() {
+            return Ok(false);
+        }
+        let started = Instant::now();
+        for cmd in cmds {
+            debug!(
+                "H2 ring: sending {} ({} bytes, queued {} ms ago)",
+                cmd.label,
+                cmd.packet.len(),
+                cmd.queued_at.elapsed().as_millis()
+            );
+            bulk.write_full(&cmd.packet, write_timeout)
+                .with_context(|| format!("H2 ring: {} write", cmd.label))?;
+            let mut buf = [0u8; 512];
+            match bulk.read(&mut buf, cmd.reply_wait) {
+                Ok(n) if n > 0 => debug!(
+                    "H2 ring: reply to {} ({n} bytes): {:02x?}",
+                    cmd.label,
+                    &buf[..n.min(8)]
+                ),
+                Ok(_) => debug!("H2 ring: no reply to {} (timeout)", cmd.label),
+                Err(e) => debug!("H2 ring: no reply to {}: {e}", cmd.label),
+            }
+        }
+        let pushed_at = Instant::now();
+        *self.last_hold.lock() = Some(Instant::now());
+        // The handle is released before the reopen, so on failure there is
+        // nothing to poll; the driver's write-error recovery retries later.
+        if let Err(e) = self.reopen_locked(&mut bulk, name) {
+            self.set_needs_init(true);
+            return Err(e.context("H2 ring: reopen after push"));
+        }
+        debug!("H2 ring: handle reopened");
+        bulk.read_flush();
+        let mut builder = PacketBuilder::new();
+        let mut answered = None;
+        while pushed_at.elapsed() < PANEL_SILENCE_BUDGET {
+            let ver = builder.get_ver_header_winusb();
+            if let Err(e) = bulk.write_full(&ver, write_timeout) {
+                debug!("H2 ring: GetVer poll write failed: {e}");
+            } else {
+                let mut buf = [0u8; 512];
+                if matches!(bulk.read(&mut buf, PANEL_POLL_READ), Ok(n) if n > 0) {
+                    bulk.read_flush();
+                    answered = Some(pushed_at.elapsed());
+                    break;
+                }
+            }
+            std::thread::sleep(PANEL_POLL_GAP);
+        }
+        self.set_needs_init(true);
+        match answered {
+            Some(after) => info!(
+                "H2 ring: panel answering {} ms after the push, cycle took {} ms",
+                after.as_millis(),
+                started.elapsed().as_millis()
+            ),
+            None => warn!(
+                "H2 ring: panel still silent {} s after the push and reopen",
+                pushed_at.elapsed().as_secs()
+            ),
+        }
+        Ok(true)
+    }
+
     /// Queue a control command for the stream thread. Latest wins per label:
     /// an older SyncPumpFan still waiting is replaced, not appended.
     pub fn defer(&self, cmd: PendingCmd) {
@@ -73,11 +226,6 @@ impl LcdLink {
 
     pub fn has_pending(&self) -> bool {
         !self.pending.lock().is_empty()
-    }
-
-    /// Take every queued command (stream over).
-    pub(crate) fn take_pending(&self) -> Vec<PendingCmd> {
-        std::mem::take(&mut *self.pending.lock())
     }
 
     /// Take only the commands that may be sent mid-stream.
@@ -92,6 +240,21 @@ impl LcdLink {
 
     pub(crate) fn has_play_safe_pending(&self) -> bool {
         self.pending.lock().iter().any(|c| c.play_safe)
+    }
+
+    /// True if a command that must wait for a panel reinit is queued.
+    pub(crate) fn has_unsafe_pending(&self) -> bool {
+        self.pending.lock().iter().any(|c| !c.play_safe)
+    }
+
+    /// Take only the commands that need the panel reinitialised first.
+    pub(crate) fn take_unsafe(&self) -> Vec<PendingCmd> {
+        let mut q = self.pending.lock();
+        let (unsafe_cmds, rest): (Vec<_>, Vec<_>) = std::mem::take(&mut *q)
+            .into_iter()
+            .partition(|c| !c.play_safe);
+        *q = rest;
+        unsafe_cmds
     }
 
     pub(crate) fn oldest_play_safe_age(&self) -> Option<Duration> {
@@ -114,6 +277,15 @@ const CONTROL_RELAXED_LEVEL: u8 = 2;
 const CONTROL_RELAX_AFTER: Duration = Duration::from_secs(3);
 
 const REOPEN_DELAY: Duration = Duration::from_millis(100);
+/// Gap between the wake-preamble commands (StopPlay, StopClock, GetVer).
+const WAKE_STEP: Duration = Duration::from_millis(150);
+/// After a PushRgbData and reopen: how long to poll GetVer for the panel
+/// to answer, the gap between polls, and each poll's reply wait.
+const PANEL_SILENCE_BUDGET: Duration = Duration::from_secs(10);
+const PANEL_POLL_GAP: Duration = Duration::from_millis(250);
+const PANEL_POLL_READ: Duration = Duration::from_millis(500);
+/// Minimum spacing between push-and-recover cycles while streaming.
+const HOLD_MIN_INTERVAL: Duration = Duration::from_secs(3);
 /// Chunk writes slower than this are logged: the panel NAKed bulk OUT.
 const SLOW_CHUNK_WRITE: Duration = Duration::from_millis(100);
 const WAIT_BUFFER_POLL: Duration = Duration::from_millis(50);
@@ -126,7 +298,6 @@ pub(crate) struct WinUsbLcdCore {
     write_timeout: Duration,
     read_timeout: Duration,
     name: String,
-    raw_device: Option<Device<GlobalContext>>,
     pub(crate) initialized: bool,
     pub(crate) consecutive_failures: u32,
     pub(crate) h264_chunk_size: usize,
@@ -202,13 +373,12 @@ impl WinUsbLcdCore {
         );
 
         Ok(Self {
-            transport: Arc::new(LcdLink::new(transport)),
+            transport: Arc::new(LcdLink::new(transport, Some(device.clone()))),
             builder: PacketBuilder::new(),
             screen,
             write_timeout,
             read_timeout,
             name: name.to_string(),
-            raw_device: Some(device),
             initialized: false,
             consecutive_failures: 0,
             h264_chunk_size: 202_752,
@@ -231,7 +401,6 @@ impl WinUsbLcdCore {
             write_timeout,
             read_timeout,
             name,
-            raw_device: None,
             initialized: false,
             consecutive_failures: 0,
             h264_chunk_size: 202_752,
@@ -314,6 +483,12 @@ impl WinUsbLcdCore {
         self.consecutive_failures = 0;
     }
 
+    /// True after the control channel reopened the handle (see
+    /// `LcdLink::push_and_recover`); the driver must rerun its init.
+    pub(crate) fn needs_init(&self) -> bool {
+        self.transport.needs_init()
+    }
+
     /// Vendor-faithful recovery: close the handle and reopen it from the raw
     /// device (ReInitDev), so a stalled endpoint is recovered within the
     /// session without a USB port reset (which would take down composite
@@ -328,23 +503,12 @@ impl WinUsbLcdCore {
         }
         self.consecutive_failures += 1;
 
-        if let Some(raw) = &self.raw_device {
-            // FIX: release the interfaces the current handle holds *before*
-            // reopening. The replacement only lands in self.transport once the
-            // new open succeeds, so without this the old handle still owns
-            // interface 0 and every claim_interface(0) returns EBUSY — the
-            // recovery path could never succeed, it just retried 20 times
-            // against a device already in an error state.
-            self.transport.lock().release();
-            std::thread::sleep(REOPEN_DELAY);
-            match RusbBulk::open_device(raw.clone()) {
-                Ok(mut t) => {
-                    if t.detach_and_configure(&self.name).is_ok() {
-                        *self.transport.lock() = t;
-                        self.consecutive_failures = 0;
-                        debug!("recovered via close+reopen");
-                        return Ok(());
-                    }
+        if self.transport.can_reopen() {
+            match self.transport.reopen(&self.name) {
+                Ok(()) => {
+                    self.consecutive_failures = 0;
+                    debug!("recovered via close+reopen");
+                    return Ok(());
                 }
                 Err(e) => warn!("reopen failed: {e}"),
             }
@@ -396,6 +560,24 @@ impl WinUsbLcdCore {
             }
         }
         self.read_response(label);
+    }
+
+    /// HydroShift II control-channel init: GetVer, frame rate, SyncClock,
+    /// StopClock. Run by `H2WinUsbLcd::do_init` after enumeration and again
+    /// by `reinit_and_flush_unsafe` after a stream.
+    pub(crate) fn h2_control_init(&mut self) {
+        self.read_firmware();
+        // FIX: this AIO never answers GetVer and set_frame_rate can fail
+        // transiently. The `?` aborted do_init and left the shared control
+        // channel unusable, taking fans and RGB down with it. Degrade instead.
+        if let Err(e) = self.set_frame_rate(30) {
+            warn!("set_frame_rate failed, continuing anyway: {e:#}");
+        }
+        let sync = self.builder.sync_clock_header_winusb(2);
+        self.send_command(sync, "SyncClock");
+        let stop_clock = self.builder.stop_clock_header_winusb();
+        self.send_command(stop_clock, "StopClock");
+        self.transport.set_needs_init(false);
     }
 
     pub(crate) fn read_firmware(&mut self) {
@@ -706,8 +888,57 @@ impl WinUsbLcdCore {
         let transport = self.transport.lock();
         transport.write_full(&cmd.packet, self.write_timeout)?;
         let mut buf = [0u8; 512];
-        let _ = transport.read(&mut buf, cmd.reply_wait);
+        match transport.read(&mut buf, cmd.reply_wait) {
+            Ok(n) if n > 0 => debug!(
+                "Reply to deferred {} ({n} bytes): {:02x?}",
+                cmd.label,
+                &buf[..n.min(16)]
+            ),
+            Ok(_) => debug!("No reply to deferred {} (timeout)", cmd.label),
+            Err(e) => debug!("Reply read after deferred {} failed: {e}", cmd.label),
+        }
         Ok(())
+    }
+
+    /// Send the queued PushRgbData mid-stream and bring the panel back,
+    /// from the stream thread. StopPlay and StopClock
+    /// first, then `LcdLink::push_and_recover` (push, reopen, wait for
+    /// GetVer), then the H2 init again. The caller resumes the stream.
+    /// Cycles are spaced by `HOLD_MIN_INTERVAL`; a command that arrives
+    /// sooner stays queued for the next chunk.
+    pub(crate) fn reinit_and_flush_unsafe(&mut self, force: bool) -> Result<bool> {
+        if !self.transport.has_unsafe_pending() || !(force || self.transport.hold_allowed()) {
+            return Ok(false);
+        }
+        let cmds = self.transport.take_unsafe();
+        info!(
+            "H2 ring: stopping play for {} queued command(s)",
+            cmds.len()
+        );
+        let started = Instant::now();
+        let stop = self.builder.stop_play_header_winusb();
+        self.send_command(stop, "StopPlay");
+        std::thread::sleep(WAKE_STEP);
+        let stop_clock = self.builder.stop_clock_header_winusb();
+        self.send_command(stop_clock, "StopClock");
+        std::thread::sleep(WAKE_STEP);
+        if let Err(e) = self
+            .transport
+            .push_and_recover(&self.name, &cmds, self.write_timeout, true)
+        {
+            // Nothing confirmed delivered: put the commands back so the
+            // next stream start or control-channel write retries them.
+            for cmd in cmds {
+                self.transport.defer(cmd);
+            }
+            return Err(e);
+        }
+        self.h2_control_init();
+        info!(
+            "H2 ring: push and reinit done in {} ms",
+            started.elapsed().as_millis()
+        );
+        Ok(true)
     }
 
     fn send_h264_chunk(
@@ -766,25 +997,44 @@ impl WinUsbLcdCore {
         self.transport.set_streaming(true);
     }
 
-    /// Mark the end of a stream. If it ended cleanly the panel is idle now, so
-    /// anything still queued goes out directly (bypassing the level check);
-    /// after an error the queue is dropped rather than hammering a device that
-    /// just stopped answering.
+    /// Mark the end of a stream and flush the play-safe commands the control
+    /// channel queued while it ran. After an error the queue is dropped
+    /// rather than hammering a device that just stopped answering.
+    ///
+    /// Commands that are unsafe in play mode go through the reinit
+    /// sequence instead of straight onto the wire: the host stopping the
+    /// feed does not idle the panel, and a PushRgbData sent here wedged
+    /// the MCU twice on 2026-09-06, once straight after the feed stopped
+    /// and once after an acknowledged StopPlay.
     fn stream_end(&mut self, clean: bool) {
         {
             let _bulk = self.transport.lock();
             self.transport.set_streaming(false);
         }
-        let pending = self.transport.take_pending();
         if !clean {
+            // Play-safe commands are resent every tick anyway; a queued
+            // ring write is kept for the next stream start or the control
+            // channel, so a later identical write is not deduplicated away.
+            self.transport.take_play_safe();
             return;
         }
-        for cmd in pending {
+        for cmd in self.transport.take_play_safe() {
             debug!("Sending deferred {} after stream end", cmd.label);
             if let Err(e) = self.send_deferred(&cmd) {
                 warn!("Deferred {} write failed: {e}", cmd.label);
             }
         }
+        // No stream left to protect, so the spacing does not apply here.
+        if let Err(e) = self.reinit_and_flush_unsafe(true) {
+            warn!("Panel reinit at stream end failed: {e:#}");
+        }
+    }
+
+    /// Mid-stream hold: a command that cannot go out in play mode is
+    /// waiting, so stop play, reinitialise, send it, and let the caller
+    /// carry on streaming. Returns true if a hold happened.
+    fn hold_for_unsafe_pending(&mut self) -> Result<bool> {
+        self.reinit_and_flush_unsafe(false)
     }
 
     pub(crate) fn stream_h264(
@@ -801,6 +1051,9 @@ impl WinUsbLcdCore {
         let interval = chunk_interval(fps);
         let mut next_deadline = Instant::now() + interval;
 
+        // A ring write queued while the panel sat idle after an earlier
+        // stream goes out now, before play starts, via the same reinit path.
+        self.reinit_and_flush_unsafe(false)?;
         self.stream_begin();
         let result = self.stream_h264_inner(
             &mut file,
@@ -847,6 +1100,13 @@ impl WinUsbLcdCore {
                 pos >= len
             };
             self.send_h264_chunk(&file_buf[..n], is_last, play_count, play_tick, stop)?;
+            if self.hold_for_unsafe_pending()? {
+                // Play was stopped and the panel reinitialised; restart the
+                // clip from its first keyframe rather than resuming mid-GOP.
+                file.seek(std::io::SeekFrom::Start(0))?;
+                *next_deadline = Instant::now() + interval;
+                continue;
+            }
             sleep_until(next_deadline, interval);
         }
 
@@ -863,6 +1123,7 @@ impl WinUsbLcdCore {
         play_tick: u32,
     ) -> Result<()> {
         let mut buf = vec![0u8; self.h264_chunk_size];
+        self.reinit_and_flush_unsafe(false)?;
         self.stream_begin();
         let result = (|| -> Result<()> {
             loop {
@@ -876,6 +1137,9 @@ impl WinUsbLcdCore {
                     break;
                 }
                 self.send_h264_chunk(&buf[..n], false, play_count, play_tick, stop)?;
+                // Live feed: cannot rewind, the decoder resyncs at the next
+                // keyframe after a hold.
+                self.hold_for_unsafe_pending()?;
             }
             Ok(())
         })();

--- a/crates/lianli-devices/src/winusb/lcd/core.rs
+++ b/crates/lianli-devices/src/winusb/lcd/core.rs
@@ -24,6 +24,9 @@ pub struct PendingCmd {
     /// after it (2026-09-06); those only go out once the stream thread has
     /// stopped play and reinitialised the panel (see `reinit_and_flush_unsafe`).
     pub play_safe: bool,
+    /// Ring payload identity of a PushRgbData, recorded by the link once the
+    /// packet is actually on the wire so identical applies can be skipped.
+    pub ring_key: Option<(Vec<u8>, u8)>,
 }
 
 /// USB bulk handle shared by the LCD stream and the HydroShift II control
@@ -47,6 +50,9 @@ pub struct LcdLink {
     needs_init: AtomicBool,
     /// When the last push-and-recover cycle ran, to space cycles out.
     last_hold: Mutex<Option<Instant>>,
+    /// Ring payload of the last PushRgbData that reached the wire, used to
+    /// skip identical re applies. Defers never record.
+    last_ring: Mutex<Option<(Vec<u8>, u8)>>,
     pending: Mutex<Vec<PendingCmd>>,
 }
 
@@ -58,6 +64,7 @@ impl LcdLink {
             streaming: AtomicBool::new(false),
             needs_init: AtomicBool::new(false),
             last_hold: Mutex::new(None),
+            last_ring: Mutex::new(None),
             pending: Mutex::new(Vec::new()),
         }
     }
@@ -177,6 +184,9 @@ impl LcdLink {
             );
             bulk.write_full(&cmd.packet, write_timeout)
                 .with_context(|| format!("H2 ring: {} write", cmd.label))?;
+            if let Some(key) = &cmd.ring_key {
+                *self.last_ring.lock() = Some(key.clone());
+            }
             let mut buf = [0u8; 512];
             match bulk.read(&mut buf, cmd.reply_wait) {
                 Ok(n) if n > 0 => debug!(
@@ -227,6 +237,11 @@ impl LcdLink {
             ),
         }
         Ok(true)
+    }
+
+    /// Ring payload of the last PushRgbData that reached the wire.
+    pub(crate) fn last_ring_payload(&self) -> Option<(Vec<u8>, u8)> {
+        self.last_ring.lock().clone()
     }
 
     /// Queue a control command for the stream thread. Latest wins per label:

--- a/crates/lianli-devices/src/winusb/lcd/core.rs
+++ b/crates/lianli-devices/src/winusb/lcd/core.rs
@@ -146,6 +146,7 @@ impl LcdLink {
     pub(crate) fn push_and_recover(
         &self,
         name: &str,
+        preamble: &[(&'static str, Vec<u8>)],
         cmds: &[PendingCmd],
         write_timeout: Duration,
         from_stream_thread: bool,
@@ -153,6 +154,18 @@ impl LcdLink {
         let mut bulk = self.bulk.lock();
         if !from_stream_thread && self.is_streaming() {
             return Ok(false);
+        }
+        // Wake commands go out under the same guard as the streaming check,
+        // so a stream that begins meanwhile cannot see them land mid play
+        for (label, packet) in preamble {
+            bulk.write_full(packet, write_timeout)
+                .with_context(|| format!("H2 ring: {label} write"))?;
+            let mut buf = [0u8; 512];
+            match bulk.read(&mut buf, WAKE_REPLY_WAIT) {
+                Ok(n) if n > 0 => debug!("H2 ring: reply to {label} ({n} bytes)"),
+                Ok(_) => debug!("H2 ring: no reply to {label} (timeout)"),
+                Err(e) => debug!("H2 ring: no reply to {label}: {e}"),
+            }
         }
         let started = Instant::now();
         for cmd in cmds {
@@ -279,6 +292,8 @@ const CONTROL_RELAX_AFTER: Duration = Duration::from_secs(3);
 const REOPEN_DELAY: Duration = Duration::from_millis(100);
 /// Gap between the wake-preamble commands (StopPlay, StopClock, GetVer).
 const WAKE_STEP: Duration = Duration::from_millis(150);
+/// Reply wait for the wake commands inside a push and recover cycle.
+const WAKE_REPLY_WAIT: Duration = Duration::from_millis(100);
 /// After a PushRgbData and reopen: how long to poll GetVer for the panel
 /// to answer, the gap between polls, and each poll's reply wait.
 const PANEL_SILENCE_BUDGET: Duration = Duration::from_secs(10);
@@ -303,6 +318,9 @@ pub(crate) struct WinUsbLcdCore {
     pub(crate) h264_chunk_size: usize,
     pub(crate) device_gone: bool,
     pub(crate) firmware: Option<String>,
+    /// Frame rate the current stream asked for, reapplied after a reinit
+    /// cycle since h2_control_init resets the panel to 30.
+    stream_fps: Option<f32>,
 }
 
 /// Read the serial the kernel cached at enumeration, matching on bus/device
@@ -384,6 +402,7 @@ impl WinUsbLcdCore {
             h264_chunk_size: 202_752,
             device_gone: false,
             firmware: None,
+            stream_fps: None,
         })
     }
 
@@ -406,6 +425,7 @@ impl WinUsbLcdCore {
             h264_chunk_size: 202_752,
             device_gone: false,
             firmware: None,
+            stream_fps: None,
         }
     }
 
@@ -779,6 +799,7 @@ impl WinUsbLcdCore {
     }
 
     pub(crate) fn apply_stream_fps(&mut self, fps: f32) -> Result<()> {
+        self.stream_fps = Some(fps);
         let clamped = fps.round().clamp(1.0, self.screen.max_fps as f32) as u8;
         self.set_frame_rate(clamped)
     }
@@ -922,9 +943,9 @@ impl WinUsbLcdCore {
         let stop_clock = self.builder.stop_clock_header_winusb();
         self.send_command(stop_clock, "StopClock");
         std::thread::sleep(WAKE_STEP);
-        if let Err(e) = self
-            .transport
-            .push_and_recover(&self.name, &cmds, self.write_timeout, true)
+        if let Err(e) =
+            self.transport
+                .push_and_recover(&self.name, &[], &cmds, self.write_timeout, true)
         {
             // Nothing confirmed delivered: put the commands back so the
             // next stream start or control-channel write retries them.
@@ -934,6 +955,12 @@ impl WinUsbLcdCore {
             return Err(e);
         }
         self.h2_control_init();
+        // The init just reset the panel rate to 30, restore the stream rate
+        if let Some(fps) = self.stream_fps {
+            if let Err(e) = self.apply_stream_fps(fps) {
+                warn!("reapplying stream fps after reinit failed: {e:#}");
+            }
+        }
         info!(
             "H2 ring: push and reinit done in {} ms",
             started.elapsed().as_millis()
@@ -1007,6 +1034,7 @@ impl WinUsbLcdCore {
     /// the MCU twice on 2026-09-06, once straight after the feed stopped
     /// and once after an acknowledged StopPlay.
     fn stream_end(&mut self, clean: bool) {
+        self.stream_fps = None;
         {
             let _bulk = self.transport.lock();
             self.transport.set_streaming(false);

--- a/crates/lianli-devices/src/winusb/lcd/h2_lcd.rs
+++ b/crates/lianli-devices/src/winusb/lcd/h2_lcd.rs
@@ -34,17 +34,7 @@ impl H2WinUsbLcd {
     fn do_init(&mut self) -> Result<()> {
         self.core.init_logging();
         self.core.reset_failure_state();
-        self.core.read_firmware();
-        // FIX: this AIO never answers GetVer and set_frame_rate can fail
-        // transiently. The `?` aborted do_init and left the shared control
-        // channel unusable, taking fans and RGB down with it. Degrade instead.
-        if let Err(e) = self.core.set_frame_rate(30) {
-            tracing::warn!("set_frame_rate failed, continuing anyway: {e:#}");
-        }
-        let sync = self.core.builder_mut().sync_clock_header_winusb(2);
-        self.core.send_command(sync, "SyncClock");
-        let stop_clock = self.core.builder_mut().stop_clock_header_winusb();
-        self.core.send_command(stop_clock, "StopClock");
+        self.core.h2_control_init();
         // FIX: clear_layers() paints a black 480x480 PNG over the panel. With
         // `lcds: []` the daemon never draws anything afterwards, so the screen
         // stays black and the firmware's own content is wiped. Media streaming
@@ -78,19 +68,19 @@ impl WinUsbLcd for H2WinUsbLcd {
         self.core.transport_release()
     }
     fn initialize(&mut self) -> Result<()> {
-        if !self.core.initialized {
+        if !self.core.initialized || self.core.needs_init() {
             self.do_init()?;
         }
         Ok(())
     }
     fn send_frame(&mut self, frame: &[u8]) -> Result<()> {
-        if !self.core.initialized {
+        if !self.core.initialized || self.core.needs_init() {
             self.do_init()?;
         }
         self.core.send_frame(frame)
     }
     fn send_frame_verified(&mut self, frame: &[u8]) -> Result<()> {
-        if !self.core.initialized {
+        if !self.core.initialized || self.core.needs_init() {
             self.do_init()?;
         }
         self.core.send_frame_verified(frame)
@@ -108,7 +98,7 @@ impl WinUsbLcd for H2WinUsbLcd {
         stop: &AtomicBool,
         fps: f32,
     ) -> Result<()> {
-        if !self.core.initialized {
+        if !self.core.initialized || self.core.needs_init() {
             self.do_init()?;
         }
         self.core.apply_stream_fps(fps)?;
@@ -121,7 +111,7 @@ impl WinUsbLcd for H2WinUsbLcd {
         stop: &AtomicBool,
         fps: f32,
     ) -> Result<()> {
-        if !self.core.initialized {
+        if !self.core.initialized || self.core.needs_init() {
             self.do_init()?;
         }
         self.core.apply_stream_fps(fps)?;

--- a/crates/lianli-gui/src/types/index.ts
+++ b/crates/lianli-gui/src/types/index.ts
@@ -281,6 +281,8 @@ export interface RgbDeviceCapabilities {
   supported_scopes: RgbScope[][];
   supports_direction?: boolean;
   supports_merge_lighting?: boolean;
+  /** LEDs are driven over RF by a bound wireless device; hidden from the list. */
+  rf_owned?: boolean;
 }
 
 export interface RgbPresetZone {

--- a/crates/lianli-gui/src/views/RgbPage.vue
+++ b/crates/lianli-gui/src/views/RgbPage.vue
@@ -34,7 +34,7 @@ const statusText = computed(() => {
   return "Starting...";
 });
 
-const rgbCaps = computed(() => config.rgbCaps);
+const rgbCaps = computed(() => config.rgbCaps.filter((c) => !c.rf_owned));
 </script>
 
 <template>

--- a/crates/lianli-shared/src/rgb.rs
+++ b/crates/lianli-shared/src/rgb.rs
@@ -697,6 +697,10 @@ pub struct RgbDeviceCapabilities {
     /// Whether this device supports merge-lighting (cross-zone synchronized animation).
     #[serde(default)]
     pub supports_merge_lighting: bool,
+    /// The LEDs are driven over RF by a bound wireless device; writes to this
+    /// entry are skipped. Hidden by the GUI and the OpenRGB server.
+    #[serde(default)]
+    pub rf_owned: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]


### PR DESCRIPTION
Follow-up to #163 and the deferral folded into #152.

## Problem

On the wired HydroShift II (Square, `1cbe:a034`, fw 1.7) a `PushRgbData` on the shared bulk pipe silences the panel once the LCD has streamed H.264 in that session: bulk IN stops answering and stays that way for 70 s or more (over 80 s in one capture with the host still feeding chunks). #152's deferral sends the packet at stream end on the assumption the panel is idle then. It is not, and an acknowledged `StopPlay` first does not change that.

## What testing showed

Stop + reinit alone does not bring the panel back. Closing and reopening the USB handle does: in every captured cycle the panel answers `GetVer` within 0.9 s of the reopen. So the fix is the sequence from the review, plus the reopen:

`StopPlay`, `StopClock`, send `PushRgbData`, close and reopen the handle, poll `GetVer` until it answers, rerun the H2 init, resume the stream.

About 1.3 s of LCD pause per ring change, no read timeouts on the stream afterwards.

## Changes

**`lcd/core.rs`**: `LcdLink` carries the rusb `Device` so a core built on the shared transport can reopen it, and runs the cycle in `push_and_recover` under one bulk guard so nothing interleaves. The stream thread runs the cycle after a chunk when a `PushRgbData` is queued, at stream start, and at clean stream end. Cycles are spaced at least 3 s apart while streaming, and `defer` keeps only the latest write, so a burst of config saves ends in one push (a GUI save loop produced 17 back-to-back cycles in testing and the pipe died with EIO until a suspend/resume). The H2 init sequence moves into the core so both paths share it; the transport is flagged `needs_init` after a reopen so the driver reruns it before the next frame.

**`h2_aio.rs`**: off the stream thread, `send_rgb_frames` runs the same cycle itself instead of writing bare (a bare write between two streams silenced the panel in testing). `send_stranded` only drains play-safe commands. An unchanged ring payload is skipped, since the daemon re-applies every effect on each config reload, including LCD media switches, and each write would be a second of LCD pause. On a bridged unit the wired write is still skipped; the same 24-LED ring is driven over RF through the pump head.

**RF-owned tag** (unchanged from the first cut): `RgbDevice::rf_owned()`, `RgbDeviceCapabilities.rf_owned`, `RgbController::exposed_capabilities()` for the OpenRGB server, and the GUI RGB page filters tagged entries, mirroring the fan list.

Side effect worth knowing: because the shared transport can now reopen, the existing write-error recovery on a shared-transport core uses close+reopen where it used to fall back to `clear_halt`.

## Testing

- `cargo test -p lianli-devices -p lianli-daemon -p lianli-shared` pass, `vue-tsc --noEmit` clean.
- Hardware: HydroShift II Square bridged to a wireless AIO, wired path forced on for the test. Twelve cycles across template switches, colour changes and daemon restarts: each 0.9 to 1.3 s, panel answering after every reopen, stream back at full rate, template switches with an unchanged ring skipped.

## Not confirmed

Whether the colour lands on the ring. The test unit is bridged, so the pump head repaints the ring over RF and the push never returns a reply, so I can't tell whether the wired write took. Someone with a wired-only unit setting a ring colour on this branch would close that out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dcCwnizjNfRVtCD1vWx4L


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for identifying LEDs controlled through wireless connections.
  - Wireless-controlled LEDs are excluded from RGB device lists and OpenRGB device indexes.

- **Bug Fixes**
  - Avoided unnecessary wireless RGB transmissions when lighting data is unchanged.
  - Improved LCD command handling and recovery during streaming and reconnection.
  - RGB updates are now coordinated more reliably with LCD playback.
  - Restored the requested display refresh rate after LCD reinitialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->