### PR TITLE
fix(wireless): improve sync, binding, and connection recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ own were validated against real hardware, others rely on community testing and f
 | Lancool V150 Wireless | Yes | Yes | - | - | - |
 | Universal Screen 8.8" Wireless | - | Yes | - | - | - |
 
-Both V1 (VID 0x0416) and V2 (VID 0x1A86) wireless dongles are supported. Binding devices is supported through the GUI, which reports command completion or failure. Wireless control requires both TX and RX dongles.
+Both V1 (VID 0x0416) and V2 (VID 0x1A86) wireless dongles are supported. Binding devices is supported through the GUI, which reports command completion or failure. Wireless control requires both TX and RX dongles. Saved fan and lighting settings do not automatically bind an unbound group on startup, use the GUI to bind it explicitly.
 
 Wireless SL V3 fans support hardware motherboard PWM sync. Other wireless fans can follow a selected Linux PWM header; if that source is missing or becomes unreadable, they run at full speed until it returns.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ own were validated against real hardware, others rely on community testing and f
 | Lancool V150 Wireless | Yes | Yes | - | - | - |
 | Universal Screen 8.8" Wireless | - | Yes | - | - | - |
 
-Both V1 (VID 0x0416) and V2 (VID 0x1A86) wireless dongles are supported. Binding devices is supported through the GUI.
+Both V1 (VID 0x0416) and V2 (VID 0x1A86) wireless dongles are supported. Binding devices is supported through the GUI, which reports command completion or failure. Wireless control requires both TX and RX dongles.
+
+Wireless SL V3 fans support hardware motherboard PWM sync. Other wireless fans can follow a selected Linux PWM header; if that source is missing or becomes unreadable, they run at full speed until it returns.
 
 > **Note:** Wireless devices with LCDs still need to be plugged in via USB to control the LCD. LCD cannot be controlled through wireless dongle alone.
 

--- a/crates/lianli-daemon/src/controllers/aio.rs
+++ b/crates/lianli-daemon/src/controllers/aio.rs
@@ -14,7 +14,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tracing::{debug, info, warn};
 
 const TICK: Duration = Duration::from_secs(1);
@@ -111,7 +111,7 @@ fn run(
 ) {
     let all_sensors = enumerate_sensors();
     let mut sensor_cache: HashMap<SensorSource, ResolvedSensor> = HashMap::new();
-    let mut switched: HashSet<[u8; 6]> = HashSet::new();
+    let mut switched: HashMap<[u8; 6], ThemeSwitch> = HashMap::new();
     // Last-sent speeds for wireless slots that resolve to "no target"
     // (off / missing curve / sensor failure): hold instead of dropping to 0.
     let mut wireless_hold: HashMap<[u8; 6], [u8; 4]> = HashMap::new();
@@ -153,7 +153,7 @@ fn run(
         );
 
         let live_macs: HashSet<[u8; 6]> = devices.iter().map(|d| d.mac).collect();
-        switched.retain(|m| live_macs.contains(m));
+        switched.retain(|m, _| live_macs.contains(m));
         wireless_hold.retain(|m, _| live_macs.contains(m));
 
         thread::sleep(TICK);
@@ -162,12 +162,18 @@ fn run(
     debug!("AioController stopped");
 }
 
+struct ThemeSwitch {
+    sequence: u8,
+    sent_at: Instant,
+    acknowledged: bool,
+}
+
 fn control_wireless(
     wireless: &WirelessController,
     devices: &[DiscoveredDevice],
     cfg: &AppConfig,
     curves: &HashMap<String, FanCurve>,
-    switched: &mut HashSet<[u8; 6]>,
+    switched: &mut HashMap<[u8; 6], ThemeSwitch>,
     wireless_hold: &mut HashMap<[u8; 6], [u8; 4]>,
     sensor_cache: &mut HashMap<SensorSource, ResolvedSensor>,
     all_sensors: &[SensorInfo],
@@ -181,18 +187,39 @@ fn control_wireless(
             continue;
         };
 
-        if !switched.contains(&device.mac) {
+        let needs_switch = match switched.get_mut(&device.mac) {
+            Some(state) => {
+                if !state.acknowledged
+                    && wireless.wireless_theme_acked(&device.mac, state.sequence, state.sent_at)
+                {
+                    state.acknowledged = true;
+                    info!(
+                        "AIO {}: wireless theme command acknowledged",
+                        device.mac_str()
+                    );
+                }
+                !state.acknowledged && state.sent_at.elapsed() >= Duration::from_secs(2)
+            }
+            None => true,
+        };
+        if needs_switch {
+            let sent_at = Instant::now();
             match wireless.switch_to_wireless_theme(&device.mac) {
-                Ok(()) => {
-                    switched.insert(device.mac);
-                    info!("AIO {}: wireless theme mode engaged", device.mac_str());
+                Ok(sequence) => {
+                    switched.insert(
+                        device.mac,
+                        ThemeSwitch {
+                            sequence,
+                            sent_at,
+                            acknowledged: false,
+                        },
+                    );
                 }
                 Err(e) => {
                     warn!(
                         "AIO {}: switch_to_wireless_theme failed: {e:#}",
                         device.mac_str()
                     );
-                    continue;
                 }
             }
         }

--- a/crates/lianli-daemon/src/controllers/fan.rs
+++ b/crates/lianli-daemon/src/controllers/fan.rs
@@ -308,14 +308,16 @@ fn fan_control_thread(
                 if let Some(ref device_id) = group.device_id {
                     if let Some(ref w) = wireless {
                         let mac_str = device_id.strip_prefix("wireless:").unwrap_or(device_id);
-                        let is_hw_sync = w
+                        let hw_sync_device = w
                             .devices()
                             .iter()
                             .find(|d| d.mac_str() == mac_str)
-                            .map(|d| d.fan_type.supports_hw_mobo_sync())
-                            .unwrap_or(false);
-                        if is_hw_sync {
-                            apply_wireless_by_id(&wireless, device_id, &[6, 6, 6, 6], group_idx);
+                            .filter(|d| d.fan_type.supports_hw_mobo_sync())
+                            .map(|d| d.mac);
+                        if let Some(mac) = hw_sync_device {
+                            if let Err(err) = w.set_hardware_pwm_sync(&mac) {
+                                warn!("Failed to enable hardware PWM sync for {device_id}: {err}");
+                            }
                             continue;
                         }
                     }
@@ -536,11 +538,7 @@ fn calculate_fan_speeds(
         pwm_values[i] = match fan_speed {
             FanSpeed::Constant(value) => *value,
             _ if fan_speed.is_mb_sync() => {
-                if let Some(source) = fan_speed.mb_sync_source() {
-                    lianli_shared::sensors::read_pwm_header(source).unwrap_or(0)
-                } else {
-                    0
-                }
+                software_sync_pwm(fan_speed, lianli_shared::sensors::read_pwm_header)
             }
             FanSpeed::Curve(curve_name) => {
                 let curve = curves
@@ -659,5 +657,27 @@ fn resolve_and_read(
             cache.remove(source);
             None
         }
+    }
+}
+
+fn software_sync_pwm(speed: &FanSpeed, read: impl FnOnce(&str) -> Option<u8>) -> u8 {
+    speed.mb_sync_source().and_then(read).unwrap_or(255)
+}
+
+#[cfg(test)]
+mod sync_tests {
+    use super::*;
+
+    #[test]
+    fn missing_software_pwm_source_runs_full_speed() {
+        let missing: FanSpeed = serde_json::from_str("\"__mb_sync__\"").unwrap();
+        assert_eq!(
+            software_sync_pwm(&missing, |_| panic!("bare sync must not read a header")),
+            255
+        );
+        let selected: FanSpeed = serde_json::from_str("\"__mb_sync__:test-header\"").unwrap();
+        assert_eq!(software_sync_pwm(&selected, |_| Some(128)), 128);
+        assert_eq!(software_sync_pwm(&selected, |_| None), 255);
+        assert_eq!(software_sync_pwm(&selected, |_| Some(0)), 0);
     }
 }

--- a/crates/lianli-daemon/src/controllers/rgb/upload.rs
+++ b/crates/lianli-daemon/src/controllers/rgb/upload.rs
@@ -194,7 +194,7 @@ impl UploadWorker {
                 }
                 job.attempts = 0;
                 if pending.jobs.len() < MAX_PENDING_DEVICES {
-                    job.ready = Instant::now() + Duration::from_millis(30);
+                    job.ready = Instant::now() + Duration::from_millis(130);
                     pending.jobs.push_back(job);
                 }
             }

--- a/crates/lianli-daemon/src/ipc/server.rs
+++ b/crates/lianli-daemon/src/ipc/server.rs
@@ -28,6 +28,7 @@ pub struct DaemonState {
     pub presets_path: PathBuf,
     pub devices: Vec<DeviceInfo>,
     pub telemetry: TelemetrySnapshot,
+    pub wireless_operations: super::wireless::WirelessOperations,
     /// RGB controller, set once devices are opened.
     pub rgb_controller: Option<Arc<Mutex<RgbController>>>,
     pub user_templates: Vec<LcdTemplate>,
@@ -47,6 +48,7 @@ impl DaemonState {
             presets_path,
             devices: Vec::new(),
             telemetry: TelemetrySnapshot::default(),
+            wireless_operations: Default::default(),
             rgb_controller: None,
             user_templates: Vec::new(),
             rgb_presets,
@@ -225,8 +227,11 @@ fn handle_request(
             super::lcd::switch_display_mode(state, tx, device_id)
         }
 
-        IpcRequest::BindWirelessDevice { mac } => super::wireless::bind(tx, mac),
-        IpcRequest::UnbindWirelessDevice { mac } => super::wireless::unbind(tx, mac),
+        IpcRequest::GetWirelessOperation { operation_id } => {
+            super::wireless::operation(state, operation_id)
+        }
+        IpcRequest::BindWirelessDevice { mac } => super::wireless::bind(state, tx, mac),
+        IpcRequest::UnbindWirelessDevice { mac } => super::wireless::unbind(state, tx, mac),
         IpcRequest::RebootWirelessLcd { device_id } => super::wireless::reboot_lcd(tx, device_id),
         IpcRequest::DisableLc217Wifi { device_id, disable } => {
             super::wireless::disable_lc217_wifi(tx, device_id, disable)

--- a/crates/lianli-daemon/src/ipc/wireless.rs
+++ b/crates/lianli-daemon/src/ipc/wireless.rs
@@ -2,7 +2,9 @@
 
 use std::sync::mpsc::Sender;
 
-use lianli_shared::ipc::IpcResponse;
+use super::SharedState;
+use lianli_shared::ipc::{IpcResponse, WirelessOperationStatus};
+use std::collections::BTreeMap;
 
 use crate::service::DaemonEvent;
 
@@ -18,25 +20,113 @@ fn parse_mac(device_id: &str) -> Option<[u8; 6]> {
     Some(mac)
 }
 
-pub fn bind(tx: Sender<DaemonEvent>, mac: String) -> IpcResponse {
-    let _ = tx.send(DaemonEvent::Bind { mac_address: mac });
-    IpcResponse::ok(serde_json::json!({
-        "message": "Bind command queued. Device should appear shortly."
-    }))
+pub struct WirelessOperations {
+    session: String,
+    next_id: u64,
+    entries: BTreeMap<String, WirelessOperationStatus>,
 }
 
-pub fn unbind(tx: Sender<DaemonEvent>, mac: String) -> IpcResponse {
-    let _ = tx.send(DaemonEvent::Unbind { mac_address: mac });
-    IpcResponse::ok(serde_json::json!({
-        "message": "Unbind command queued."
-    }))
+impl Default for WirelessOperations {
+    fn default() -> Self {
+        let started = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default();
+        Self {
+            session: format!("{:x}-{:x}", std::process::id(), started.as_nanos()),
+            next_id: 0,
+            entries: BTreeMap::new(),
+        }
+    }
+}
+
+impl WirelessOperations {
+    fn reserve(&mut self) -> anyhow::Result<String> {
+        if self.entries.len() >= 64 {
+            let completed = self.entries.iter().find_map(|(id, status)| {
+                (!matches!(status, WirelessOperationStatus::Pending)).then(|| id.clone())
+            });
+            let id =
+                completed.ok_or_else(|| anyhow::anyhow!("wireless operation queue is full"))?;
+            self.entries.remove(&id);
+        }
+        self.next_id = self
+            .next_id
+            .checked_add(1)
+            .ok_or_else(|| anyhow::anyhow!("wireless operation IDs exhausted"))?;
+        let id = format!("{}-{}", self.session, self.next_id);
+        self.entries
+            .insert(id.clone(), WirelessOperationStatus::Pending);
+        Ok(id)
+    }
+
+    pub(crate) fn complete(&mut self, id: &str, result: anyhow::Result<()>) {
+        if let Some(status) = self.entries.get_mut(id) {
+            *status = match result {
+                Ok(()) => WirelessOperationStatus::Succeeded,
+                Err(error) => WirelessOperationStatus::Failed {
+                    message: format!("{error:#}"),
+                },
+            };
+        }
+    }
+}
+
+pub fn operation(state: &SharedState, id: String) -> IpcResponse {
+    match state.lock().wireless_operations.entries.get(&id) {
+        Some(status) => IpcResponse::ok(status),
+        None => IpcResponse::error("wireless operation not found or expired"),
+    }
+}
+
+pub fn bind(state: &SharedState, tx: Sender<DaemonEvent>, mac: String) -> IpcResponse {
+    queue_binding(state, tx, mac, true)
+}
+
+pub fn unbind(state: &SharedState, tx: Sender<DaemonEvent>, mac: String) -> IpcResponse {
+    queue_binding(state, tx, mac, false)
+}
+
+fn queue_binding(
+    state: &SharedState,
+    tx: Sender<DaemonEvent>,
+    mac: String,
+    bind: bool,
+) -> IpcResponse {
+    if parse_mac(&format!("wireless:{mac}")).is_none() {
+        return IpcResponse::error("invalid wireless MAC address");
+    }
+    let mut state = state.lock();
+    let operation_id = match state.wireless_operations.reserve() {
+        Ok(id) => id,
+        Err(error) => return IpcResponse::error(error.to_string()),
+    };
+    let event = if bind {
+        DaemonEvent::Bind {
+            mac_address: mac,
+            operation_id: operation_id.clone(),
+        }
+    } else {
+        DaemonEvent::Unbind {
+            mac_address: mac,
+            operation_id: operation_id.clone(),
+        }
+    };
+    if tx.send(event).is_err() {
+        state.wireless_operations.entries.remove(&operation_id);
+        return IpcResponse::error("wireless command queue is disconnected");
+    }
+    IpcResponse::ok(
+        serde_json::json!({ "operation_id": operation_id, "message": "Wireless command queued." }),
+    )
 }
 
 pub fn reboot_lcd(tx: Sender<DaemonEvent>, device_id: String) -> IpcResponse {
     let Some(mac) = parse_mac(&device_id) else {
         return IpcResponse::error("invalid device_id format");
     };
-    let _ = tx.send(DaemonEvent::RebootWirelessLcd { mac });
+    if tx.send(DaemonEvent::RebootWirelessLcd { mac }).is_err() {
+        return IpcResponse::error("wireless command queue is disconnected");
+    }
     IpcResponse::ok(serde_json::json!({"message": "LCD reboot queued."}))
 }
 
@@ -48,17 +138,26 @@ pub fn disable_lc217_wifi(
     let Some(mac) = parse_mac(&device_id) else {
         return IpcResponse::error("invalid device_id format");
     };
-    let _ = tx.send(DaemonEvent::DisableLc217Wifi { mac, disable });
+    if tx
+        .send(DaemonEvent::DisableLc217Wifi { mac, disable })
+        .is_err()
+    {
+        return IpcResponse::error("wireless command queue is disconnected");
+    }
     IpcResponse::ok(serde_json::json!({"message": "LC217 wifi toggle queued."}))
 }
 
 pub fn bind_all(tx: Sender<DaemonEvent>) -> IpcResponse {
-    let _ = tx.send(DaemonEvent::BindAll);
+    if tx.send(DaemonEvent::BindAll).is_err() {
+        return IpcResponse::error("wireless command queue is disconnected");
+    }
     IpcResponse::ok(serde_json::json!({"message": "Bind all queued."}))
 }
 
 pub fn unbind_all(tx: Sender<DaemonEvent>) -> IpcResponse {
-    let _ = tx.send(DaemonEvent::UnbindAll);
+    if tx.send(DaemonEvent::UnbindAll).is_err() {
+        return IpcResponse::error("wireless command queue is disconnected");
+    }
     IpcResponse::ok(serde_json::json!({"message": "Unbind all queued."}))
 }
 
@@ -72,5 +171,66 @@ pub fn get_channel(state: &std::sync::Arc<parking_lot::Mutex<super::DaemonState>
         IpcResponse::ok(serde_json::json!({"channel": dev.serial}))
     } else {
         IpcResponse::error("no wireless device found")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn operation_ids_do_not_alias_across_daemon_sessions() {
+        let mut previous = WirelessOperations {
+            session: "previous".into(),
+            ..Default::default()
+        };
+        let mut current = WirelessOperations {
+            session: "current".into(),
+            ..Default::default()
+        };
+        let previous_id = previous.reserve().unwrap();
+        let current_id = current.reserve().unwrap();
+        assert_ne!(previous_id, current_id);
+        assert!(!current.entries.contains_key(&previous_id));
+    }
+
+    #[test]
+    fn operation_results_are_bounded_and_pending_work_is_never_evicted() {
+        let mut operations = WirelessOperations::default();
+        let first = operations.reserve().unwrap();
+        for _ in 1..64 {
+            operations.reserve().unwrap();
+        }
+        assert!(operations.reserve().is_err());
+        assert!(matches!(
+            operations.entries[&first],
+            WirelessOperationStatus::Pending
+        ));
+        operations.complete(&first, Err(anyhow::anyhow!("receiver timed out")));
+        let result = serde_json::to_value(&operations.entries[&first]).unwrap();
+        assert_eq!(
+            result,
+            serde_json::json!({"status": "failed", "message": "receiver timed out"})
+        );
+        let next = operations.reserve().unwrap();
+        assert!(!operations.entries.contains_key(&first));
+        assert_eq!(operations.entries.len(), 64);
+        operations.complete(&next, Ok(()));
+        assert!(matches!(
+            operations.entries[&next],
+            WirelessOperationStatus::Succeeded
+        ));
+    }
+
+    #[test]
+    fn disconnected_queue_does_not_report_acceptance_or_retain_pending_operation() {
+        let state = std::sync::Arc::new(parking_lot::Mutex::new(super::super::DaemonState::new(
+            std::path::PathBuf::from("/tmp/lianli-wireless-ipc-test/config.json"),
+        )));
+        let (tx, rx) = std::sync::mpsc::channel();
+        drop(rx);
+        let result = bind(&state, tx, "01:02:03:04:05:06".into());
+        assert!(matches!(result, IpcResponse::Error { .. }));
+        assert!(state.lock().wireless_operations.entries.is_empty());
     }
 }

--- a/crates/lianli-daemon/src/service/init.rs
+++ b/crates/lianli-daemon/src/service/init.rs
@@ -811,25 +811,6 @@ impl ServiceManager {
         configured_ids
     }
 
-    fn auto_rebind_configured_wireless(&mut self) {
-        let configured_ids = self.configured_wireless_device_ids();
-
-        for dev in self.wireless.unbound_devices() {
-            if dev.master_mac != [0u8; 6] {
-                continue;
-            }
-            let device_id = format!("wireless:{}", dev.mac_str());
-            if !configured_ids.contains(&device_id) {
-                continue;
-            }
-
-            info!("Auto-rebinding configured wireless device {device_id}");
-            if let Err(err) = self.wireless.bind_device(&dev.mac) {
-                warn!("Auto-rebind failed for {device_id}: {err}");
-            }
-        }
-    }
-
     pub(super) fn try_wireless(&mut self) {
         if !lianli_devices::wireless::tx_dongle_present() {
             debug!("[wireless] no TX/RX devices found, skipping wireless");
@@ -843,7 +824,6 @@ impl ServiceManager {
             Ok(()) => match self.wireless.start_polling() {
                 Ok(()) => {
                     let _ = self.wireless.send_rx_sequence();
-                    self.auto_rebind_configured_wireless();
                     info!("Wireless links active");
                 }
                 Err(err) => warn!("[wireless] polling start failed: {err}"),

--- a/crates/lianli-daemon/src/service/init.rs
+++ b/crates/lianli-daemon/src/service/init.rs
@@ -835,6 +835,10 @@ impl ServiceManager {
             debug!("[wireless] no TX/RX devices found, skipping wireless");
             return;
         }
+        let restart_controllers = self.controllers.fan.is_some() || self.controllers.aio.is_some();
+        if let Some(rgb) = &self.controllers.rgb {
+            rgb.lock().set_wireless(None);
+        }
         match self.wireless.connect() {
             Ok(()) => match self.wireless.start_polling() {
                 Ok(()) => {
@@ -847,6 +851,11 @@ impl ServiceManager {
             Err(_) => {
                 debug!("[wireless] no TX/RX devices found, skipping wireless");
             }
+        }
+        if restart_controllers {
+            self.start_fan_control();
+            self.start_aio_control();
+            self.rebuild_rgb_controller();
         }
     }
 

--- a/crates/lianli-daemon/src/service/mod.rs
+++ b/crates/lianli-daemon/src/service/mod.rs
@@ -108,10 +108,12 @@ pub enum DaemonEvent {
     }, // Desktop→LCD. Handled by main event loop.
     Bind {
         mac_address: String,
-    }, // MAC address pending wireless device bind. Handled by main event loop.
+        operation_id: String,
+    },
     Unbind {
         mac_address: String,
-    }, // MAC address pending wireless device unbind. Handled by main event loop.
+        operation_id: String,
+    },
     SetEne6k77FanQuantity {
         device_id: String,
         quantity: u8,
@@ -661,28 +663,38 @@ impl ServiceManager {
                     self.handle_display_switch_to_lcd(&device_id, pid);
                 }
                 DaemonEvent::Bind {
-                    mac_address: mac_str,
+                    mac_address,
+                    operation_id,
                 } => {
-                    if let Some(mac) = parse_mac_str(&mac_str) {
-                        if let Err(e) = self.wireless.bind_device(&mac) {
-                            warn!("Failed to bind wireless device {mac_str}: {e}");
-                        }
-                        self.device_poll();
-                    } else {
-                        warn!("Invalid MAC address for bind: {mac_str}");
+                    let result = parse_mac_str(&mac_address)
+                        .ok_or_else(|| anyhow::anyhow!("invalid wireless MAC address"))
+                        .and_then(|mac| self.wireless.bind_device(&mac));
+                    if let Err(error) = &result {
+                        warn!("Failed to bind wireless device {mac_address}: {error:#}");
                     }
+                    self.ipc
+                        .state
+                        .lock()
+                        .wireless_operations
+                        .complete(&operation_id, result);
+                    self.device_poll();
                 }
                 DaemonEvent::Unbind {
-                    mac_address: mac_str,
+                    mac_address,
+                    operation_id,
                 } => {
-                    if let Some(mac) = parse_mac_str(&mac_str) {
-                        if let Err(e) = self.wireless.unbind_device(&mac) {
-                            warn!("Failed to unbind wireless device {mac_str}: {e}");
-                        }
-                        self.device_poll();
-                    } else {
-                        warn!("Invalid MAC address for unbind: {mac_str}");
+                    let result = parse_mac_str(&mac_address)
+                        .ok_or_else(|| anyhow::anyhow!("invalid wireless MAC address"))
+                        .and_then(|mac| self.wireless.unbind_device(&mac));
+                    if let Err(error) = &result {
+                        warn!("Failed to unbind wireless device {mac_address}: {error:#}");
                     }
+                    self.ipc
+                        .state
+                        .lock()
+                        .wireless_operations
+                        .complete(&operation_id, result);
+                    self.device_poll();
                 }
                 DaemonEvent::SetEne6k77FanQuantity {
                     device_id,

--- a/crates/lianli-devices/src/wireless/aio.rs
+++ b/crates/lianli-devices/src/wireless/aio.rs
@@ -175,13 +175,14 @@ mod aio_tests {
             .raw_seen = Instant::now();
         assert!(controller.wireless_theme_acked(&mac, 7, sent_at));
         assert!(!controller.wireless_theme_acked(&mac, 8, sent_at));
+        let stale_seen = Instant::now() - ACK_FRESHNESS - std::time::Duration::from_millis(1);
         controller
             .device_health
             .lock()
             .get_mut(&mac)
             .unwrap()
-            .raw_seen = sent_at - ACK_FRESHNESS;
-        assert!(!controller.wireless_theme_acked(&mac, 7, sent_at - ACK_FRESHNESS));
+            .raw_seen = stale_seen;
+        assert!(!controller.wireless_theme_acked(&mac, 7, stale_seen));
     }
 
     #[test]

--- a/crates/lianli-devices/src/wireless/aio.rs
+++ b/crates/lianli-devices/src/wireless/aio.rs
@@ -1,43 +1,42 @@
 use super::controller::WirelessController;
+use super::convergence::AckSignal;
 use super::discovery::DiscoveredDevice;
+use super::discovery::ACK_FRESHNESS;
 use super::fan_type::WirelessFanType;
-use super::{
-    AIO_PARAM_LEN, RF_AIO_PARAMS, RF_AIO_SWITCH_WIRELESS, RF_CHUNKS, RF_CHUNK_SIZE, RF_DATA_SIZE,
-    RF_SELECT, USB_CMD_SEND_RF,
-};
-use anyhow::{Context, Result};
-use lianli_transport::usb::{RusbBulk, USB_TIMEOUT};
-use std::thread;
-use std::time::Duration;
+use super::{AIO_PARAM_LEN, RF_AIO_PARAMS, RF_AIO_SWITCH_WIRELESS, RF_DATA_SIZE, RF_SELECT};
+use anyhow::Result;
+use std::time::Instant;
 use tracing::debug;
 
 impl WirelessController {
-    /// Signal an AIO device to start honouring RF-driven theme / pump state.
-    /// Must be sent once per AIO MAC after discovery, before the first `set_aio_params`.
-    /// Idempotent — safe to re-invoke on reconnects.
-    pub fn switch_to_wireless_theme(&self, mac: &[u8; 6]) -> Result<()> {
+    pub fn switch_to_wireless_theme(&self, mac: &[u8; 6]) -> Result<u8> {
         let device = self.device_by_mac_snapshot(mac)?;
         let master_mac = *self.master_mac.lock();
         let master_ch = *self.master_channel.lock();
 
-        let mut rf_data = vec![0u8; RF_DATA_SIZE];
-        rf_data[0] = RF_SELECT;
-        rf_data[1] = RF_AIO_SWITCH_WIRELESS;
-        rf_data[2..8].copy_from_slice(&device.mac);
-        rf_data[8..14].copy_from_slice(&master_mac);
-        rf_data[14] = device.rx_type;
-        rf_data[15] = master_ch;
+        let sequence = self.bump_target_cmd_seq(mac, device.cmd_seq);
+        let rf_data = wireless_theme_packet(
+            &device,
+            &master_mac,
+            master_ch,
+            self.next_slot_index(&device),
+            sequence,
+        );
+        self.enqueue_rf_command(
+            &device,
+            rf_data,
+            AckSignal::CmdSeq(sequence),
+            "AIO wireless theme",
+        )?;
+        Ok(sequence)
+    }
 
-        self.tx_recover(|handle| {
-            for _ in 0..10 {
-                send_rf_frame_via(handle, &device, &rf_data)?;
-                thread::sleep(Duration::from_millis(2));
-            }
-            Ok(())
-        })?;
-
-        debug!("switch_to_wireless_theme sent to {}", device.mac_str());
-        Ok(())
+    pub fn wireless_theme_acked(&self, mac: &[u8; 6], sequence: u8, sent_at: Instant) -> bool {
+        self.device_health.lock().get(mac).is_some_and(|health| {
+            health.raw_seen >= sent_at
+                && health.raw_seen.elapsed() <= ACK_FRESHNESS
+                && health.published.cmd_seq == sequence
+        })
     }
 
     /// Send the 32-byte aio_param block. Carries pump speed, on-screen sensor
@@ -59,7 +58,7 @@ impl WirelessController {
         rf_data[16] = slot_index;
         rf_data[18..18 + AIO_PARAM_LEN].copy_from_slice(aio_param);
 
-        self.tx_recover(|handle| send_rf_frame_via(handle, &device, &rf_data))?;
+        self.tx_recover(|handle| self.send_rf_packet(handle, &device, &rf_data))?;
 
         debug!(
             "set_aio_params sent to {} (pump_timer={}, theme={})",
@@ -71,25 +70,23 @@ impl WirelessController {
     }
 }
 
-fn send_rf_frame_via(handle: &RusbBulk, device: &DiscoveredDevice, rf_data: &[u8]) -> Result<()> {
-    assert_eq!(rf_data.len(), RF_DATA_SIZE);
-    for chunk_idx in 0..RF_CHUNKS as u8 {
-        let mut packet = vec![0u8; 64];
-        packet[0] = USB_CMD_SEND_RF;
-        packet[1] = chunk_idx;
-        packet[2] = device.channel;
-        packet[3] = device.rx_type;
-
-        let start = chunk_idx as usize * RF_CHUNK_SIZE;
-        let end = start + RF_CHUNK_SIZE;
-        packet[4..64].copy_from_slice(&rf_data[start..end]);
-
-        handle
-            .write(&packet, USB_TIMEOUT)
-            .context("sending RF packet chunk")?;
-        thread::sleep(Duration::from_millis(1));
-    }
-    Ok(())
+fn wireless_theme_packet(
+    device: &DiscoveredDevice,
+    master_mac: &[u8; 6],
+    channel: u8,
+    slot: u8,
+    sequence: u8,
+) -> Vec<u8> {
+    let mut packet = vec![0; RF_DATA_SIZE];
+    packet[0] = RF_SELECT;
+    packet[1] = RF_AIO_SWITCH_WIRELESS;
+    packet[2..8].copy_from_slice(&device.mac);
+    packet[8..14].copy_from_slice(master_mac);
+    packet[14] = device.rx_type;
+    packet[15] = channel;
+    packet[16] = slot;
+    packet[17] = sequence;
+    packet
 }
 
 /// Map pump target RPM → firmware PWM timer value for the given AIO variant.
@@ -145,6 +142,47 @@ fn square_pump_timer(rpm: u32) -> u16 {
 #[cfg(test)]
 mod aio_tests {
     use super::*;
+
+    #[test]
+    fn wireless_theme_packet_carries_slot_sequence_and_requires_fresh_ack() {
+        let mut record = [0; 42];
+        record[..6].copy_from_slice(&[1, 2, 3, 4, 5, 6]);
+        record[13] = 2;
+        record[18] = 10;
+        record[41] = 0x1c;
+        let device = super::super::discovery::parse_device_record(&record, 0).unwrap();
+        let packet = wireless_theme_packet(&device, &[9; 6], 8, 3, 7);
+        assert_eq!(
+            &packet[..18],
+            &[0x12, 0x19, 1, 2, 3, 4, 5, 6, 9, 9, 9, 9, 9, 9, 2, 8, 3, 7]
+        );
+        assert_eq!(packet.len(), 240);
+        assert!(packet[18..].iter().all(|&byte| byte == 0));
+
+        let controller = WirelessController::new();
+        let mac = device.mac;
+        let mut health = super::super::discovery::DeviceHealth::new(device);
+        health.published.cmd_seq = 7;
+        let sent_at = Instant::now();
+        health.raw_seen = sent_at - std::time::Duration::from_millis(1);
+        controller.device_health.lock().insert(mac, health);
+        assert!(!controller.wireless_theme_acked(&mac, 7, sent_at));
+        controller
+            .device_health
+            .lock()
+            .get_mut(&mac)
+            .unwrap()
+            .raw_seen = Instant::now();
+        assert!(controller.wireless_theme_acked(&mac, 7, sent_at));
+        assert!(!controller.wireless_theme_acked(&mac, 8, sent_at));
+        controller
+            .device_health
+            .lock()
+            .get_mut(&mac)
+            .unwrap()
+            .raw_seen = sent_at - ACK_FRESHNESS;
+        assert!(!controller.wireless_theme_acked(&mac, 7, sent_at - ACK_FRESHNESS));
+    }
 
     #[test]
     fn circle_curve_clamps_to_range() {

--- a/crates/lianli-devices/src/wireless/bind.rs
+++ b/crates/lianli-devices/src/wireless/bind.rs
@@ -150,7 +150,7 @@ impl WirelessController {
                 &self.device_health,
                 &self.master_entries,
                 &self.receiver_state,
-                &self.fg_sync,
+                &self.poll_stop,
                 &self.master_mac,
             );
 

--- a/crates/lianli-devices/src/wireless/bind.rs
+++ b/crates/lianli-devices/src/wireless/bind.rs
@@ -11,20 +11,36 @@ use tracing::info;
 
 impl WirelessController {
     pub fn bind_device(&self, mac: &[u8; 6]) -> Result<()> {
+        let _binding = self.begin_binding(mac)?;
         self.check_bind_allowed(mac)?;
         let master_mac = *self.master_mac.lock();
         let new_rx = self.get_rx_unused();
-        self.set_bind_intent(mac, true);
         self.converge_bind_state(mac, &master_mac, new_rx)?;
+        self.confirm_binding(mac, true);
         self.save_rf_config()
     }
 
     pub fn unbind_device(&self, mac: &[u8; 6]) -> Result<()> {
+        let _binding = self.begin_binding(mac)?;
         self.check_unbind_allowed(mac)?;
-        self.forget_mb_rgb_target(mac);
-        self.set_bind_intent(mac, false);
         self.converge_bind_state(mac, &[0u8; 6], 0)?;
+        self.confirm_binding(mac, false);
+        self.forget_mb_rgb_target(mac);
         self.save_rf_config()
+    }
+
+    fn begin_binding(&self, mac: &[u8; 6]) -> Result<BindingGuard> {
+        let _order = self.command_order.lock();
+        let mut binding = self.binding_mac.lock();
+        anyhow::ensure!(
+            binding.is_none(),
+            "another wireless binding operation is pending"
+        );
+        *binding = Some(*mac);
+        if let Some(queue) = &self.pending_commands {
+            queue.lock().retain(|command| command.mac != *mac);
+        }
+        Ok(BindingGuard(std::sync::Arc::clone(&self.binding_mac)))
     }
 
     fn check_bind_allowed(&self, mac: &[u8; 6]) -> Result<()> {
@@ -119,6 +135,11 @@ impl WirelessController {
         let deadline = Instant::now() + CONVERGE_TIMEOUT;
         let mut attempts = 0u32;
         loop {
+            anyhow::ensure!(
+                !self.poll_stop.load(std::sync::atomic::Ordering::Acquire),
+                "wireless controller is stopping"
+            );
+            let sent_at = Instant::now();
             self.send_bind_packet(mac, target_master_mac, target_rx)?;
             attempts += 1;
             thread::sleep(POLL_GAP);
@@ -128,7 +149,7 @@ impl WirelessController {
                 &self.discovered_devices,
                 &self.device_health,
                 &self.master_entries,
-                &self.mobo_pwm,
+                &self.receiver_state,
                 &self.fg_sync,
                 &self.master_mac,
             );
@@ -137,6 +158,7 @@ impl WirelessController {
                 .device_health
                 .lock()
                 .get(mac)
+                .filter(|h| h.raw_seen >= sent_at)
                 .map(|h| (h.raw_master, h.raw_rx, h.raw_channel));
 
             let master_ch = *self.master_channel.lock();
@@ -144,7 +166,7 @@ impl WirelessController {
                 Some((m, r, ch)) => {
                     &m == target_master_mac && r == target_rx && (target_rx == 0 || ch == master_ch)
                 }
-                None => target_master_mac == &[0u8; 6],
+                None => false,
             };
             if converged {
                 return Ok(());
@@ -259,6 +281,14 @@ impl WirelessController {
     }
 }
 
+struct BindingGuard(std::sync::Arc<parking_lot::Mutex<Option<[u8; 6]>>>);
+
+impl Drop for BindingGuard {
+    fn drop(&mut self) {
+        *self.0.lock() = None;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::discovery::{DeviceHealth, MasterEntry};
@@ -306,6 +336,53 @@ mod tests {
         h.raw_master = master;
         h.bind_intent = intent;
         health.insert(*mac, h);
+    }
+
+    #[test]
+    fn pending_binding_is_exclusive_and_released_on_failure() {
+        let c = controller_with([9; 6], false);
+        let mac = [1, 2, 3, 4, 5, 6];
+        let binding = c.begin_binding(&mac).unwrap();
+        assert!(c.begin_binding(&[2; 6]).is_err());
+        assert_eq!(*c.binding_mac.lock(), Some(mac));
+        drop(binding);
+        assert!(c.bind_device(&mac).is_err());
+        assert!(c.binding_mac.lock().is_none());
+    }
+
+    #[test]
+    fn confirmed_unbind_is_published_immediately_and_prevents_auto_rebind() {
+        let c = controller_with([9; 6], false);
+        let mac = [1, 2, 3, 4, 5, 6];
+        seed_device(&c, &mac, [9; 6], true);
+        let mut health = c.device_health.lock();
+        let h = health.get_mut(&mac).unwrap();
+        c.discovered_devices.lock().push(h.published.clone());
+        h.raw_master = [0; 6];
+        h.raw_rx = 0;
+        drop(health);
+        c.confirm_binding(&mac, false);
+        assert!(c.devices().is_empty());
+        assert_eq!(c.unbound_devices().len(), 1);
+        assert!(c.rebind_candidates().is_empty());
+    }
+
+    #[test]
+    fn failed_binding_commands_preserve_prior_intent() {
+        let c = controller_with([9; 6], false);
+        let mac = [1, 2, 3, 4, 5, 6];
+        seed_device(&c, &mac, [0; 6], false);
+        c.device_health.lock().get_mut(&mac).unwrap().man_unbind = true;
+        assert!(c.bind_device(&mac).is_err());
+        let health = c.device_health.lock();
+        assert!(!health[&mac].bind_intent);
+        assert!(health[&mac].man_unbind);
+        drop(health);
+        seed_device(&c, &mac, [9; 6], true);
+        assert!(c.unbind_device(&mac).is_err());
+        let health = c.device_health.lock();
+        assert!(health[&mac].bind_intent);
+        assert!(!health[&mac].man_unbind);
     }
 
     #[test]

--- a/crates/lianli-devices/src/wireless/controller.rs
+++ b/crates/lianli-devices/src/wireless/controller.rs
@@ -34,7 +34,6 @@ pub struct WirelessController {
     pub(super) device_health: DeviceHealthMap,
     pub(super) master_entries: MasterEntryMap,
     pub(super) clock_init_sent: Arc<AtomicBool>,
-    pub(super) fg_sync: Arc<AtomicBool>,
     pub(super) tx_failures: Arc<AtomicU32>,
     pub(super) desired_effects: Arc<Mutex<std::collections::HashMap<[u8; 6], [u8; 4]>>>,
     pub(super) mb_rgb_targets: MbRgbTargetMap,
@@ -63,7 +62,6 @@ impl Clone for WirelessController {
             device_health: Arc::clone(&self.device_health),
             master_entries: Arc::clone(&self.master_entries),
             clock_init_sent: Arc::clone(&self.clock_init_sent),
-            fg_sync: Arc::clone(&self.fg_sync),
             tx_failures: Arc::clone(&self.tx_failures),
             desired_effects: Arc::clone(&self.desired_effects),
             mb_rgb_targets: Arc::clone(&self.mb_rgb_targets),
@@ -94,7 +92,6 @@ impl WirelessController {
             device_health: Arc::new(Mutex::new(Default::default())),
             master_entries: Arc::new(Mutex::new(Default::default())),
             clock_init_sent: Arc::new(AtomicBool::new(false)),
-            fg_sync: Arc::new(AtomicBool::new(false)),
             tx_failures: Arc::new(AtomicU32::new(0)),
             desired_effects: Arc::new(Mutex::new(std::collections::HashMap::new())),
             mb_rgb_targets: Arc::new(Mutex::new(Default::default())),
@@ -234,7 +231,6 @@ impl WirelessController {
         let device_health = Arc::clone(&self.device_health);
         let master_entries = Arc::clone(&self.master_entries);
         let receiver_state = Arc::clone(&self.receiver_state);
-        let fg_sync = Arc::clone(&self.fg_sync);
         let master_mac = Arc::clone(&self.master_mac);
         let retarget_ctrl = self.clone();
         let rx_running = Arc::clone(&self.rx_running);
@@ -257,9 +253,12 @@ impl WirelessController {
                     &device_health,
                     &master_entries,
                     &receiver_state,
-                    &fg_sync,
+                    &stop_flag,
                     &master_mac,
                 ) {
+                    if stop_flag.load(Ordering::Acquire) {
+                        break;
+                    }
                     consecutive_errors += 1;
                     consecutive_successes = 0;
                     info!("RX polling ({consecutive_errors}): {err:#}, continuing");
@@ -276,6 +275,9 @@ impl WirelessController {
                             "5 consecutive RX errors, sending RX reset ({total_resets}/{MAX_RESETS})"
                         );
                         let handle = rx.lock();
+                        if stop_flag.load(Ordering::Acquire) {
+                            break;
+                        }
                         let mut reset_cmd = vec![0u8; 64];
                         reset_cmd[0] = 0x15; // USB_ResetAnother
                         if handle.write(&reset_cmd, USB_TIMEOUT).is_ok() {
@@ -429,7 +431,7 @@ impl WirelessController {
                 (&*CMD_RX_QUERY_37, true),
                 (&*CMD_RX_LCD_MODE, false),
             ] {
-                with_transport_recovery(rx, &RX_IDS, "RX", Some(&self.poll_stop), |handle| {
+                with_transport_recovery(rx, &RX_IDS, "RX", &self.poll_stop, |handle| {
                     handle
                         .write(cmd, USB_TIMEOUT)
                         .context("sending RX command")?;
@@ -500,7 +502,7 @@ impl WirelessController {
         F: FnMut(&RusbBulk) -> Result<R>,
     {
         let tx = self.tx.as_ref().context("TX device not connected")?;
-        let result = with_transport_recovery(tx, &TX_IDS, "TX", Some(&self.poll_stop), op);
+        let result = with_transport_recovery(tx, &TX_IDS, "TX", &self.poll_stop, op);
         match &result {
             Ok(_) => self.tx_failures.store(0, Ordering::Relaxed),
             Err(_) => {
@@ -716,7 +718,9 @@ impl WirelessController {
     /// includes the current fan RPM so the RX dongle can measure motherboard
     /// PWM duty from the FG signal.
     pub fn set_fg_sync(&self, enabled: bool) {
-        self.fg_sync.store(enabled, Ordering::Relaxed);
+        self.receiver_state
+            .fg_sync
+            .store(enabled, Ordering::Relaxed);
     }
 
     /// Send a 240-byte RF packet as 4× 64-byte USB chunks.

--- a/crates/lianli-devices/src/wireless/controller.rs
+++ b/crates/lianli-devices/src/wireless/controller.rs
@@ -1,7 +1,7 @@
 use super::convergence::{PendingQueue, TargetSeqMap};
 use super::discovery::{
-    poll_and_discover, DeviceHealthMap, DiscoveredDevice, MasterEntryMap, ACK_FRESHNESS,
-    REBIND_FOREIGN_AFTER,
+    poll_and_discover, DeviceHealthMap, DiscoveredDevice, MasterEntryMap, ReceiverState,
+    ACK_FRESHNESS, REBIND_FOREIGN_AFTER,
 };
 use super::mb_sync::MbRgbTargetMap;
 use super::transport::{open_any, with_transport_recovery};
@@ -12,7 +12,7 @@ use super::{
 use anyhow::{bail, Context, Result};
 use lianli_transport::usb::{RusbBulk, USB_TIMEOUT};
 use parking_lot::Mutex;
-use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
@@ -23,6 +23,8 @@ const TX_FAILURE_THRESHOLD: u32 = 5;
 pub struct WirelessController {
     pub(super) tx: Option<Arc<Mutex<RusbBulk>>>,
     pub(super) rx: Option<Arc<Mutex<RusbBulk>>>,
+    pub(super) receiver_state: Arc<ReceiverState>,
+    pub(super) rx_running: Arc<AtomicBool>,
     pub(super) poll_stop: Arc<AtomicBool>,
     pub(super) poll_thread: Option<JoinHandle<()>>,
     pub(super) video_mode_active: Arc<AtomicBool>,
@@ -32,14 +34,12 @@ pub struct WirelessController {
     pub(super) device_health: DeviceHealthMap,
     pub(super) master_entries: MasterEntryMap,
     pub(super) clock_init_sent: Arc<AtomicBool>,
-    /// Motherboard PWM duty cycle (0-255) extracted from RX GetDev response bytes [2:3].
-    /// 0xFFFF means unavailable/not yet read.
-    pub(super) mobo_pwm: Arc<AtomicU16>,
     pub(super) fg_sync: Arc<AtomicBool>,
     pub(super) tx_failures: Arc<AtomicU32>,
     pub(super) desired_effects: Arc<Mutex<std::collections::HashMap<[u8; 6], [u8; 4]>>>,
     pub(super) mb_rgb_targets: MbRgbTargetMap,
     pub(super) command_order: Arc<Mutex<()>>,
+    pub(super) binding_mac: Arc<Mutex<Option<[u8; 6]>>>,
     /// Pending commands awaiting device ack, drained by the convergence loop.
     pub(super) pending_commands: Option<PendingQueue>,
     /// Per-device target `cmd_seq`; incremented per state-changing command.
@@ -52,6 +52,8 @@ impl Clone for WirelessController {
         Self {
             tx: self.tx.clone(),
             rx: self.rx.clone(),
+            receiver_state: Arc::clone(&self.receiver_state),
+            rx_running: Arc::clone(&self.rx_running),
             poll_stop: Arc::clone(&self.poll_stop),
             poll_thread: None,
             video_mode_active: Arc::clone(&self.video_mode_active),
@@ -61,12 +63,12 @@ impl Clone for WirelessController {
             device_health: Arc::clone(&self.device_health),
             master_entries: Arc::clone(&self.master_entries),
             clock_init_sent: Arc::clone(&self.clock_init_sent),
-            mobo_pwm: Arc::clone(&self.mobo_pwm),
             fg_sync: Arc::clone(&self.fg_sync),
             tx_failures: Arc::clone(&self.tx_failures),
             desired_effects: Arc::clone(&self.desired_effects),
             mb_rgb_targets: Arc::clone(&self.mb_rgb_targets),
             command_order: Arc::clone(&self.command_order),
+            binding_mac: Arc::clone(&self.binding_mac),
             pending_commands: self.pending_commands.clone(),
             target_cmd_seqs: self.target_cmd_seqs.clone(),
             convergence_thread: None,
@@ -81,6 +83,8 @@ impl WirelessController {
         Self {
             tx: None,
             rx: None,
+            receiver_state: Arc::new(ReceiverState::default()),
+            rx_running: Arc::new(AtomicBool::new(false)),
             poll_stop: Arc::new(AtomicBool::new(false)),
             poll_thread: None,
             video_mode_active: Arc::new(AtomicBool::new(false)),
@@ -90,12 +94,12 @@ impl WirelessController {
             device_health: Arc::new(Mutex::new(Default::default())),
             master_entries: Arc::new(Mutex::new(Default::default())),
             clock_init_sent: Arc::new(AtomicBool::new(false)),
-            mobo_pwm: Arc::new(AtomicU16::new(0xFFFF)),
             fg_sync: Arc::new(AtomicBool::new(false)),
             tx_failures: Arc::new(AtomicU32::new(0)),
             desired_effects: Arc::new(Mutex::new(std::collections::HashMap::new())),
             mb_rgb_targets: Arc::new(Mutex::new(Default::default())),
             command_order: Arc::new(Mutex::new(())),
+            binding_mac: Arc::new(Mutex::new(None)),
             pending_commands: Some(pending_commands),
             target_cmd_seqs: Some(target_cmd_seqs),
             convergence_thread: None,
@@ -103,7 +107,9 @@ impl WirelessController {
     }
 
     pub fn connect(&mut self) -> Result<()> {
-        self.mb_rgb_targets.lock().clear();
+        self.stop();
+        self.poll_stop = Arc::new(AtomicBool::new(false));
+        self.receiver_state.pages.store(1, Ordering::Relaxed);
         let mut tx = None;
         let max_retries = 3;
 
@@ -127,23 +133,17 @@ impl WirelessController {
         tx.detach_and_configure("TX")?;
         let tx_arc = Arc::new(Mutex::new(tx));
 
-        let rx_arc = match open_any(&RX_IDS) {
-            Ok(mut rx) => {
-                rx.detach_and_configure("RX")?;
-                rx.read_flush();
-                Some(Arc::new(Mutex::new(rx)))
-            }
-            Err(_) => {
-                warn!("RX dongle not found – telemetry disabled");
-                None
-            }
-        };
-
+        let mut rx = open_any(&RX_IDS).context("opening wireless RX dongle")?;
+        rx.detach_and_configure("RX")?;
+        rx.read_flush();
         self.tx = Some(tx_arc);
-        self.rx = rx_arc;
+        self.rx = Some(Arc::new(Mutex::new(rx)));
         self.tx_failures.store(0, Ordering::Relaxed);
 
-        self.discover_master_mac()?;
+        if let Err(error) = self.discover_master_mac() {
+            self.stop();
+            return Err(error);
+        }
         Ok(())
     }
 
@@ -179,7 +179,7 @@ impl WirelessController {
             };
             drop(handle);
 
-            if len >= 7 && response[0] == USB_CMD_GET_MAC {
+            if valid_master_response(&response[..len]) {
                 let mut mac = self.master_mac.lock();
                 mac.copy_from_slice(&response[1..7]);
                 if mac.iter().any(|&b| b != 0) {
@@ -201,6 +201,10 @@ impl WirelessController {
     }
 
     pub fn start_polling(&mut self) -> Result<()> {
+        anyhow::ensure!(
+            self.poll_thread.is_none() && self.convergence_thread.is_none(),
+            "wireless workers already started"
+        );
         let tx = self
             .tx
             .as_ref()
@@ -229,10 +233,12 @@ impl WirelessController {
         let discovered_devices = Arc::clone(&self.discovered_devices);
         let device_health = Arc::clone(&self.device_health);
         let master_entries = Arc::clone(&self.master_entries);
-        let mobo_pwm = Arc::clone(&self.mobo_pwm);
+        let receiver_state = Arc::clone(&self.receiver_state);
         let fg_sync = Arc::clone(&self.fg_sync);
         let master_mac = Arc::clone(&self.master_mac);
         let retarget_ctrl = self.clone();
+        let rx_running = Arc::clone(&self.rx_running);
+        rx_running.store(true, Ordering::Release);
 
         let discovery_done = Arc::new(AtomicBool::new(false));
         let discovery_signal = discovery_done.clone();
@@ -250,7 +256,7 @@ impl WirelessController {
                     &discovered_devices,
                     &device_health,
                     &master_entries,
-                    &mobo_pwm,
+                    &receiver_state,
                     &fg_sync,
                     &master_mac,
                 ) {
@@ -277,7 +283,7 @@ impl WirelessController {
                             let _ = handle.read(&mut resp, Duration::from_millis(2000));
                         }
                         drop(handle);
-                        thread::sleep(Duration::from_millis(500));
+                        wait_for_poll(&stop_flag, Duration::from_millis(500));
                         consecutive_errors = 0;
                         continue;
                     }
@@ -288,7 +294,7 @@ impl WirelessController {
                     } else {
                         Duration::from_secs((1 << consecutive_errors.min(5)).min(30))
                     };
-                    thread::sleep(backoff);
+                    wait_for_poll(&stop_flag, backoff);
                     continue;
                 }
                 consecutive_errors = 0;
@@ -304,8 +310,9 @@ impl WirelessController {
                     last_retarget = Instant::now();
                     retarget_ctrl.retarget_mischannelled_devices();
                 }
-                thread::sleep(Duration::from_millis(500));
+                wait_for_poll(&stop_flag, Duration::from_millis(500));
             }
+            rx_running.store(false, Ordering::Release);
         }));
 
         let deadline = std::time::Instant::now() + Duration::from_secs(5);
@@ -329,6 +336,7 @@ impl WirelessController {
                 queue,
                 device_health,
                 Arc::clone(&self.desired_effects),
+                Arc::clone(&self.binding_mac),
                 conv_stop,
             ));
         }
@@ -421,7 +429,7 @@ impl WirelessController {
                 (&*CMD_RX_QUERY_37, true),
                 (&*CMD_RX_LCD_MODE, false),
             ] {
-                with_transport_recovery(rx, &RX_IDS, "RX", |handle| {
+                with_transport_recovery(rx, &RX_IDS, "RX", Some(&self.poll_stop), |handle| {
                     handle
                         .write(cmd, USB_TIMEOUT)
                         .context("sending RX command")?;
@@ -465,7 +473,11 @@ impl WirelessController {
     }
 
     pub fn is_connected(&self) -> bool {
-        self.tx.is_some() && self.tx_failures.load(Ordering::Relaxed) < TX_FAILURE_THRESHOLD
+        self.tx.is_some()
+            && self.rx.is_some()
+            && !self.poll_stop.load(Ordering::Acquire)
+            && self.rx_running.load(Ordering::Acquire)
+            && self.tx_failures.load(Ordering::Relaxed) < TX_FAILURE_THRESHOLD
     }
 
     /// Returns true if any wireless device's currently-running effect_index
@@ -488,7 +500,7 @@ impl WirelessController {
         F: FnMut(&RusbBulk) -> Result<R>,
     {
         let tx = self.tx.as_ref().context("TX device not connected")?;
-        let result = with_transport_recovery(tx, &TX_IDS, "TX", op);
+        let result = with_transport_recovery(tx, &TX_IDS, "TX", Some(&self.poll_stop), op);
         match &result {
             Ok(_) => self.tx_failures.store(0, Ordering::Relaxed),
             Err(_) => {
@@ -555,26 +567,24 @@ impl WirelessController {
             .collect()
     }
 
-    pub(super) fn set_bind_intent(&self, mac: &[u8; 6], intent: bool) {
-        {
-            let mut health = self.device_health.lock();
-            if let Some(h) = health.get_mut(mac) {
-                h.bind_intent = intent;
-                if intent {
-                    h.man_unbind = false;
-                } else {
-                    h.man_unbind = true;
-                    h.foreign_since = None;
-                }
-            }
-        }
-        if let Some(d) = self
+    pub(super) fn confirm_binding(&self, mac: &[u8; 6], intent: bool) {
+        let mut health = self.device_health.lock();
+        let Some(h) = health.get_mut(mac) else { return };
+        h.bind_intent = intent;
+        h.man_unbind = !intent;
+        h.foreign_since = None;
+        h.observed_master = h.raw_master;
+        h.published.bind_intent = intent;
+        h.published.master_mac = h.raw_master;
+        h.published.rx_type = h.raw_rx;
+        h.published.channel = h.raw_channel;
+        if let Some(device) = self
             .discovered_devices
             .lock()
             .iter_mut()
             .find(|d| d.mac == *mac)
         {
-            d.bind_intent = intent;
+            *device = h.published.clone();
         }
     }
 
@@ -660,6 +670,9 @@ impl WirelessController {
     /// the master channel. Vendor firmware applies the channel from these
     /// packets lazily, so this runs on the poll cadence without a deadline.
     pub(super) fn retarget_mischannelled_devices(&self) {
+        if self.binding_mac.lock().is_some() {
+            return;
+        }
         let master_mac = *self.master_mac.lock();
         let master_ch = *self.master_channel.lock();
         let targets: Vec<([u8; 6], u8)> = {
@@ -694,7 +707,7 @@ impl WirelessController {
     /// Current motherboard PWM duty cycle (0-255), or `None` if unavailable.
     /// Extracted from RX GetDev response bytes [2:3] during polling.
     pub fn motherboard_pwm(&self) -> Option<u8> {
-        match self.mobo_pwm.load(Ordering::Relaxed) {
+        match self.receiver_state.pwm.load(Ordering::Relaxed) {
             0xFFFF => None,
             v => Some(v as u8),
         }
@@ -744,12 +757,17 @@ impl WirelessController {
     pub(super) fn next_slot_index(&self, device: &DiscoveredDevice) -> u8 {
         let devices = self.discovered_devices.lock();
         let master_mac = *self.master_mac.lock();
-        devices
+        let mut next_slot = 1u8;
+        for bound in devices
             .iter()
             .filter(|d| (d.bind_intent || d.master_mac == master_mac) && d.device_type != 0xFF)
-            .position(|d| d.mac == device.mac)
-            .map(|i| (i + 1) as u8)
-            .unwrap_or(1)
+        {
+            if bound.mac == device.mac {
+                return next_slot;
+            }
+            next_slot = next_slot.saturating_add(1);
+        }
+        next_slot
     }
 
     pub(super) fn device_by_mac_snapshot(&self, mac: &[u8; 6]) -> Result<DiscoveredDevice> {
@@ -770,11 +788,23 @@ impl WirelessController {
         let owns_runtime = self.poll_thread.is_some() || self.convergence_thread.is_some();
         if owns_runtime {
             self.mb_rgb_targets.lock().clear();
-        }
-        if self.poll_thread.is_some() {
             self.poll_stop.store(true, Ordering::SeqCst);
+            for handle in [&self.poll_thread, &self.convergence_thread]
+                .into_iter()
+                .flatten()
+            {
+                handle.thread().unpark();
+            }
             if let Some(handle) = self.poll_thread.take() {
                 let _ = handle.join();
+            }
+            if let Some(handle) = self.convergence_thread.take() {
+                let _ = handle.join();
+            }
+            self.rx_running.store(false, Ordering::Release);
+            self.receiver_state.pwm.store(0xFFFF, Ordering::Relaxed);
+            if let Some(queue) = &self.pending_commands {
+                queue.lock().clear();
             }
         }
         self.tx.take();
@@ -792,6 +822,24 @@ impl WirelessController {
                 && health.published.effect_index == effect_index
         });
         observed && !self.has_pending_mb_rgb_transition(mac)
+    }
+}
+
+fn valid_master_response(response: &[u8]) -> bool {
+    response.len() >= 13
+        && response[0] == USB_CMD_GET_MAC
+        && response[1..7].iter().any(|&b| b != 0)
+        && u32::from_be_bytes(response[7..11].try_into().unwrap()) > 1
+}
+
+fn wait_for_poll(stop: &AtomicBool, duration: Duration) {
+    let deadline = Instant::now() + duration;
+    while !stop.load(Ordering::Acquire) {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        thread::park_timeout(remaining);
     }
 }
 
@@ -813,6 +861,73 @@ mod tests {
     use crate::wireless::discovery::{DeviceHealth, DiscoveredDevice};
     use crate::wireless::WirelessFanType;
     use std::collections::BTreeMap;
+
+    #[test]
+    fn new_binding_uses_next_slot_without_claiming_ownership_first() {
+        let controller = WirelessController::new();
+        *controller.master_mac.lock() = [9; 6];
+        let first = entry([9; 6]).published;
+        let mut second = first.clone();
+        second.mac = [2; 6];
+        let mut unbound = entry([0; 6]).published;
+        unbound.mac = [3; 6];
+        *controller.discovered_devices.lock() =
+            vec![first.clone(), second.clone(), unbound.clone()];
+        assert_eq!(controller.next_slot_index(&first), 1);
+        assert_eq!(controller.next_slot_index(&second), 2);
+        assert_eq!(controller.next_slot_index(&unbound), 3);
+        assert!(!unbound.bind_intent);
+    }
+
+    #[test]
+    fn stop_joins_both_workers_and_clone_drop_does_not_stop_owner() {
+        let mut controller = WirelessController::new();
+        let finished = Arc::new(AtomicU32::new(0));
+        for slot in [
+            &mut controller.poll_thread,
+            &mut controller.convergence_thread,
+        ] {
+            let stop = Arc::clone(&controller.poll_stop);
+            let finished = Arc::clone(&finished);
+            *slot = Some(thread::spawn(move || {
+                wait_for_poll(&stop, Duration::from_secs(30));
+                finished.fetch_add(1, Ordering::Release);
+            }));
+        }
+        drop(controller.clone());
+        assert!(!controller.poll_stop.load(Ordering::Acquire));
+        controller.stop();
+        assert_eq!(finished.load(Ordering::Acquire), 2);
+        assert!(controller.poll_thread.is_none());
+        assert!(controller.convergence_thread.is_none());
+        controller.stop();
+    }
+
+    #[test]
+    fn convergence_only_runtime_is_stopped_and_joined() {
+        let mut controller = WirelessController::new();
+        let stop = Arc::clone(&controller.poll_stop);
+        controller.convergence_thread = Some(thread::spawn(move || {
+            wait_for_poll(&stop, Duration::from_secs(30));
+        }));
+        controller.stop();
+        assert!(controller.poll_stop.load(Ordering::Acquire));
+        assert!(controller.convergence_thread.is_none());
+    }
+
+    #[test]
+    fn master_discovery_rejects_missing_clock_and_truncated_identity() {
+        let mut response = [0x11, 1, 2, 3, 4, 5, 6, 0, 0, 0, 2, 1, 2];
+        assert!(valid_master_response(&response));
+        assert!(!valid_master_response(&response[..7]));
+        response[10] = 0;
+        assert!(!valid_master_response(&response));
+        response[10] = 1;
+        assert!(!valid_master_response(&response));
+        response[10] = 2;
+        response[1..7].fill(0);
+        assert!(!valid_master_response(&response));
+    }
 
     fn entry(master: [u8; 6]) -> DeviceHealth {
         let rec = DiscoveredDevice {

--- a/crates/lianli-devices/src/wireless/controller.rs
+++ b/crates/lianli-devices/src/wireless/controller.rs
@@ -20,7 +20,26 @@ use tracing::{debug, error, info, warn};
 
 const TX_FAILURE_THRESHOLD: u32 = 5;
 
+struct RuntimeClaim(Arc<AtomicBool>);
+
+impl RuntimeClaim {
+    fn acquire(claimed: &Arc<AtomicBool>) -> Result<Self> {
+        claimed
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .map_err(|_| anyhow::anyhow!("wireless runtime already claimed"))?;
+        Ok(Self(Arc::clone(claimed)))
+    }
+}
+
+impl Drop for RuntimeClaim {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::Release);
+    }
+}
+
 pub struct WirelessController {
+    runtime_claimed: Arc<AtomicBool>,
+    runtime_claim: Option<RuntimeClaim>,
     pub(super) tx: Option<Arc<Mutex<RusbBulk>>>,
     pub(super) rx: Option<Arc<Mutex<RusbBulk>>>,
     pub(super) receiver_state: Arc<ReceiverState>,
@@ -49,6 +68,8 @@ pub struct WirelessController {
 impl Clone for WirelessController {
     fn clone(&self) -> Self {
         Self {
+            runtime_claimed: Arc::clone(&self.runtime_claimed),
+            runtime_claim: None,
             tx: self.tx.clone(),
             rx: self.rx.clone(),
             receiver_state: Arc::clone(&self.receiver_state),
@@ -79,6 +100,8 @@ impl WirelessController {
         let pending_commands: PendingQueue = Arc::new(Mutex::new(Default::default()));
         let target_cmd_seqs: TargetSeqMap = Arc::new(Mutex::new(Default::default()));
         Self {
+            runtime_claimed: Arc::new(AtomicBool::new(false)),
+            runtime_claim: None,
             tx: None,
             rx: None,
             receiver_state: Arc::new(ReceiverState::default()),
@@ -105,6 +128,7 @@ impl WirelessController {
 
     pub fn connect(&mut self) -> Result<()> {
         self.stop();
+        let _claim = RuntimeClaim::acquire(&self.runtime_claimed)?;
         self.poll_stop = Arc::new(AtomicBool::new(false));
         self.receiver_state.pages.store(1, Ordering::Relaxed);
         let mut tx = None;
@@ -202,6 +226,25 @@ impl WirelessController {
             self.poll_thread.is_none() && self.convergence_thread.is_none(),
             "wireless workers already started"
         );
+        let claim = RuntimeClaim::acquire(&self.runtime_claimed)?;
+        anyhow::ensure!(
+            !self.poll_stop.load(Ordering::Acquire),
+            "wireless connection stopped; reconnect before polling"
+        );
+        match self.start_workers() {
+            Ok(()) => {
+                self.runtime_claim = Some(claim);
+                Ok(())
+            }
+            Err(error) => {
+                self.stop();
+                self.rx_running.store(false, Ordering::Release);
+                Err(error)
+            }
+        }
+    }
+
+    fn start_workers(&mut self) -> Result<()> {
         let tx = self
             .tx
             .as_ref()
@@ -223,7 +266,6 @@ impl WirelessController {
         thread::sleep(Duration::from_millis(500));
 
         self.video_mode_active.store(false, Ordering::Release);
-        self.poll_stop.store(false, Ordering::SeqCst);
         self.clock_init_sent.store(false, Ordering::Release);
 
         let stop_flag = self.poll_stop.clone();
@@ -239,7 +281,8 @@ impl WirelessController {
         let discovery_done = Arc::new(AtomicBool::new(false));
         let discovery_signal = discovery_done.clone();
 
-        self.poll_thread = Some(thread::spawn(move || {
+        let poll_worker = thread::Builder::new().name("wireless-discovery".into());
+        self.poll_thread = Some(poll_worker.spawn(move || {
             let mut found_devices = false;
             let mut consecutive_errors = 0u32;
             let mut consecutive_successes = 0u32;
@@ -315,7 +358,7 @@ impl WirelessController {
                 wait_for_poll(&stop_flag, Duration::from_millis(500));
             }
             rx_running.store(false, Ordering::Release);
-        }));
+        }).context("spawning wireless discovery thread")?);
 
         let deadline = std::time::Instant::now() + Duration::from_secs(5);
         loop {
@@ -340,7 +383,7 @@ impl WirelessController {
                 Arc::clone(&self.desired_effects),
                 Arc::clone(&self.binding_mac),
                 conv_stop,
-            ));
+            )?);
         }
 
         Ok(())
@@ -812,6 +855,7 @@ impl WirelessController {
         }
         self.tx.take();
         self.rx.take();
+        self.runtime_claim.take();
     }
 
     pub fn rgb_upload_applied(&self, mac: &[u8; 6], effect_index: [u8; 4]) -> bool {
@@ -864,6 +908,110 @@ mod tests {
     use crate::wireless::discovery::{DeviceHealth, DiscoveredDevice};
     use crate::wireless::WirelessFanType;
     use std::collections::BTreeMap;
+
+    #[test]
+    fn clones_cannot_start_or_connect_while_runtime_is_claimed() {
+        let mut owner = WirelessController::new();
+        owner.runtime_claim = Some(RuntimeClaim::acquire(&owner.runtime_claimed).unwrap());
+        owner.poll_stop.store(true, Ordering::Release);
+        owner.clock_init_sent.store(true, Ordering::Release);
+        let mut clone = owner.clone();
+
+        assert!(clone
+            .start_polling()
+            .unwrap_err()
+            .to_string()
+            .contains("already claimed"));
+        assert!(clone
+            .connect()
+            .unwrap_err()
+            .to_string()
+            .contains("already claimed"));
+        drop(clone);
+        assert!(owner.runtime_claimed.load(Ordering::Acquire));
+        assert!(owner.poll_stop.load(Ordering::Acquire));
+        assert!(owner.clock_init_sent.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn failed_start_releases_runtime_claim() {
+        let mut controller = WirelessController::new();
+        assert!(controller
+            .start_polling()
+            .unwrap_err()
+            .to_string()
+            .contains("TX device"));
+        assert!(!controller.runtime_claimed.load(Ordering::Acquire));
+        let mut clone = controller.clone();
+        assert!(clone
+            .start_polling()
+            .unwrap_err()
+            .to_string()
+            .contains("TX device"));
+    }
+
+    #[test]
+    fn stopped_clone_cannot_restart_old_connection() {
+        let controller = WirelessController::new();
+        let mut clone = controller.clone();
+        controller.poll_stop.store(true, Ordering::Release);
+        assert!(clone
+            .start_polling()
+            .unwrap_err()
+            .to_string()
+            .contains("reconnect"));
+        assert!(controller.poll_stop.load(Ordering::Acquire));
+        assert!(!controller.runtime_claimed.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn runtime_claim_is_exclusive_across_concurrent_callers() {
+        let claimed = Arc::new(AtomicBool::new(false));
+        let barrier = Arc::new(std::sync::Barrier::new(8));
+        let workers: Vec<_> = (0..8)
+            .map(|_| {
+                let claimed = Arc::clone(&claimed);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    let claim = RuntimeClaim::acquire(&claimed);
+                    barrier.wait();
+                    claim.is_ok()
+                })
+            })
+            .collect();
+        let winners = workers
+            .into_iter()
+            .map(|worker| usize::from(worker.join().unwrap()))
+            .sum::<usize>();
+        assert_eq!(winners, 1);
+        assert!(RuntimeClaim::acquire(&claimed).is_ok());
+    }
+
+    #[test]
+    fn ownership_outlives_poll_exit_and_is_released_after_convergence_join() {
+        let mut controller = WirelessController::new();
+        controller.runtime_claim =
+            Some(RuntimeClaim::acquire(&controller.runtime_claimed).unwrap());
+        controller.poll_thread = Some(thread::spawn(|| {}));
+        let stop = Arc::clone(&controller.poll_stop);
+        let claimed = Arc::clone(&controller.runtime_claimed);
+        let (result_tx, result_rx) = std::sync::mpsc::channel();
+        controller.convergence_thread = Some(thread::spawn(move || {
+            wait_for_poll(&stop, Duration::from_secs(30));
+            result_tx.send(claimed.load(Ordering::Acquire)).unwrap();
+        }));
+        let mut clone = controller.clone();
+        assert!(!controller.rx_running.load(Ordering::Acquire));
+        assert!(clone
+            .start_polling()
+            .unwrap_err()
+            .to_string()
+            .contains("already claimed"));
+        controller.stop();
+        assert!(result_rx.recv().unwrap());
+        assert!(!controller.runtime_claimed.load(Ordering::Acquire));
+    }
 
     #[test]
     fn new_binding_uses_next_slot_without_claiming_ownership_first() {

--- a/crates/lianli-devices/src/wireless/controller.rs
+++ b/crates/lianli-devices/src/wireless/controller.rs
@@ -544,24 +544,23 @@ impl WirelessController {
             .collect()
     }
 
-    /// MACs eligible for automatic recovery: live masterless devices that
-    /// were not explicitly unbound by the user. Bound devices that drifted
-    /// away must have been masterless for [`REBIND_FOREIGN_AFTER`] first.
-    /// Devices owned by another controller are never candidates.
+    /// Recovery requires ownership confirmed in this runtime and sustained loss of that ownership.
     pub fn rebind_candidates(&self) -> Vec<[u8; 6]> {
         self.device_health
             .lock()
             .iter()
             .filter(|(_, h)| {
-                if h.dead || h.man_unbind || h.observed_master != [0u8; 6] {
+                if h.dead
+                    || h.man_unbind
+                    || !h.bind_intent
+                    || h.observed_master != [0u8; 6]
+                    || h.raw_master != [0u8; 6]
+                    || h.raw_seen.elapsed() > ACK_FRESHNESS
+                {
                     return false;
                 }
-                if h.bind_intent {
-                    h.foreign_since
-                        .is_some_and(|t| t.elapsed() >= REBIND_FOREIGN_AFTER)
-                } else {
-                    true
-                }
+                h.foreign_since
+                    .is_some_and(|t| t.elapsed() >= REBIND_FOREIGN_AFTER)
             })
             .map(|(mac, _)| *mac)
             .collect()
@@ -1039,9 +1038,31 @@ mod tests {
     }
 
     #[test]
-    fn masterless_without_intent_is_candidate() {
+    fn masterless_at_startup_is_not_automatically_claimed() {
         let c = controller_with_health(vec![(mac(), entry([0u8; 6]))]);
-        assert_eq!(c.rebind_candidates(), vec![mac()]);
+        assert!(c.rebind_candidates().is_empty());
+        c.device_health
+            .lock()
+            .get_mut(&mac())
+            .unwrap()
+            .foreign_since = Some(Instant::now() - REBIND_FOREIGN_AFTER - Duration::from_secs(1));
+        assert!(c.rebind_candidates().is_empty());
+    }
+
+    #[test]
+    fn recovery_requires_a_fresh_masterless_sighting() {
+        let mut h = entry([0; 6]);
+        h.bind_intent = true;
+        h.foreign_since = Some(Instant::now() - REBIND_FOREIGN_AFTER - Duration::from_secs(1));
+        h.raw_master = [7; 6];
+        let c = controller_with_health(vec![(mac(), h)]);
+        assert!(c.rebind_candidates().is_empty());
+        let mut health = c.device_health.lock();
+        let h = health.get_mut(&mac()).unwrap();
+        h.raw_master = [0; 6];
+        h.raw_seen = Instant::now() - ACK_FRESHNESS - Duration::from_secs(1);
+        drop(health);
+        assert!(c.rebind_candidates().is_empty());
     }
 
     #[test]

--- a/crates/lianli-devices/src/wireless/convergence.rs
+++ b/crates/lianli-devices/src/wireless/convergence.rs
@@ -132,7 +132,7 @@ impl WirelessController {
         rgb_targets: RgbTargets,
         binding_mac: BindingMac,
         stop: Arc<AtomicBool>,
-    ) -> thread::JoinHandle<()> {
+    ) -> Result<thread::JoinHandle<()>> {
         thread::Builder::new()
             .name("wireless-convergence".into())
             .spawn(move || {
@@ -149,7 +149,7 @@ impl WirelessController {
                 }
                 debug!("wireless convergence loop stopped");
             })
-            .expect("spawning convergence thread")
+            .context("spawning wireless convergence thread")
     }
 }
 

--- a/crates/lianli-devices/src/wireless/convergence.rs
+++ b/crates/lianli-devices/src/wireless/convergence.rs
@@ -18,6 +18,8 @@ const TICK_INTERVAL: Duration = Duration::from_millis(100);
 const RGB_CONTROL_INTERVAL: Duration = Duration::from_secs(1);
 const MAX_PENDING_COMMANDS: usize = 256;
 
+pub(super) type BindingMac = Arc<Mutex<Option<[u8; 6]>>>;
+
 pub(super) type RgbTargets = Arc<Mutex<std::collections::HashMap<[u8; 6], [u8; 4]>>>;
 
 /// How a pending command is acknowledged. Different RF command types use
@@ -78,6 +80,10 @@ impl WirelessController {
             rf_data.len() == RF_DATA_SIZE,
             "invalid wireless command length"
         );
+        ensure!(
+            !binding_blocks_control(&self.binding_mac, &self.device_health, &device.mac),
+            "wireless binding change prevents this control command"
+        );
         let queue = self
             .pending_commands
             .as_ref()
@@ -124,6 +130,7 @@ impl WirelessController {
         queue: PendingQueue,
         health_map: DeviceHealthMap,
         rgb_targets: RgbTargets,
+        binding_mac: BindingMac,
         stop: Arc<AtomicBool>,
     ) -> thread::JoinHandle<()> {
         thread::Builder::new()
@@ -133,7 +140,7 @@ impl WirelessController {
                 while !stop.load(Ordering::SeqCst) {
                     let tick_start = Instant::now();
 
-                    drain_pending(&tx, &queue, &health_map, &rgb_targets, &stop);
+                    drain_pending(&tx, &queue, &health_map, &rgb_targets, &binding_mac, &stop);
 
                     let elapsed = tick_start.elapsed();
                     if elapsed < TICK_INTERVAL {
@@ -158,6 +165,7 @@ fn drain_pending(
     queue: &PendingQueue,
     health_map: &DeviceHealthMap,
     rgb_targets: &RgbTargets,
+    binding_mac: &BindingMac,
     stop: &Arc<AtomicBool>,
 ) {
     if lianli_transport::usb::shutting_down() {
@@ -217,6 +225,9 @@ fn drain_pending(
             }
             cmd.last_sent = now;
             let handle = tx.lock();
+            if binding_blocks_control(binding_mac, health_map, &cmd.mac) {
+                continue;
+            }
             if superseded_command(&queue.lock(), &cmd) {
                 continue;
             }
@@ -236,6 +247,10 @@ fn drain_pending(
             warn!(mac = ?cmd.mac, operation = %cmd.description, "Wireless command retry discarded because the queue is full");
         }
     }
+}
+
+fn binding_blocks_control(binding: &BindingMac, health: &DeviceHealthMap, mac: &[u8; 6]) -> bool {
+    *binding.lock() == Some(*mac) || health.lock().get(mac).is_some_and(|h| h.man_unbind)
 }
 
 fn retry_due(elapsed: Duration, changing_rgb: bool, acknowledgement: &AckSignal) -> bool {
@@ -302,10 +317,13 @@ fn send_rf_frame(handle: &RusbBulk, channel: &u8, rx_type: &u8, rf_data: &[u8]) 
 /// Check whether the device's reported PWM values match the target. Allows a
 /// tolerance of 5 because the device rounds to its nearest internal step.
 fn pwm_acked(reported: &[u8; 4], target: &[u8; 4]) -> bool {
-    reported
-        .iter()
-        .zip(target.iter())
-        .all(|(r, t)| r.abs_diff(*t) <= 5 || (*t <= 10 && *r == *t))
+    reported.iter().zip(target.iter()).all(|(r, t)| {
+        if *t <= 10 {
+            *r == *t
+        } else {
+            r.abs_diff(*t) <= 5
+        }
+    })
 }
 
 #[cfg(test)]

--- a/crates/lianli-devices/src/wireless/convergence_tests.rs
+++ b/crates/lianli-devices/src/wireless/convergence_tests.rs
@@ -92,3 +92,47 @@ fn full_queue_accepts_replacement_but_rejects_another_command_without_losing_wor
         AckSignal::Pwm([255, 255, 255, 255])
     ));
 }
+
+#[test]
+fn low_pwm_and_hardware_sync_acknowledgements_require_exact_values() {
+    assert!(!pwm_acked(&[1; 4], &[6; 4]));
+    assert!(!pwm_acked(&[6; 4], &[0; 4]));
+    assert!(pwm_acked(&[6; 4], &[6; 4]));
+    assert!(pwm_acked(&[105; 4], &[100; 4]));
+    assert!(!pwm_acked(&[106; 4], &[100; 4]));
+}
+
+#[test]
+fn binding_pause_blocks_only_target_device_and_manual_unbind_keeps_it_blocked() {
+    let controller = WirelessController::new();
+    let mac = [1; 6];
+    *controller.binding_mac.lock() = Some(mac);
+    assert!(binding_blocks_control(
+        &controller.binding_mac,
+        &controller.device_health,
+        &mac
+    ));
+    assert!(!binding_blocks_control(
+        &controller.binding_mac,
+        &controller.device_health,
+        &[2; 6]
+    ));
+    *controller.binding_mac.lock() = None;
+    assert!(!binding_blocks_control(
+        &controller.binding_mac,
+        &controller.device_health,
+        &mac
+    ));
+    let mut record = [0; 42];
+    record[..6].copy_from_slice(&mac);
+    record[41] = 0x1c;
+    let device = super::super::discovery::parse_device_record(&record, 0).unwrap();
+    let mut health = super::super::discovery::DeviceHealth::new(device);
+    health.man_unbind = true;
+    controller.device_health.lock().insert(mac, health);
+    assert!(binding_blocks_control(
+        &controller.binding_mac,
+        &controller.device_health,
+        &mac
+    ));
+}

--- a/crates/lianli-devices/src/wireless/discovery.rs
+++ b/crates/lianli-devices/src/wireless/discovery.rs
@@ -630,9 +630,10 @@ fn rebuild_published_vec(
             .filter(|d| !d.bind_intent && d.master_mac != *local)
         {
             info!(
-                "  {} ({}) not bound to this dongle",
+                "  {} ({}) not bound to this dongle; reported master={:02x?}",
                 d.mac_str(),
-                d.fan_type.display_name()
+                d.fan_type.display_name(),
+                d.master_mac
             );
         }
     }

--- a/crates/lianli-devices/src/wireless/discovery.rs
+++ b/crates/lianli-devices/src/wireless/discovery.rs
@@ -335,6 +335,7 @@ fn commit_streak<T: Copy + Eq>(cand: &mut Option<(T, u32)>, observed: T) -> Opti
 pub(super) struct ReceiverState {
     pub pwm: AtomicU16,
     pub pages: AtomicU8,
+    pub fg_sync: AtomicBool,
 }
 
 impl Default for ReceiverState {
@@ -342,6 +343,7 @@ impl Default for ReceiverState {
         Self {
             pwm: AtomicU16::new(0xFFFF),
             pages: AtomicU8::new(1),
+            fg_sync: AtomicBool::new(false),
         }
     }
 }
@@ -357,7 +359,7 @@ pub(super) fn poll_and_discover(
     health_map: &DeviceHealthMap,
     master_entries: &MasterEntryMap,
     receiver: &ReceiverState,
-    fg_sync: &Arc<AtomicBool>,
+    stop: &AtomicBool,
     master_mac: &Arc<Mutex<[u8; 6]>>,
 ) -> Result<()> {
     sweep(health_map, discovered_devices, master_mac);
@@ -368,7 +370,7 @@ pub(super) fn poll_and_discover(
     cmd[0] = USB_CMD_SEND_RF;
     cmd[1] = pages;
 
-    if fg_sync.load(Ordering::Relaxed) {
+    if receiver.fg_sync.load(Ordering::Relaxed) {
         let rpm = discovered_devices
             .lock()
             .iter()
@@ -381,7 +383,7 @@ pub(super) fn poll_and_discover(
     }
 
     let mut response = [0u8; 26 * 512];
-    let len = with_transport_recovery(rx, &RX_IDS, "RX", None, |handle| {
+    let len = with_transport_recovery(rx, &RX_IDS, "RX", stop, |handle| {
         handle.read_flush();
         handle
             .write(&cmd, USB_TIMEOUT)

--- a/crates/lianli-devices/src/wireless/discovery.rs
+++ b/crates/lianli-devices/src/wireless/discovery.rs
@@ -5,7 +5,7 @@ use lianli_transport::usb::{RusbBulk, USB_TIMEOUT};
 use parking_lot::Mutex;
 use std::collections::BTreeMap;
 use std::fmt;
-use std::sync::atomic::{AtomicBool, AtomicU16, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU8, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tracing::{debug, info};
@@ -332,6 +332,20 @@ fn commit_streak<T: Copy + Eq>(cand: &mut Option<(T, u32)>, observed: T) -> Opti
     }
 }
 
+pub(super) struct ReceiverState {
+    pub pwm: AtomicU16,
+    pub pages: AtomicU8,
+}
+
+impl Default for ReceiverState {
+    fn default() -> Self {
+        Self {
+            pwm: AtomicU16::new(0xFFFF),
+            pages: AtomicU8::new(1),
+        }
+    }
+}
+
 /// Polls the RX device for the current device list.
 ///
 /// Sends GetDev command (0x10) and parses the response into
@@ -342,16 +356,13 @@ pub(super) fn poll_and_discover(
     discovered_devices: &Arc<Mutex<Vec<DiscoveredDevice>>>,
     health_map: &DeviceHealthMap,
     master_entries: &MasterEntryMap,
-    mobo_pwm: &Arc<AtomicU16>,
+    receiver: &ReceiverState,
     fg_sync: &Arc<AtomicBool>,
     master_mac: &Arc<Mutex<[u8; 6]>>,
 ) -> Result<()> {
     sweep(health_map, discovered_devices, master_mac);
 
-    let pages = {
-        let devices = discovered_devices.lock();
-        (devices.len().div_ceil(10).clamp(1, 2)) as u8
-    };
+    let pages = receiver.pages.load(Ordering::Relaxed).clamp(1, 26);
 
     let mut cmd = vec![0u8; 64];
     cmd[0] = USB_CMD_SEND_RF;
@@ -369,45 +380,46 @@ pub(super) fn poll_and_discover(
         cmd[3] = (rpm & 0xFF) as u8;
     }
 
-    with_transport_recovery(rx, &RX_IDS, "RX", |handle| {
+    let mut response = [0u8; 26 * 512];
+    let len = with_transport_recovery(rx, &RX_IDS, "RX", None, |handle| {
         handle.read_flush();
         handle
             .write(&cmd, USB_TIMEOUT)
             .context("sending GetDev command")?;
-        Ok(())
-    })?;
-    let handle = rx.lock();
-
-    let mut response = [0u8; 1024];
-    let len = handle.read_silence(
-        &mut response,
-        Duration::from_millis(100),
-        Duration::from_millis(10),
-    );
-
-    if len < 4 || response[0] != USB_CMD_SEND_RF {
-        debug!(
-            "GetDev: no usable response (len={len}, echo=0x{:02x}), retrying next poll",
-            response[0]
+        let len = handle.read_silence(
+            &mut response[..usize::from(pages) * 512],
+            Duration::from_millis(100),
+            Duration::from_millis(10),
         );
-        return Ok(());
-    }
+        validate_discovery_response(&response[..len], pages)?;
+        Ok(len)
+    });
+    let len = match len {
+        Ok(len) => len,
+        Err(error) => {
+            receiver.pwm.store(0xFFFF, Ordering::Relaxed);
+            return Err(error);
+        }
+    };
+    receiver
+        .pages
+        .store(discovery_page_count(response[1]), Ordering::Relaxed);
 
     {
-        let device_count = (response[1] as usize).min(12);
+        let device_count = usize::from(response[1]).min(usize::from(pages) * 10);
 
         let indicator = response[2];
         if indicator >> 7 == 1 {
-            mobo_pwm.store(0xFFFF, Ordering::Relaxed);
+            receiver.pwm.store(0xFFFF, Ordering::Relaxed);
         } else {
             let off_time = (indicator & 0x7F) as u16;
             let on_time = response[3] as u16;
             let denominator = off_time + on_time;
             if denominator > 0 {
                 let pwm = (255u16 * on_time / denominator).min(255);
-                mobo_pwm.store(pwm, Ordering::Relaxed);
+                receiver.pwm.store(pwm, Ordering::Relaxed);
             } else {
-                mobo_pwm.store(0xFFFF, Ordering::Relaxed);
+                receiver.pwm.store(0xFFFF, Ordering::Relaxed);
             }
         }
 
@@ -457,6 +469,23 @@ pub(super) fn poll_and_discover(
         }
     }
 
+    Ok(())
+}
+
+fn discovery_page_count(total: u8) -> u8 {
+    total.div_ceil(10).max(1)
+}
+
+fn validate_discovery_response(response: &[u8], pages: u8) -> Result<()> {
+    anyhow::ensure!(
+        response.len() >= 4 && response[0] == USB_CMD_SEND_RF,
+        "missing or invalid GetDev response"
+    );
+    let records = usize::from(response[1]).min(usize::from(pages) * 10);
+    anyhow::ensure!(
+        response.len() >= 4 + records * 42,
+        "truncated GetDev response"
+    );
     Ok(())
 }
 
@@ -919,5 +948,34 @@ mod tests {
         assert_eq!(h.published.fan_rpms, [100, 200, 0, 0]);
         assert_eq!(h.raw_master, [7u8; 6]);
         assert_eq!(devices.lock().len(), 1);
+    }
+}
+
+#[cfg(test)]
+mod response_tests {
+    use super::*;
+
+    #[test]
+    fn receiver_total_bootstraps_followup_pages_without_known_devices() {
+        let mut first = vec![0; 4 + 10 * 42];
+        first[0] = USB_CMD_SEND_RF;
+        first[1] = 23;
+        assert!(validate_discovery_response(&first, 1).is_ok());
+        let pages = discovery_page_count(first[1]);
+        assert_eq!(pages, 3);
+        assert!(validate_discovery_response(&first, pages).is_err());
+        first.resize(4 + 23 * 42, 0);
+        assert!(validate_discovery_response(&first, pages).is_ok());
+        assert_eq!(discovery_page_count(0), 1);
+        assert_eq!(discovery_page_count(255), 26);
+    }
+
+    #[test]
+    fn empty_scan_is_healthy_but_silence_wrong_echo_and_truncation_are_errors() {
+        assert!(validate_discovery_response(&[0x10, 0, 0x80, 0], 1).is_ok());
+        assert!(validate_discovery_response(&[], 1).is_err());
+        assert!(validate_discovery_response(&[0x10, 0, 0], 1).is_err());
+        assert!(validate_discovery_response(&[0x11, 0, 0, 0], 1).is_err());
+        assert!(validate_discovery_response(&[0x10, 1, 0, 0], 1).is_err());
     }
 }

--- a/crates/lianli-devices/src/wireless/fan_speed.rs
+++ b/crates/lianli-devices/src/wireless/fan_speed.rs
@@ -21,22 +21,15 @@ fn pwm_last_sent() -> &'static Mutex<HashMap<[u8; 6], Instant>> {
 }
 
 impl WirelessController {
-    /// Set fan PWM values for a specific device identified by MAC address.
-    /// Uses the device's own rx_type and channel from discovery.
-    ///
-    /// RF PWM packet layout (240 bytes):
-    /// ```text
-    /// [0]     = 0x12 (RF_Select — envelope command)
-    /// [1]     = 0x10 (RF_Bind — PWM sub-command)
-    /// [2-7]   = Device (slave) MAC address
-    /// [8-13]  = Master MAC address
-    /// [14]    = Target RX type (from device discovery)
-    /// [15]    = Target channel (master channel)
-    /// [16]    = Sequence index (1 for one-shot commands)
-    /// [17-20] = Fan PWM values (4 bytes, one per fan slot)
-    /// [21-239]= Reserved
-    /// ```
     pub fn set_fan_speeds_by_mac(&self, mac: &[u8; 6], fan_pwm: &[u8; 4]) -> Result<()> {
+        self.send_fan_pwm(mac, Some(fan_pwm))
+    }
+
+    pub fn set_hardware_pwm_sync(&self, mac: &[u8; 6]) -> Result<()> {
+        self.send_fan_pwm(mac, None)
+    }
+
+    fn send_fan_pwm(&self, mac: &[u8; 6], fan_pwm: Option<&[u8; 4]>) -> Result<()> {
         let devices = self.discovered_devices.lock();
         let master_mac = *self.master_mac.lock();
         let master_ch = *self.master_channel.lock();
@@ -59,11 +52,7 @@ impl WirelessController {
 
         drop(devices);
 
-        let mut pwm = *fan_pwm;
-        apply_pwm_constraints(&mut pwm, &device);
-        if device.is_inf_right_attach {
-            reverse_fan_order(&mut pwm, device.fan_count as usize);
-        }
+        let pwm = prepare_pwm(fan_pwm, &device)?;
 
         let needs_send = pwm
             .iter()
@@ -80,15 +69,7 @@ impl WirelessController {
             return Ok(());
         }
 
-        let mut rf_data = vec![0u8; RF_DATA_SIZE];
-        rf_data[0] = RF_SELECT;
-        rf_data[1] = RF_PWM_CMD;
-        rf_data[2..8].copy_from_slice(&device.mac);
-        rf_data[8..14].copy_from_slice(&master_mac);
-        rf_data[14] = device.rx_type;
-        rf_data[15] = master_ch;
-        rf_data[16] = slot_index;
-        rf_data[17..21].copy_from_slice(&pwm);
+        let rf_data = build_pwm_packet(&device, &master_mac, master_ch, slot_index, pwm);
 
         self.enqueue_rf_command(&device, rf_data, AckSignal::Pwm(pwm), "fan PWM")?;
 
@@ -156,5 +137,98 @@ fn reverse_fan_order<T: Copy>(slots: &mut [T; 4], fan_count: usize) {
     let n = fan_count.min(4);
     if n > 1 {
         slots[..n].reverse();
+    }
+}
+
+fn build_pwm_packet(
+    device: &DiscoveredDevice,
+    master_mac: &[u8; 6],
+    channel: u8,
+    slot: u8,
+    pwm: [u8; 4],
+) -> Vec<u8> {
+    let mut data = vec![0; RF_DATA_SIZE];
+    data[0] = RF_SELECT;
+    data[1] = RF_PWM_CMD;
+    data[2..8].copy_from_slice(&device.mac);
+    data[8..14].copy_from_slice(master_mac);
+    data[14] = device.rx_type;
+    data[15] = channel;
+    data[16] = slot;
+    data[17..21].copy_from_slice(&pwm);
+    data
+}
+
+fn prepare_pwm(fan_pwm: Option<&[u8; 4]>, device: &DiscoveredDevice) -> Result<[u8; 4]> {
+    let Some(fan_pwm) = fan_pwm else {
+        anyhow::ensure!(
+            device.fan_type.supports_hw_mobo_sync(),
+            "device does not support hardware PWM sync"
+        );
+        return Ok([6; 4]);
+    };
+    let mut pwm = *fan_pwm;
+    apply_pwm_constraints(&mut pwm, device);
+    if device.is_inf_right_attach {
+        reverse_fan_order(&mut pwm, device.fan_count as usize);
+    }
+    Ok(pwm)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn device(fan_type: WirelessFanType) -> DiscoveredDevice {
+        let mut record = [0; 42];
+        record[..6].copy_from_slice(&[1, 2, 3, 4, 5, 6]);
+        record[13] = 2;
+        record[19] = 3;
+        record[41] = 0x1c;
+        let mut device = super::super::discovery::parse_device_record(&record, 0).unwrap();
+        device.fan_type = fan_type;
+        device
+    }
+
+    #[test]
+    fn hardware_sync_packet_preserves_all_four_sentinels() {
+        for family in [WirelessFanType::Slv3Led, WirelessFanType::Slv3Lcd] {
+            let device = device(family);
+            let pwm = prepare_pwm(None, &device).unwrap();
+            let packet = build_pwm_packet(&device, &[9; 6], 8, 3, pwm);
+            assert_eq!(
+                &packet[..21],
+                &[0x12, 0x10, 1, 2, 3, 4, 5, 6, 9, 9, 9, 9, 9, 9, 2, 8, 3, 6, 6, 6, 6]
+            );
+            assert_eq!(packet.len(), 240);
+            assert!(packet[21..].iter().all(|&byte| byte == 0));
+            assert_eq!(
+                prepare_pwm(Some(&[6; 4]), &device).unwrap(),
+                [35, 35, 35, 0]
+            );
+        }
+        assert!(prepare_pwm(None, &device(WirelessFanType::SlInf)).is_err());
+    }
+
+    #[test]
+    fn normal_pwm_retains_stop_floors_filters_and_slot_order() {
+        assert_eq!(
+            prepare_pwm(Some(&[0, 1, 255, 255]), &device(WirelessFanType::Slv3Led)).unwrap(),
+            [0, 35, 255, 0]
+        );
+        assert_eq!(
+            prepare_pwm(Some(&[153, 154, 155, 255]), &device(WirelessFanType::Clv1)).unwrap(),
+            [152, 152, 156, 0]
+        );
+        let mut reversed = device(WirelessFanType::SlInf);
+        reversed.is_inf_right_attach = true;
+        assert_eq!(
+            prepare_pwm(Some(&[100, 150, 200, 255]), &reversed).unwrap(),
+            [200, 150, 100, 0]
+        );
+        assert_eq!(
+            prepare_pwm(Some(&[255; 4]), &device(WirelessFanType::WaterBlock)).unwrap(),
+            [255; 4]
+        );
     }
 }

--- a/crates/lianli-devices/src/wireless/mb_sync.rs
+++ b/crates/lianli-devices/src/wireless/mb_sync.rs
@@ -1,6 +1,6 @@
 use super::controller::WirelessController;
 use super::convergence::AckSignal;
-use super::{RF_DATA_SIZE, RF_MB_LIGHT_SYNC, RF_PWM_CMD, RF_SELECT};
+use super::{RF_DATA_SIZE, RF_MB_LIGHT_SYNC, RF_SELECT};
 use anyhow::{bail, Result};
 use parking_lot::Mutex;
 use std::collections::HashMap;
@@ -168,56 +168,6 @@ impl WirelessController {
         {
             targets.remove(mac);
         }
-    }
-
-    pub fn set_mb_pwm_sync(&self, enabled: bool) -> Result<()> {
-        let devices = self.discovered_devices.lock();
-        let master_mac = *self.master_mac.lock();
-        let master_ch = *self.master_channel.lock();
-
-        let e1_devices: Vec<_> = devices
-            .iter()
-            .filter(|d| d.master_mac == master_mac && d.mac[5] == 0xE1)
-            .cloned()
-            .collect();
-        drop(devices);
-
-        if e1_devices.is_empty() {
-            return Ok(());
-        }
-
-        for device in &e1_devices {
-            let target_cmd_seq = self.bump_target_cmd_seq(&device.mac, device.cmd_seq);
-
-            let mut rf_data = vec![0u8; RF_DATA_SIZE];
-            rf_data[0] = RF_SELECT;
-            rf_data[1] = RF_PWM_CMD;
-            rf_data[2..8].copy_from_slice(&device.mac);
-            rf_data[8..14].copy_from_slice(&master_mac);
-            rf_data[14] = device.rx_type;
-            rf_data[15] = master_ch;
-            rf_data[17] = target_cmd_seq;
-
-            if enabled {
-                rf_data[20..24].copy_from_slice(&[6, 6, 6, 6]);
-            } else {
-                rf_data[20..24].copy_from_slice(&device.current_pwm);
-            }
-
-            self.enqueue_rf_command(
-                device,
-                rf_data,
-                AckSignal::Pwm(if enabled { [6; 4] } else { device.current_pwm }),
-                format!("MB PWM sync {}", if enabled { "on" } else { "off" }),
-            )?;
-        }
-
-        debug!(
-            "MB PWM sync {}: {} companion device(s)",
-            if enabled { "enabled" } else { "disabled" },
-            e1_devices.len(),
-        );
-        Ok(())
     }
 
     pub fn has_mb_pwm_companion(&self) -> bool {

--- a/crates/lianli-devices/src/wireless/opcodes.rs
+++ b/crates/lianli-devices/src/wireless/opcodes.rs
@@ -129,7 +129,7 @@ impl WirelessController {
                 chunk_idx,
                 &image[start..end],
             )?;
-            self.wait_pic_ack(&device.mac, next_seq);
+            self.wait_pic_ack(&device.mac, next_seq)?;
         }
 
         let len = image.len() as u16;
@@ -145,7 +145,7 @@ impl WirelessController {
             PIC_TERMINATOR,
             &term_payload,
         )?;
-        self.wait_pic_ack(&device.mac, next_seq);
+        self.wait_pic_ack(&device.mac, next_seq)?;
 
         debug!(
             "SendPic: {} ({} chunks + terminator, {} bytes)",
@@ -198,15 +198,20 @@ impl WirelessController {
         Ok(next_seq)
     }
 
-    fn wait_pic_ack(&self, mac: &[u8; 6], expected_seq: u8) {
+    fn wait_pic_ack(&self, mac: &[u8; 6], expected_seq: u8) -> Result<()> {
         let deadline = std::time::Instant::now() + Duration::from_secs(2);
         while std::time::Instant::now() < deadline {
             if let Some(d) = self.device_by_mac(mac) {
                 if d.cmd_seq == expected_seq {
-                    return;
+                    return Ok(());
                 }
             }
+            anyhow::ensure!(
+                !self.poll_stop.load(std::sync::atomic::Ordering::Acquire),
+                "wireless controller is stopping"
+            );
             std::thread::sleep(Duration::from_millis(50));
         }
+        bail!("picture command acknowledgement timed out for {mac:02x?}")
     }
 }

--- a/crates/lianli-devices/src/wireless/transport.rs
+++ b/crates/lianli-devices/src/wireless/transport.rs
@@ -3,7 +3,7 @@ use lianli_transport::usb::RusbBulk;
 use parking_lot::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
 /// Try to open a USB device matching any of the given VID:PID pairs.
 pub(super) fn open_any(ids: &[(u16, u16)]) -> Result<RusbBulk> {
@@ -39,41 +39,126 @@ pub(super) fn with_transport_recovery<F, R>(
     arc: &Arc<Mutex<RusbBulk>>,
     ids: &[(u16, u16)],
     name: &str,
-    stop: Option<&AtomicBool>,
+    stop: &AtomicBool,
     mut op: F,
 ) -> Result<R>
 where
     F: FnMut(&RusbBulk) -> Result<R>,
 {
-    let first = {
-        let handle = arc.lock();
-        anyhow::ensure!(
-            !stop.is_some_and(|flag| flag.load(Ordering::Acquire)),
-            "wireless controller is stopping"
-        );
-        op(&handle)
-    };
-    match first {
-        Ok(r) => Ok(r),
-        Err(e) => {
-            // Failures are expected once shutdown starts, since new
-            // transfers are refused. Do not warn or attempt a reopen, the
-            // caller is about to be joined anyway.
-            if lianli_transport::usb::shutting_down()
-                || stop.is_some_and(|flag| flag.load(Ordering::Acquire))
-            {
-                debug!("{name} transport op failed ({e}) while shutting down, not reopening");
-                return Err(e).context("shutting down");
-            }
-            warn!("{name} transport op failed ({e}); attempting reopen");
-            reopen_transport(arc, ids, name).context("reopen after stale handle")?;
-            info!("{name} transport reopened, retrying");
+    retry_transport_operation(
+        stop,
+        || {
             let handle = arc.lock();
             anyhow::ensure!(
-                !stop.is_some_and(|flag| flag.load(Ordering::Acquire)),
+                !stop.load(Ordering::Acquire),
                 "wireless controller is stopping"
             );
             op(&handle)
+        },
+        |error| {
+            warn!("{name} transport op failed ({error}); attempting reopen");
+            reopen_transport(arc, ids, name).context("reopen after stale handle")?;
+            info!("{name} transport reopened, retrying");
+            Ok(())
+        },
+    )
+}
+
+fn retry_transport_operation<R>(
+    stop: &AtomicBool,
+    mut operation: impl FnMut() -> Result<R>,
+    reopen: impl FnOnce(&anyhow::Error) -> Result<()>,
+) -> Result<R> {
+    anyhow::ensure!(
+        !stop.load(Ordering::Acquire),
+        "wireless controller is stopping"
+    );
+    match operation() {
+        Ok(result) => Ok(result),
+        Err(error) => {
+            if lianli_transport::usb::shutting_down() || stop.load(Ordering::Acquire) {
+                return Err(error).context("shutting down");
+            }
+            reopen(&error)?;
+            anyhow::ensure!(
+                !stop.load(Ordering::Acquire),
+                "wireless controller is stopping"
+            );
+            operation()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    #[test]
+    fn stopped_controller_never_starts_an_operation() {
+        let stop = AtomicBool::new(true);
+        let result: Result<()> = retry_transport_operation(
+            &stop,
+            || panic!("operation must not start"),
+            |_| panic!("transport must not reopen"),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn stop_during_failed_operation_prevents_reopen() {
+        let stop = AtomicBool::new(false);
+        let result: Result<()> = retry_transport_operation(
+            &stop,
+            || {
+                stop.store(true, Ordering::Release);
+                anyhow::bail!("receiver read failed")
+            },
+            |_| panic!("transport must not reopen after stop"),
+        );
+        assert!(result.unwrap_err().to_string().contains("shutting down"));
+    }
+
+    #[test]
+    fn stop_during_reopen_prevents_retry() {
+        let stop = AtomicBool::new(false);
+        let attempts = Cell::new(0);
+        let result: Result<()> = retry_transport_operation(
+            &stop,
+            || {
+                attempts.set(attempts.get() + 1);
+                anyhow::bail!("receiver read failed")
+            },
+            |_| {
+                stop.store(true, Ordering::Release);
+                Ok(())
+            },
+        );
+        assert!(result.is_err());
+        assert_eq!(attempts.get(), 1);
+    }
+
+    #[test]
+    fn running_controller_reopens_once_and_returns_retry_result() {
+        let stop = AtomicBool::new(false);
+        let attempts = Cell::new(0);
+        let reopens = Cell::new(0);
+        let result = retry_transport_operation(
+            &stop,
+            || {
+                attempts.set(attempts.get() + 1);
+                if attempts.get() == 1 {
+                    anyhow::bail!("receiver read failed");
+                }
+                Ok(42)
+            },
+            |_| {
+                reopens.set(reopens.get() + 1);
+                Ok(())
+            },
+        );
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(attempts.get(), 2);
+        assert_eq!(reopens.get(), 1);
     }
 }

--- a/crates/lianli-devices/src/wireless/transport.rs
+++ b/crates/lianli-devices/src/wireless/transport.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use lianli_transport::usb::RusbBulk;
 use parking_lot::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tracing::{debug, info, warn};
 
@@ -38,6 +39,7 @@ pub(super) fn with_transport_recovery<F, R>(
     arc: &Arc<Mutex<RusbBulk>>,
     ids: &[(u16, u16)],
     name: &str,
+    stop: Option<&AtomicBool>,
     mut op: F,
 ) -> Result<R>
 where
@@ -45,6 +47,10 @@ where
 {
     let first = {
         let handle = arc.lock();
+        anyhow::ensure!(
+            !stop.is_some_and(|flag| flag.load(Ordering::Acquire)),
+            "wireless controller is stopping"
+        );
         op(&handle)
     };
     match first {
@@ -53,7 +59,9 @@ where
             // Failures are expected once shutdown starts, since new
             // transfers are refused. Do not warn or attempt a reopen, the
             // caller is about to be joined anyway.
-            if lianli_transport::usb::shutting_down() {
+            if lianli_transport::usb::shutting_down()
+                || stop.is_some_and(|flag| flag.load(Ordering::Acquire))
+            {
                 debug!("{name} transport op failed ({e}) while shutting down, not reopening");
                 return Err(e).context("shutting down");
             }
@@ -61,6 +69,10 @@ where
             reopen_transport(arc, ids, name).context("reopen after stale handle")?;
             info!("{name} transport reopened, retrying");
             let handle = arc.lock();
+            anyhow::ensure!(
+                !stop.is_some_and(|flag| flag.load(Ordering::Acquire)),
+                "wireless controller is stopping"
+            );
             op(&handle)
         }
     }

--- a/crates/lianli-gui/src/components/devices/DeviceCard.vue
+++ b/crates/lianli-gui/src/components/devices/DeviceCard.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import { useDialog } from "naive-ui";
+import { useDialog, useMessage } from "naive-ui";
 import { Monitor, Fan, Droplet, Palette, Loader2, Locate } from "lucide-vue-next";
 import type { DeviceInfo } from "@/types";
 import { useDevicesStore } from "@/stores/devices";
@@ -15,6 +15,7 @@ import {
   familyIsDesktopMode,
 } from "@/constants";
 
+const message = useMessage();
 const props = defineProps<{ device: DeviceInfo }>();
 
 const devices = useDevicesStore();
@@ -125,18 +126,32 @@ async function onBind() {
     });
     if (!ok) return;
   }
-  devices.pending.set(d.value.device_id, "bind");
-  await aio.bindWireless(mac);
-  await refreshSoon();
+  const pendingId = d.value.device_id;
+  devices.pending.set(pendingId, "bind", true);
+  try {
+    await aio.bindWireless(mac);
+  } catch (error) {
+    message.error(String(error));
+  } finally {
+    devices.pending.clear(pendingId);
+    await refreshSoon();
+  }
 }
 
 async function onUnbind() {
   const mac = d.value.device_id.startsWith("wireless:")
     ? d.value.device_id.slice("wireless:".length)
     : d.value.device_id;
-  devices.pending.set(d.value.device_id, "unbind");
-  await aio.unbindWireless(mac);
-  await refreshSoon();
+  const pendingId = d.value.device_id;
+  devices.pending.set(pendingId, "unbind", true);
+  try {
+    await aio.unbindWireless(mac);
+  } catch (error) {
+    message.error(String(error));
+  } finally {
+    devices.pending.clear(pendingId);
+    await refreshSoon();
+  }
 }
 
 async function refreshSoon() {

--- a/crates/lianli-gui/src/components/fans/FanGroupCard.vue
+++ b/crates/lianli-gui/src/components/fans/FanGroupCard.vue
@@ -63,11 +63,15 @@ function decodeMode(value: string): FanSpeed {
 
 // Speed mode dropdown options: Off / curve names / Constant PWM / MB Sync.
 const modeOptions = computed(() => {
-  const opts: { label: string; value: string }[] = [
+  const opts: { label: string; value: string; disabled?: boolean }[] = [
     { label: "Off", value: "off" },
     ...props.curveNames.map((n) => ({ label: `Curve: ${n}`, value: `curve:${n}` })),
     { label: "Constant PWM", value: "constant" },
-    { label: "MB Sync", value: "__mb_sync__" },
+    {
+      label: "MB Sync",
+      value: MB_SYNC_KEY,
+      disabled: !props.device.mb_sync_support && !props.pwmHeaders.length,
+    },
   ];
   return opts;
 });
@@ -91,9 +95,12 @@ function modeOf(slot: number): string {
 
 function onMode(slot: number, value: string) {
   if (value === "__mb_sync__") {
-    // Port-wide: every fan on this port becomes MB Sync.
-    // Preserve any existing PWM source, default to bare __mb_sync__.
-    setAllSlots(MB_SYNC_KEY);
+    if (props.device.mb_sync_support) {
+      setAllSlots(MB_SYNC_KEY);
+    } else {
+      const source = currentPwmSource.value || props.pwmHeaders[0]?.id;
+      if (source) setAllSlots(`${MB_SYNC_PREFIX}${source}`);
+    }
     return;
   }
   const decoded = decodeMode(value);
@@ -169,9 +176,14 @@ function setPwm(slot: number, v: number) {
       </div>
     </div>
 
-    <!-- PWM source picker: only for devices without hardware MB sync (e.g. wireless) -->
-    <div v-if="groupIsMbSync() && !device.mb_sync_support && pwmHeaderOptions.length" class="pwm-source-row">
+    <div
+      v-if="groupIsMbSync() && !device.mb_sync_support"
+      class="pwm-source-row"
+    >
       <label class="muted">PWM source</label>
+      <span class="muted">
+        Fans run at full speed if the selected source is unavailable.
+      </span>
       <n-select
         size="small"
         :value="currentPwmSource"

--- a/crates/lianli-gui/src/composables/usePendingAction.ts
+++ b/crates/lianli-gui/src/composables/usePendingAction.ts
@@ -6,20 +6,14 @@ const PENDING_TIMEOUT_MS = 10_000;
 interface PendingEntry {
   kind: PendingActionKind;
   startedAt: number;
+  awaitingResult: boolean;
 }
 
-/**
- * Tracks in-flight device actions (bind/unbind/display-mode switch/fan-qty).
- *
- * An entry is cleared when the daemon reports the expected state change or
- * after the 10s safety timeout — whichever comes first. Mirrors the Slint
- * GUI's `SharedState::pending_actions` semantics.
- */
 export function usePendingAction() {
   const pending = reactive<Record<string, PendingEntry>>({});
 
-  function set(deviceId: string, kind: PendingActionKind) {
-    pending[deviceId] = { kind, startedAt: Date.now() };
+  function set(deviceId: string, kind: PendingActionKind, awaitingResult = false) {
+    pending[deviceId] = { kind, startedAt: Date.now(), awaitingResult };
   }
 
   function clear(deviceId: string) {
@@ -35,6 +29,7 @@ export function usePendingAction() {
     const now = Date.now();
     const present = new Set(deviceIds);
     for (const [key, entry] of Object.entries(pending)) {
+      if (entry.awaitingResult) continue;
       if (now - entry.startedAt >= PENDING_TIMEOUT_MS) {
         delete pending[key];
         continue;
@@ -50,6 +45,8 @@ export function usePendingAction() {
           break;
         }
         case "unbind":
+          if (!present.has(key)) delete pending[key];
+          break;
         case "switch":
           // clears once the device reappears (post-switch) — kept until then
           if (present.has(key)) delete pending[key];

--- a/crates/lianli-gui/src/stores/aio.ts
+++ b/crates/lianli-gui/src/stores/aio.ts
@@ -11,20 +11,41 @@ export const useAioStore = defineStore("aio", () => {
   const ipc = useIpc();
   const lastError = ref("");
 
-  async function bindWireless(mac: string) {
+  async function changeBinding(mac: string, bind: boolean) {
+    lastError.value = "";
     try {
-      await ipc.request("BindWirelessDevice", { mac });
+      const queued = await ipc.request<{ operation_id?: string }>(
+        bind ? "BindWirelessDevice" : "UnbindWirelessDevice",
+        { mac },
+      );
+      if (queued.operation_id == null) return;
+      const deadline = Date.now() + 60_000;
+      while (Date.now() < deadline) {
+        const result = await ipc.request<{ status: string; message?: string }>(
+          "GetWirelessOperation",
+          { operation_id: queued.operation_id },
+        );
+        if (result.status === "succeeded") return;
+        if (result.status === "failed") {
+          throw new Error(result.message || "Wireless operation failed");
+        }
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+      throw new Error(
+        "Wireless operation is still pending; refresh the device list to check its state.",
+      );
     } catch (e) {
       lastError.value = String(e);
+      throw e;
     }
   }
 
+  async function bindWireless(mac: string) {
+    await changeBinding(mac, true);
+  }
+
   async function unbindWireless(mac: string) {
-    try {
-      await ipc.request("UnbindWirelessDevice", { mac });
-    } catch (e) {
-      lastError.value = String(e);
-    }
+    await changeBinding(mac, false);
   }
 
   return { lastError, bindWireless, unbindWireless };

--- a/crates/lianli-shared/src/ipc.rs
+++ b/crates/lianli-shared/src/ipc.rs
@@ -103,7 +103,9 @@ pub enum IpcRequest {
     SwitchDisplayMode {
         device_id: String,
     },
-    /// Bind an unbound wireless device to this dongle.
+    GetWirelessOperation {
+        operation_id: String,
+    },
     BindWirelessDevice {
         mac: String,
     },
@@ -209,6 +211,14 @@ pub enum IpcEvent {
         device_index: u8,
         rpms: Vec<u16>,
     },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum WirelessOperationStatus {
+    Pending,
+    Succeeded,
+    Failed { message: String },
 }
 
 /// Info about a connected device, returned by ListDevices.


### PR DESCRIPTION
Fix hardware PWM sync, missing-source fan safety, RX recovery, discovery pagination, and worker shutdown. Add acknowledged AIO switching and bind/unbind results, preserve intentional unbinding across restarts, and reduce RGB retransmission traffic while retaining retries until acknowledgement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Wireless binding and unbinding now show progress, success, or failure in the GUI.
  - Both TX and RX dongles are required for wireless control.
  - Supported SL V3 fans now offer hardware motherboard PWM synchronization.
  - MB Sync options reflect available hardware and PWM headers.

- **Bug Fixes**
  - Improved reliability of wireless AIO theme changes and RGB uploads.
  - Binding errors are now surfaced instead of silently ignored.
  - Wireless fans run at full speed when PWM sources are unavailable.
  - Saved settings no longer automatically bind unbound groups at startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->