### PR TITLE
fix(rgb): render Scope selector when direction unsupported

### DIFF
--- a/crates/lianli-gui/src/components/rgb/RgbZoneEditor.vue
+++ b/crates/lianli-gui/src/components/rgb/RgbZoneEditor.vue
@@ -314,8 +314,8 @@ const zoneLabel = computed(
         </div>
       </div>
 
-      <div v-if="showDirection" class="two-col">
-        <div class="field">
+      <div v-if="showDirection || showScope" class="two-col">
+        <div v-if="showDirection" class="field">
           <label class="muted">Direction</label>
           <n-select
             size="small"


### PR DESCRIPTION
Fixes #199

## Problem
The Scope dropdown (All / Inner / Outer) is never rendered for the SL-Infinity, so only-inner or only-outer rings cannot be addressed from the GUI. The Scope field lives inside the Direction row, which is gated on `showDirection` — false for devices with `supports_direction: false` and no software modes.

## Change
`crates/lianli-gui/src/components/rgb/RgbZoneEditor.vue`: show the row when `showDirection || showScope`, keep the Direction field conditional inside it. Scope now renders whenever the device exposes scopes.

## Verification
- Built with `cargo build --release -p lianli-gui` (Vue bundle rebuilt cleanly)
- On an SL-Infinity hub (ENE 6K77, fw v1.4): Scope dropdown now visible in the zone editor; setting scope=Outer sends a single HID feature report to the outer port only (strace on /dev/hidraw), scope=All sends both inner and outer — matching daemon behavior

<img width="1241" height="1302" alt="image" src="https://github.com/user-attachments/assets/9a0ce87e-6e86-4996-90c5-0f53847e19cd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the layout of RGB zone editor controls so the shared two-column arrangement remains consistent when either control is available.
  * Direction controls continue to appear only when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->